### PR TITLE
[INTERPRETER] Implement fused multiply-add (FMA) for float32 and float64 types

### DIFF
--- a/python/src/interpreter.cc
+++ b/python/src/interpreter.cc
@@ -1,4 +1,5 @@
 #include <atomic>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -639,6 +640,30 @@ void require_dtype(const AnyArray &array, const char *name) {
     throw std::invalid_argument(std::string(name) + " has unsupported dtype");
 }
 
+template <typename T>
+py::object fma_array(py::object x_obj, py::object y_obj, py::object z_obj) {
+  AnyArray x = py::cast<AnyArray>(x_obj);
+  AnyArray y = py::cast<AnyArray>(y_obj);
+  AnyArray z = py::cast<AnyArray>(z_obj);
+  require_dtype<T>(x, "x");
+  require_dtype<T>(y, "y");
+  require_dtype<T>(z, "z");
+  if (x.size() != y.size() || x.size() != z.size())
+    throw std::invalid_argument("fma operands must have the same size");
+  py::object ret = numpy_empty(x.size(), x_obj.attr("dtype"));
+  auto ret_array = py::cast<MutableArray>(ret);
+  auto *out = static_cast<T *>(ret_array.data());
+  for (size_t i = 0; i < x.size(); ++i) {
+    T a, b, c;
+    memcpy(&a, const_element_data(x, i), sizeof(T));
+    memcpy(&b, const_element_data(y, i), sizeof(T));
+    memcpy(&c, const_element_data(z, i), sizeof(T));
+    // Select the overload that rounds directly to the operand type.
+    out[i] = std::fma(a, b, c);
+  }
+  return ret.attr("reshape")(shape_list(x));
+}
+
 std::vector<uint64_t> copy_uint64_array(const AnyArray &array) {
   std::vector<uint64_t> data(array.size());
   for (size_t i = 0; i < array.size(); ++i)
@@ -721,6 +746,9 @@ void init_triton_interpreter(py::module_ &m) {
       .value("UMIN", RMWOp::UMIN)
       .value("UMAX", RMWOp::UMAX)
       .export_values();
+
+  m.def("fma_fp32", &fma_array<float>);
+  m.def("fma_fp64", &fma_array<double>);
 
   m.def("load",
         [](py::object ptr_obj, py::object mask_obj, py::object other_obj,

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1174,8 +1174,9 @@ def test_math_fma_op(dtype, device):
 
 
 @pytest.mark.interpreter
-def test_math_fma_op_special_values(device):
-    check_type_supported('float64', device)
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+def test_math_fma_op_edge_cases(dtype, device):
+    check_type_supported(dtype, device)
 
     @triton.jit
     def kernel(Z, X, Y, W, SIZE: tl.constexpr):
@@ -1186,25 +1187,49 @@ def test_math_fma_op_special_values(device):
         z = tl.math.fma(x, y, w)
         tl.store(Z + off, z)
 
-    finfo = np.finfo(np.float64)
+    finfo = np.finfo(getattr(np, dtype))
     inf, nan = float('inf'), float('nan')
+    if dtype == "float32":
+        mid_x, mid_y = 4097, 4097
+        lower, upper = 16785408, 16785410
+        # Product: 2**128 - 2**103, the float32 overflow midpoint
+        overflow_x, overflow_y = 31 * 2**59, 1082401 * 2**44
+    else:
+        mid_x, mid_y = 2**27 + 1, 2**27 + 2
+        lower = 2**54 + 3 * 2**27
+        upper = lower + 4
+        # Product: 2**1024 - 2**970, the float64 overflow midpoint
+        overflow_x, overflow_y = (2**27 - 1) * 2**485, (2**27 + 1) * 2**485
     cases = [
         # x, y, w, expected
+        # Round to either side of a midpoint, check just below and at the overflow threshold
+        (mid_x, mid_y, 2**-30, upper),
+        (mid_x, mid_y, -2**-30, lower),
+        (overflow_x, overflow_y, -1, finfo.max),
+        (overflow_x, overflow_y, 0, inf),
+        # Finite results adjacent to infinity, including exact equality
+        (finfo.max, 1, 1, finfo.max),
+        (-finfo.max, 1, 0, -finfo.max),
+        # NaN propagation, invalid multiplication, and an infinite addend
         (nan, 1.0, 1.0, nan),
         (inf, 0.0, 1.0, nan),
-        (2.0, 3.0, inf, inf),
         (-finfo.max, finfo.max, inf, inf),
+        # Signed zero, exact cancellation, and overflow cancellation.
         (-0.0, 1.0, -0.0, -0.0),
         (1.0, 1.0, -1.0, 0.0),
-        (finfo.max, 2.0, finfo.max, inf),
+        (finfo.max, 2.0, -finfo.max, finfo.max),
+        # Preserve subnormals and round underflow ties to even
+        (finfo.smallest_subnormal, 1.0, 0.0, finfo.smallest_subnormal),
         (-finfo.smallest_subnormal, 0.5, 0.0, -0.0),
+        (finfo.smallest_subnormal, 0.5, finfo.smallest_subnormal, 2 * finfo.smallest_subnormal),
+        (finfo.tiny, 0.5, 0.0, finfo.tiny / 2),
     ]
-    x, y, w, expected = (np.array(column, dtype=np.float64) for column in zip(*cases))
+    x, y, w, expected = (np.array(column, dtype=dtype) for column in zip(*cases))
 
-    x_tri = to_triton(x, device=device, dst_type='float64')
-    y_tri = to_triton(y, device=device, dst_type='float64')
-    w_tri = to_triton(w, device=device, dst_type='float64')
-    z_tri = to_triton(np.zeros_like(x), device=device, dst_type='float64')
+    x_tri = to_triton(x, device=device, dst_type=dtype)
+    y_tri = to_triton(y, device=device, dst_type=dtype)
+    w_tri = to_triton(w, device=device, dst_type=dtype)
+    z_tri = to_triton(np.zeros_like(x), device=device, dst_type=dtype)
     kernel[(1, )](z_tri, x_tri, y_tri, w_tri, SIZE=len(cases))
 
     z = to_numpy(z_tri)

--- a/python/test/unit/runtime/test_interpreter.py
+++ b/python/test/unit/runtime/test_interpreter.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import itertools
 
 from triton._C.libtriton import interpreter as _interpreter
@@ -86,3 +87,15 @@ def test_atomic_cas_accepts_non_contiguous_ndarray_views() -> None:
     np.testing.assert_array_equal(old, original[:, ::2])
     original[:, ::2] = desired
     np.testing.assert_array_equal(dst, original)
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+def test_fma_broadcast_and_strides(dtype):
+    x = np.arange(12, dtype=dtype).reshape(3, 4)[:, ::2]
+    y = np.array(2, dtype=dtype)
+    z = np.arange(2, dtype=dtype)
+    handles = [interpreter.TensorHandle(value, getattr(tl, dtype)) for value in (x, y, z)]
+    result = interpreter.InterpreterBuilder().create_fma(*handles)
+    assert result.data.shape == x.shape
+    assert result.data.dtype == np.dtype(dtype)
+    np.testing.assert_array_equal(result.data, x * y + z)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -7,7 +7,6 @@ from typing import Tuple, List, Dict, Callable, TypeVar, Optional
 import math
 import numpy as np
 import time
-from fractions import Fraction
 
 import triton
 import triton.language as tl
@@ -258,25 +257,6 @@ def _umulhi_64(a, b):
     return ((int(a) & mask) * (int(b) & mask)) >> 64
 
 
-def _fma_fp64(a, b, c):
-    # Numpy has no fused multiply-add, and float64 has no wider type to hold the
-    # product exactly, so round the exact rational value instead.
-    if math.isnan(a) or math.isnan(b) or math.isnan(c) or math.isinf(a) or math.isinf(b):
-        return a * b + c
-    if math.isinf(c):
-        return c
-    exact = Fraction(a) * Fraction(b) + Fraction(c)
-    if exact == 0:
-        # Only zero operands can make this a negative zero.
-        return a * b + c if a * b == 0.0 and c == 0.0 else 0.0
-    sign = 1.0 if exact > 0 else -1.0
-    try:
-        ret = float(exact)
-    except OverflowError:
-        return math.copysign(math.inf, sign)
-    return ret if ret != 0.0 else math.copysign(0.0, sign)
-
-
 def _e8m0_to_f32(scale):
     assert scale.dtype in (np.uint8, np.int8)
     scale = scale.astype(np.uint8)
@@ -372,7 +352,6 @@ def _prepare_dot_scaled_operand(value_handle, scale_handle, format_enum, k_pack,
 np_erf_fp32 = np.vectorize(_erf, otypes=[np.float32])
 np_erf_fp64 = np.vectorize(_erf, otypes=[np.float64])
 np_umulhi_u64 = np.vectorize(_umulhi_64, otypes=[np.uint64])
-np_fma_fp64 = np.vectorize(_fma_fp64, otypes=[np.float64])
 
 
 class ExtraFunctions:
@@ -708,10 +687,12 @@ class InterpreterBuilder:
 
     def create_fma(self, x, y, z):
         # An fma rounds once, but multiplying and then adding rounds twice.
-        # float64 has the precision to round the narrower types correctly.
+        # float64 intermediate rounding is safe for float16, but not float32.
         dtype = z.data.dtype
         if dtype == np.float64:
-            ret = np_fma_fp64(x.data, y.data, z.data)
+            ret = _interpreter.fma_fp64(*np.broadcast_arrays(x.data, y.data, z.data))
+        elif dtype == np.float32:
+            ret = _interpreter.fma_fp32(*np.broadcast_arrays(x.data, y.data, z.data))
         else:
             product = np.multiply(x.data, y.data, dtype=np.float64)
             ret = np.add(product, z.data, dtype=np.float64).astype(dtype)


### PR DESCRIPTION
Avoid complex numpy workarounds with a lot of edge cases. Closes https://github.com/triton-lang/triton/pull/11611