### PR TITLE
Fix physical offsets for sliced TMEM scales

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -6109,3 +6109,68 @@ def test_tmem288k_simple(Ncol1: int, Ncol2: int):
     num_warps = 4
     tmem288k_simple_kernel[(1, )](input, output, M, Ncol1, Ncol2, num_warps=num_warps)
     torch.testing.assert_close(input.cpu(), output.cpu(), atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("M,K,parent_m,compact,use_acc,offset", [
+    (256, 256, 512, False, False, 0),
+    (256, 256, 256, False, False, 0),
+    (128, 256, 512, False, False, 0),
+    (256, 128, 512, False, False, 0),
+    (256, 512, 512, False, False, 0),
+    (256, 256, 512, True, False, 0),
+    (256, 256, 512, False, True, 0),
+    (256, 256, 512, False, False, 256),
+    (256, 256, 512, True, False, 256),
+])
+def test_tcgen05_mma_scaled_sliced_a_scales(M, K, parent_m, compact, use_acc, offset):
+
+    @gluon.jit
+    def kernel(out, M: ttgl.constexpr, K: ttgl.constexpr, PARENT_M: ttgl.constexpr, COMPACT: ttgl.constexpr,
+               USE_ACC: ttgl.constexpr, OFFSET: ttgl.constexpr):
+        N: ttgl.constexpr = 128
+        reg: ttgl.constexpr = ttgl.BlockedLayout([1, 4], [4, 8], [4, 1], [1, 0])
+        a = ttgl.full([M, K], 1, ttgl.float8e5, reg)
+        b = ttgl.full([K, N], 1, ttgl.float8e5, reg)
+        smem_a = ttgl.allocate_shared_memory(ttgl.float8e5, [M, K], ttgl.NVMMASharedLayout(128, 8, transposed=False), a)
+        smem_b = ttgl.allocate_shared_memory(ttgl.float8e5, [K, N], ttgl.NVMMASharedLayout(128, 8, transposed=True), b)
+
+        parent = allocate_tensor_memory(ttgl.uint8, [PARENT_M, K // 32], TensorMemoryScalesLayout())
+        preg: ttgl.constexpr = parent.get_reg_layout()
+        rows = ttgl.arange(0, PARENT_M, ttgl.SliceLayout(1, preg))[:, None]
+        scale_values = (127 + rows // 128 + ttgl.zeros([PARENT_M, K // 32], ttgl.int32, preg)).to(ttgl.uint8)
+        parent.store(scale_values)
+        view = parent.slice(OFFSET, M, dim=0)
+        if COMPACT:
+            scale_a = allocate_tensor_memory(ttgl.uint8, [M, K // 32], TensorMemoryScalesLayout())
+            compact_reg: ttgl.constexpr = scale_a.get_reg_layout()
+            compact_rows = ttgl.arange(0, M, ttgl.SliceLayout(1, compact_reg))[:, None]
+            compact_values = (127 + (compact_rows + OFFSET) // 128 +
+                              ttgl.zeros([M, K // 32], ttgl.int32, compact_reg)).to(ttgl.uint8)
+            scale_a.store(compact_values)
+        else:
+            scale_a = view
+        scale_b = allocate_tensor_memory(ttgl.uint8, [N, K // 32], TensorMemoryScalesLayout())
+        scale_b.store(ttgl.full([N, K // 32], 127, ttgl.uint8, scale_b.get_reg_layout()))
+
+        acc = allocate_tensor_memory(ttgl.float32, [M, N], TensorMemoryLayout([128, 128], 1))
+        if USE_ACC:
+            acc.store(ttgl.full([M, N], 3, ttgl.float32, acc.get_reg_layout()))
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar, count=1)
+        tcgen05_mma_scaled(smem_a, smem_b, acc, scale_a, scale_b, "e5m2", "e5m2", use_acc=USE_ACC, mbarriers=[bar])
+        mbarrier.wait(bar, phase=0)
+        mbarrier.invalidate(bar)
+
+        result = acc.load()
+        result_reg: ttgl.constexpr = result.type.layout
+        rm = ttgl.arange(0, M, ttgl.SliceLayout(1, result_reg))[:, None]
+        rn = ttgl.arange(0, N, ttgl.SliceLayout(0, result_reg))[None, :]
+        ttgl.store(out + rm * N + rn, result)
+
+    out = torch.empty((M, 128), dtype=torch.float32, device="cuda")
+    kernel[(1, )](out, M, K, parent_m, compact, use_acc, offset, num_warps=4)
+    # Integer K and power-of-two scales have an exact, independent oracle.
+    expected = torch.tensor([K * 2**((row + offset) // 128) + (3 if use_acc else 0) for row in range(M)],
+                            dtype=torch.float32, device="cuda")
+    torch.testing.assert_close(out, expected[:, None].expand_as(out), atol=0, rtol=0)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -6131,7 +6131,7 @@ def test_tcgen05_mma_scaled_sliced_a_scales(M, K, parent_m, compact, use_acc, of
         N: ttgl.constexpr = 128
         reg: ttgl.constexpr = ttgl.BlockedLayout([1, 4], [4, 8], [4, 1], [1, 0])
         k = ttgl.arange(0, K, ttgl.SliceLayout(0, reg))[None, :]
-        a = ttgl.broadcast_to((1 + k // 128).to(ttgl.float8e5), [M, K])
+        a = (1 + k // 128 + ttgl.zeros([M, K], ttgl.int32, reg)).to(ttgl.float8e5)
         b = ttgl.full([K, N], 1, ttgl.float8e5, reg)
         smem_a = ttgl.allocate_shared_memory(ttgl.float8e5, [M, K], ttgl.NVMMASharedLayout(128, 8, transposed=False), a)
         smem_b = ttgl.allocate_shared_memory(ttgl.float8e5, [K, N], ttgl.NVMMASharedLayout(128, 8, transposed=True), b)
@@ -6172,7 +6172,9 @@ def test_tcgen05_mma_scaled_sliced_a_scales(M, K, parent_m, compact, use_acc, of
     out = torch.empty((M, 128), dtype=torch.float32, device="cuda")
     kernel[(1, )](out, M, K, parent_m, compact, use_acc, offset, num_warps=4)
     # Unequal K-word contributions expose scale-word permutations; the oracle is exact.
-    expected = torch.tensor([32 * sum((1 + j // 4) * 2**((row + offset) // 128 + j // 4) for j in range(K // 32)) +
-                             (3 if use_acc else 0) for row in range(M)],
-                            dtype=torch.float32, device="cuda")
+    expected = torch.tensor([
+        32 * sum((1 + j // 4) * 2**((row + offset) // 128 + j // 4)
+                 for j in range(K // 32)) + (3 if use_acc else 0)
+        for row in range(M)
+    ], dtype=torch.float32, device="cuda")
     torch.testing.assert_close(out, expected[:, None].expand_as(out), atol=0, rtol=0)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -6130,26 +6130,27 @@ def test_tcgen05_mma_scaled_sliced_a_scales(M, K, parent_m, compact, use_acc, of
                USE_ACC: ttgl.constexpr, OFFSET: ttgl.constexpr):
         N: ttgl.constexpr = 128
         reg: ttgl.constexpr = ttgl.BlockedLayout([1, 4], [4, 8], [4, 1], [1, 0])
-        a = ttgl.full([M, K], 1, ttgl.float8e5, reg)
+        k = ttgl.arange(0, K, ttgl.SliceLayout(0, reg))[None, :]
+        a = ttgl.broadcast_to((1 + k // 128).to(ttgl.float8e5), [M, K])
         b = ttgl.full([K, N], 1, ttgl.float8e5, reg)
         smem_a = ttgl.allocate_shared_memory(ttgl.float8e5, [M, K], ttgl.NVMMASharedLayout(128, 8, transposed=False), a)
         smem_b = ttgl.allocate_shared_memory(ttgl.float8e5, [K, N], ttgl.NVMMASharedLayout(128, 8, transposed=True), b)
 
-        parent = allocate_tensor_memory(ttgl.uint8, [PARENT_M, K // 32], TensorMemoryScalesLayout())
-        preg: ttgl.constexpr = parent.get_reg_layout()
-        rows = ttgl.arange(0, PARENT_M, ttgl.SliceLayout(1, preg))[:, None]
-        scale_values = (127 + rows // 128 + ttgl.zeros([PARENT_M, K // 32], ttgl.int32, preg)).to(ttgl.uint8)
-        parent.store(scale_values)
-        view = parent.slice(OFFSET, M, dim=0)
         if COMPACT:
             scale_a = allocate_tensor_memory(ttgl.uint8, [M, K // 32], TensorMemoryScalesLayout())
             compact_reg: ttgl.constexpr = scale_a.get_reg_layout()
             compact_rows = ttgl.arange(0, M, ttgl.SliceLayout(1, compact_reg))[:, None]
-            compact_values = (127 + (compact_rows + OFFSET) // 128 +
-                              ttgl.zeros([M, K // 32], ttgl.int32, compact_reg)).to(ttgl.uint8)
+            compact_cols = ttgl.arange(0, K // 32, ttgl.SliceLayout(0, compact_reg))[None, :]
+            compact_values = (127 + (compact_rows + OFFSET) // 128 + compact_cols // 4).to(ttgl.uint8)
             scale_a.store(compact_values)
         else:
-            scale_a = view
+            parent = allocate_tensor_memory(ttgl.uint8, [PARENT_M, K // 32], TensorMemoryScalesLayout())
+            preg: ttgl.constexpr = parent.get_reg_layout()
+            rows = ttgl.arange(0, PARENT_M, ttgl.SliceLayout(1, preg))[:, None]
+            cols = ttgl.arange(0, K // 32, ttgl.SliceLayout(0, preg))[None, :]
+            scale_values = (127 + rows // 128 + cols // 4).to(ttgl.uint8)
+            parent.store(scale_values)
+            scale_a = parent.slice(OFFSET, M, dim=0)
         scale_b = allocate_tensor_memory(ttgl.uint8, [N, K // 32], TensorMemoryScalesLayout())
         scale_b.store(ttgl.full([N, K // 32], 127, ttgl.uint8, scale_b.get_reg_layout()))
 
@@ -6170,7 +6171,8 @@ def test_tcgen05_mma_scaled_sliced_a_scales(M, K, parent_m, compact, use_acc, of
 
     out = torch.empty((M, 128), dtype=torch.float32, device="cuda")
     kernel[(1, )](out, M, K, parent_m, compact, use_acc, offset, num_warps=4)
-    # Integer K and power-of-two scales have an exact, independent oracle.
-    expected = torch.tensor([K * 2**((row + offset) // 128) + (3 if use_acc else 0) for row in range(M)],
+    # Unequal K-word contributions expose scale-word permutations; the oracle is exact.
+    expected = torch.tensor([32 * sum((1 + j // 4) * 2**((row + offset) // 128 + j // 4) for j in range(K // 32)) +
+                             (3 if use_acc else 0) for row in range(M)],
                             dtype=torch.float32, device="cuda")
     torch.testing.assert_close(out, expected[:, None].expand_as(out), atol=0, rtol=0)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -6131,7 +6131,7 @@ def test_tcgen05_mma_scaled_sliced_a_scales(M, K, parent_m, compact, use_acc, of
         N: ttgl.constexpr = 128
         reg: ttgl.constexpr = ttgl.BlockedLayout([1, 4], [4, 8], [4, 1], [1, 0])
         k = ttgl.arange(0, K, ttgl.SliceLayout(0, reg))[None, :]
-        a = (1 + k // 128 + ttgl.zeros([M, K], ttgl.int32, reg)).to(ttgl.float8e5)
+        a = (1.0 + k // 128 + ttgl.zeros([M, K], ttgl.float32, reg)).to(ttgl.float8e5)
         b = ttgl.full([K, N], 1, ttgl.float8e5, reg)
         smem_a = ttgl.allocate_shared_memory(ttgl.float8e5, [M, K], ttgl.NVMMASharedLayout(128, 8, transposed=False), a)
         smem_b = ttgl.allocate_shared_memory(ttgl.float8e5, [K, N], ttgl.NVMMASharedLayout(128, 8, transposed=True), b)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -940,11 +940,14 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
                                            numRepKWords);
     int offsetA = scaleIdxA * numColPerScaleBlockA;
     int offsetB = scaleIdxB * numColPerScaleBlockB;
-    if (useK96) {
+    if (mxfpInstKind == mxfpKind::mxf8f6f4 || useK96) {
+      // Sliced scales retain the parent layout's physical repetition strides.
       offsetA =
           ttng::getTMemSubSliceOffset(op.getAScale().getType(),
                                       m * desc.mmaSizeM, 0) +
           ttng::getTMemSubSliceOffset(op.getAScale().getType(), wordIdx * 4, 1);
+    }
+    if (useK96) {
       offsetB =
           ttng::getTMemSubSliceOffset(op.getBScale().getType(),
                                       n * desc.mmaSizeN, 0) +

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -922,10 +922,6 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
                             int k) -> MMAInstOperands {
     auto [numRepM, numRepN, numRepK] = desc.repShape;
     int numRepKWords = ceil<int>(blockK, dot.mmaSizeK * mmasPerScaleWord);
-    int numColPerScaleBlockA = ceil<int>(
-        ttng::getTmemAllocSizes(cast<MemDescType>(op.getAScale().getType()))
-            .numCols,
-        numRepM * numRepKWords);
     int numColPerScaleBlockB = ceil<int>(
         ttng::getTmemAllocSizes(cast<MemDescType>(op.getBScale().getType()))
             .numCols,
@@ -934,11 +930,9 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
     int baseK = dot.getKOffset(k) / dot.mmaSizeK;
     int subWordIdx = baseK % mmasPerScaleWord;
     int wordIdx = baseK / mmasPerScaleWord;
-    int scaleIdxA = linearizeScaleBlockIdx(op.getAScale(), m, wordIdx, numRepM,
-                                           numRepKWords);
     int scaleIdxB = linearizeScaleBlockIdx(op.getBScale(), n, wordIdx, numRepN,
                                            numRepKWords);
-    int offsetA = scaleIdxA * numColPerScaleBlockA;
+    int offsetA;
     int offsetB = scaleIdxB * numColPerScaleBlockB;
     if (mxfpInstKind == mxfpKind::mxf8f6f4 || useK96) {
       // Sliced scales retain the parent layout's physical repetition strides.
@@ -946,6 +940,14 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
           ttng::getTMemSubSliceOffset(op.getAScale().getType(),
                                       m * desc.mmaSizeM, 0) +
           ttng::getTMemSubSliceOffset(op.getAScale().getType(), wordIdx * 4, 1);
+    } else {
+      int numColPerScaleBlockA = ceil<int>(
+          ttng::getTmemAllocSizes(cast<MemDescType>(op.getAScale().getType()))
+              .numCols,
+          numRepM * numRepKWords);
+      int scaleIdxA = linearizeScaleBlockIdx(op.getAScale(), m, wordIdx, numRepM,
+                                             numRepKWords);
+      offsetA = scaleIdxA * numColPerScaleBlockA;
     }
     if (useK96) {
       offsetB =

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -945,8 +945,8 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
           ttng::getTmemAllocSizes(cast<MemDescType>(op.getAScale().getType()))
               .numCols,
           numRepM * numRepKWords);
-      int scaleIdxA = linearizeScaleBlockIdx(op.getAScale(), m, wordIdx, numRepM,
-                                             numRepKWords);
+      int scaleIdxA = linearizeScaleBlockIdx(op.getAScale(), m, wordIdx,
+                                             numRepM, numRepKWords);
       offsetA = scaleIdxA * numColPerScaleBlockA;
     }
     if (useK96) {


### PR DESCRIPTION
Fixes #11633.

Use the retained physical TMEM layout when computing A-scale offsets for `tcgen05_mma_scaled`. A row slice can have the same logical shape as a compact allocation but different physical strides; using the logical shape reads the wrong scales.

## Tests

`pytest python/test/gluon/test_core.py::test_tcgen05_mma_scaled_sliced_a_scales -s --tb=short`

All nine regression kernels pass on B200; the original compiler fails four. Varying operands and scales across K words also makes an incorrect scale-word permutation fail the exact oracle.

[Compiler tests](https://github.com/1sgtpepper/triton/actions/runs/34458190284): 263 C++ tests and 299 lit tests pass; two extension-plugin tests are unsupported. Repository formatting checks pass.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --show-diff-on-failure --verbose --files ...` on the complete base-to-head changed-file list.
- [x] I have added tests in `/python/test`.
- [x] I have not added any `lit` tests.
