### PR TITLE
[ConSan] Slice proxy and barrier bookkeeping by proven indices

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -237,7 +237,7 @@ public:
   // and invalidate prior proxy-fence coverage for that source thread.
   void createSetProxyAccessCall(ImplicitLocOpBuilder &b, Value bufferMask,
                                 int thread, Value pred, Operation *insertPoint,
-                                Value effectCTAs);
+                                Value effectCTAs, Value bufferIndex = {});
   // fenceProxyAccesses: mark all generic accesses visible to the current base
   // thread as covered by fence.proxy.async. A CTA fence covers the current
   // buffer row; a cluster fence covers every cluster buffer row.

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -104,6 +104,29 @@ Value createCmpIntTensorScalar(
   return arith::CmpIOp::create(b, predicate, tensor, splat);
 }
 
+bool hasUniqueBarrierDescriptors(Value barriers, uint32_t mbarLength) {
+  auto descriptors =
+      barriers.getDefiningOp<tti::ExperimentalBufferDescriptorsOp>();
+  if (!descriptors)
+    return false;
+  llvm::SmallDenseSet<uint64_t> keys;
+  // Match BufferDescriptorsOpConversion's address trimming and length
+  // packing. Adding its common base preserves equality modulo this mask.
+  uint64_t addressMask = descriptors.getMemType() == MemType::SHARED_MEM
+                             ? (1ULL << 24) - 1
+                             : 0xffffffffULL;
+  for (auto [offset, length] :
+       llvm::zip_equal(descriptors.getOffsets(), descriptors.getLengths())) {
+    if (static_cast<uint32_t>(length) != mbarLength)
+      continue;
+    uint64_t key = (static_cast<uint64_t>(mbarLength) << 32) |
+                   (static_cast<uint32_t>(offset) & addressMask);
+    if (!keys.insert(key).second)
+      return false;
+  }
+  return true;
+}
+
 template <typename OpTy>
 Value reduceLastDim(ImplicitLocOpBuilder &b, Value tensor) {
   OpBuilder::InsertionGuard guard(b);
@@ -362,7 +385,8 @@ Value createDimIndices(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
 }
 
 Value createLoadTrackingPhase(ImplicitLocOpBuilder &b, Value trackingPtr,
-                              RankedTensorType trackingType, Value phase) {
+                              RankedTensorType trackingType, Value phase,
+                              Value barrierIndex = {}) {
   int phaseDim = trackingType.getRank() - 1;
   assert(phaseDim >= 0 && trackingType.getShape()[phaseDim] == 2 &&
          "expected a trailing barrier phase dimension");
@@ -382,7 +406,27 @@ Value createLoadTrackingPhase(ImplicitLocOpBuilder &b, Value trackingPtr,
   Value offset = arith::MulIOp::create(b, phaseIndex, bankElements);
   Value bankPtr =
       triton::AddPtrOp::create(b, trackingPtr.getType(), trackingPtr, offset);
-  return tti::createLoadScratchMemory(b, b.getLoc(), bankPtr, bankType);
+  SmallVector<int64_t> strides;
+  if (barrierIndex) {
+    assert(phaseDim > 3 && "expected a barrier axis before the phase");
+    SmallVector<int64_t> shape(bankType.getShape());
+    int64_t stride = 1;
+    for (int64_t extent : shape) {
+      strides.push_back(stride);
+      stride *= extent;
+    }
+    Value barrierOffset = arith::MulIOp::create(
+        b, barrierIndex, arith::ConstantIntOp::create(b, strides[3], 32));
+    bankPtr =
+        triton::AddPtrOp::create(b, bankPtr.getType(), bankPtr, barrierOffset);
+    // Keep the K axis while preserving the full origin and phase-bank spacing.
+    shape[3] = 1;
+    bankType = tti::getIntTensorType(
+        b.getInsertionBlock()->getParent(), shape,
+        bankType.getElementType().getIntOrFloatBitWidth());
+  }
+  return tti::createLoadScratchMemory(b, b.getLoc(), bankPtr, bankType,
+                                      strides);
 }
 
 Value createCurrentCTAMask(ImplicitLocOpBuilder &b) {
@@ -509,11 +553,12 @@ Value createLeadCTAEffectMask(ImplicitLocOpBuilder &b,
 Operation *createMaskedStoreScratchMemory(ImplicitLocOpBuilder &b, Location loc,
                                           Value alloc, Value tensor,
                                           RankedTensorType tensorType,
-                                          Value mask) {
+                                          Value mask,
+                                          ArrayRef<int64_t> strides = {}) {
   int64_t numCTAs = ttg::lookupNumCTAs(b);
   return tti::createStoreScratchMemory(b, loc, alloc, tensor, tensorType,
                                        /*currentCTAOnly=*/false,
-                                       numCTAs > 1 ? mask : Value{});
+                                       numCTAs > 1 ? mask : Value{}, strides);
 }
 
 Operation *createCTAScopedStoreScratchMemory(ImplicitLocOpBuilder &b,
@@ -1817,20 +1862,23 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
         auto clearTable = [&](RankedTensorType tableType) {
           Value tablePtr = entryBlock->getArgument(nextArg++);
           SmallVector<int64_t> shape(tableType.getShape());
+          assert(shape.size() >= 3 && "Expected a tracking or commit table");
+          unsigned streamDim = std::min<unsigned>(3, shape.size() - 1);
           SmallVector<int64_t> strides(shape.size(), 1);
           for (unsigned dim = 1; dim < shape.size(); ++dim)
             strides[dim] = strides[dim - 1] * shape[dim - 1];
-          int64_t extent = shape[3];
+          int64_t extent = shape[streamDim];
           unsigned bitWidth =
               tableType.getElementType().getIntOrFloatBitWidth();
           int64_t threadsPerWarp = ttg::lookupThreadsPerWarp(fb);
-          // Keep a warp's 128-bit vector span while streaming the K/T axis.
+          // Stream K/T (or the issuer axis of a commit table), preserving
+          // the complete CTA and buffer dimensions used by the clear mask.
           int64_t chunk = std::min<int64_t>(
               extent, std::max<int64_t>(1, threadsPerWarp * (128 / bitWidth) /
-                                               strides[3]));
+                                               strides[streamDim]));
           RankedTensorType storeType = tableType;
           if (chunk < extent) {
-            shape[3] = chunk;
+            shape[streamDim] = chunk;
             storeType = tti::getIntTensorType(
                 fb.getInsertionBlock()->getParent(), shape, bitWidth);
           }
@@ -1849,7 +1897,8 @@ void FunctionBuilder::createPublishWriteVisibilityCall(
           Value first = arith::ConstantIntOp::create(fb, 0, 32);
           Value step = arith::ConstantIntOp::create(fb, chunk, 32);
           Value limit = arith::ConstantIntOp::create(fb, extent, 32);
-          Value stride = arith::ConstantIntOp::create(fb, strides[3], 32);
+          Value stride =
+              arith::ConstantIntOp::create(fb, strides[streamDim], 32);
           Block *preheader = fb.getInsertionBlock();
           Block *continueBlock = preheader->splitBlock(fb.getInsertionPoint());
           Block *loopBlock = fb.createBlock(continueBlock);
@@ -2169,28 +2218,8 @@ void FunctionBuilder::createTrackVisibleAccessesCall(
   if (readBufferMask)
     args.push_back(readBufferMask);
 
-  auto descriptors =
-      barriers.value.getDefiningOp<tti::ExperimentalBufferDescriptorsOp>();
-  bool sliceBarrierTracking = static_cast<bool>(descriptors);
-  if (sliceBarrierTracking) {
-    llvm::SmallDenseSet<uint64_t> keys;
-    // Match BufferDescriptorsOpConversion's address trimming and length
-    // packing. Adding its common base preserves equality modulo this mask.
-    uint64_t addressMask = descriptors.getMemType() == MemType::SHARED_MEM
-                               ? (1ULL << 24) - 1
-                               : 0xffffffffULL;
-    for (auto [offset, length] :
-         llvm::zip_equal(descriptors.getOffsets(), descriptors.getLengths())) {
-      if (static_cast<uint32_t>(length) != mbarLength)
-        continue;
-      uint64_t key = (static_cast<uint64_t>(mbarLength) << 32) |
-                     (static_cast<uint32_t>(offset) & addressMask);
-      if (!keys.insert(key).second) {
-        sliceBarrierTracking = false;
-        break;
-      }
-    }
-  }
+  bool sliceBarrierTracking =
+      hasUniqueBarrierDescriptors(barriers.value, mbarLength);
   specializationArgs.append(static_cast<uint64_t>(sliceBarrierTracking));
 
   createCallToCachedFunction(
@@ -2579,9 +2608,10 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
   Value threadMaskVal = arith::ConstantIntOp::create(b, threadMask, 64);
   ValueType barriers = auxData.barriers.at(insertPoint);
   auto barriersType = cast<RankedTensorType>(barriers.type);
+  uint32_t mbarLength = getMemDescLength(mbar);
   SmallVector<Value> args = {
       tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      arith::ConstantIntOp::create(b, mbarLength, 32),
       phase,
       pred,
       threadMaskVal,
@@ -2616,13 +2646,16 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
     specializationArgs.append(readVisibilityType);
     specializationArgs.append(readTrackingType);
   }
+  bool sliceBarrierTracking =
+      hasUniqueBarrierDescriptors(barriers.value, mbarLength);
+  specializationArgs.append(static_cast<uint64_t>(sliceBarrierTracking));
 
   createCallToCachedFunction(
       b, "transfer_visible_accesses", args, /*assertInfo=*/std::nullopt,
       specializationArgs,
       [transferWrites, transferReads, writeVisibilityType, writeTrackingType,
-       readVisibilityType,
-       readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+       readVisibilityType, readTrackingType,
+       sliceBarrierTracking](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value phase = entryBlock->getArgument(2);
@@ -2637,17 +2670,34 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
         Value currentCTA = createCurrentCTAMask(fb);
+        Value barrierIndex, anyMatch;
+        if (sliceBarrierTracking) {
+          auto indexType =
+              cast<RankedTensorType>(barriers.getType()).clone(fb.getI32Type());
+          Value indices = triton::MakeRangeOp::create(
+              fb, indexType, 0, indexType.getNumElements());
+          Value selectedIndices = arith::SelectOp::create(
+              fb, barriersEqBar, indices,
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, indexType));
+          barrierIndex = reduceAll<arith::OrIOp>(fb, selectedIndices);
+          anyMatch = reduceAll<arith::OrIOp>(fb, barriersEqBar);
+        }
+        auto createBarrierMask = [&](RankedTensorType type) -> Value {
+          if (sliceBarrierTracking)
+            return triton::SplatOp::create(fb, type.clone(fb.getI1Type()),
+                                           anyMatch);
+          return convertAndBroadcast(fb, barriersEqBar, {3}, type);
+        };
 
         if (transferWrites) {
           Value visibilityPtr = entryBlock->getArgument(nextArg++);
           Value trackingPtr = entryBlock->getArgument(nextArg++);
           Value visibility = tti::createLoadScratchMemory(
               fb, fb.getLoc(), visibilityPtr, writeVisibilityType);
-          Value tracking = createLoadTrackingPhase(fb, trackingPtr,
-                                                   writeTrackingType, phase);
+          Value tracking = createLoadTrackingPhase(
+              fb, trackingPtr, writeTrackingType, phase, barrierIndex);
           auto phaseTrackingType = cast<RankedTensorType>(tracking.getType());
-          Value barrierMask =
-              convertAndBroadcast(fb, barriersEqBar, {3}, phaseTrackingType);
+          Value barrierMask = createBarrierMask(phaseTrackingType);
           Value barrierCTAMask =
               createCTASetMask(fb, phaseTrackingType, /*dim=*/2, currentCTA);
           barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
@@ -2689,11 +2739,10 @@ void FunctionBuilder::createTransferVisibleAccessesCall(
           Value trackingPtr = entryBlock->getArgument(nextArg++);
           Value visibility = tti::createLoadScratchMemory(
               fb, fb.getLoc(), visibilityPtr, readVisibilityType);
-          Value tracking =
-              createLoadTrackingPhase(fb, trackingPtr, readTrackingType, phase);
+          Value tracking = createLoadTrackingPhase(
+              fb, trackingPtr, readTrackingType, phase, barrierIndex);
           auto phaseTrackingType = cast<RankedTensorType>(tracking.getType());
-          Value barrierMask =
-              convertAndBroadcast(fb, barriersEqBar, {3}, phaseTrackingType);
+          Value barrierMask = createBarrierMask(phaseTrackingType);
           Value barrierCTAMask =
               createCTASetMask(fb, phaseTrackingType, /*dim=*/2, currentCTA);
           barrierMask = arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
@@ -3226,11 +3275,9 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
       });
 }
 
-void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
-                                               Value bufferMask, int thread,
-                                               Value pred,
-                                               Operation *insertPoint,
-                                               Value effectCTAs) {
+void FunctionBuilder::createSetProxyAccessCall(
+    ImplicitLocOpBuilder &b, Value bufferMask, int thread, Value pred,
+    Operation *insertPoint, Value effectCTAs, Value bufferIndex) {
   if (auxData.proxyAccessVisibility.empty())
     return;
   if (!pred)
@@ -3239,11 +3286,14 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
   ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
   auto visibilityType = cast<RankedTensorType>(visibility.type);
   bool hasTracking = !auxData.proxyAccessTracking.empty();
+  bool singleBuffer = static_cast<bool>(bufferIndex);
   RankedTensorType trackingType;
-  SmallVector<Value> args = {bufferMask, pred,
+  SmallVector<Value> args = {singleBuffer ? bufferIndex : bufferMask, pred,
                              arith::ConstantIntOp::create(b, thread, 32),
                              visibility.value, effectCTAs};
-  ManglingArgs specializationArgs{visibilityType, (uint64_t)hasTracking};
+  // Equal row-view shapes can have different backing strides and bank offsets.
+  ManglingArgs specializationArgs{visibilityType, (uint64_t)hasTracking,
+                                  (uint64_t)singleBuffer};
   if (hasTracking) {
     ValueType tracking = auxData.proxyAccessTracking.at(insertPoint);
     trackingType = cast<RankedTensorType>(tracking.type);
@@ -3254,9 +3304,10 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "set_proxy_access", args, /*assertInfo=*/std::nullopt,
       specializationArgs,
-      [visibilityType, trackingType, hasTracking](ImplicitLocOpBuilder &fb,
-                                                  Block *entryBlock) {
-        Value bufferMask = entryBlock->getArgument(0);
+      [visibilityBackingType = visibilityType,
+       trackingBackingType = trackingType, hasTracking,
+       singleBuffer](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value bufferSelection = entryBlock->getArgument(0);
         Value pred = entryBlock->getArgument(1);
         Value threadVal = entryBlock->getArgument(2);
         Value visibilityPtr = entryBlock->getArgument(3);
@@ -3266,10 +3317,51 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
+        SmallVector<int64_t> visibilityStrides, trackingStrides;
+        auto createBufferView = [&](RankedTensorType type,
+                                    SmallVectorImpl<int64_t> &strides) {
+          if (!singleBuffer)
+            return type;
+          SmallVector<int64_t> shape(type.getShape());
+          strides.resize(shape.size(), 1);
+          for (unsigned dim = 1; dim < shape.size(); ++dim)
+            strides[dim] = strides[dim - 1] * shape[dim - 1];
+          shape[1] = 1;
+          return tti::getIntTensorType(
+              fb.getInsertionBlock()->getParent(), shape,
+              type.getElementType().getIntOrFloatBitWidth());
+        };
+        RankedTensorType visibilityType =
+            createBufferView(visibilityBackingType, visibilityStrides);
+        RankedTensorType trackingType;
+        if (hasTracking)
+          trackingType = createBufferView(trackingBackingType, trackingStrides);
+
+        auto selectBufferPointer = [&](Value ptr,
+                                       RankedTensorType type) -> Value {
+          if (!singleBuffer)
+            return ptr;
+          Value stride =
+              arith::ConstantIntOp::create(fb, type.getShape()[0], 32);
+          Value offset = arith::MulIOp::create(fb, bufferSelection, stride);
+          return triton::AddPtrOp::create(fb, ptr.getType(), ptr, offset)
+              .getResult();
+        };
+        visibilityPtr =
+            selectBufferPointer(visibilityPtr, visibilityBackingType);
+        if (hasTracking)
+          trackingPtr = selectBufferPointer(trackingPtr, trackingBackingType);
+
+        auto createBufferRows = [&](RankedTensorType type) -> Value {
+          if (singleBuffer) {
+            auto maskType = cast<RankedTensorType>(type.clone(fb.getI1Type()));
+            return tti::createConstIntTensor(fb, fb.getLoc(), 1, maskType);
+          }
+          return convertAndBroadcast(fb, bufferSelection, {1}, type);
+        };
         Value visibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), visibilityPtr, visibilityType);
-        Value bufferVector = bufferMask;
-        bufferMask = convertAndBroadcast(fb, bufferMask, {1}, visibilityType);
+            fb, fb.getLoc(), visibilityPtr, visibilityType, visibilityStrides);
+        Value bufferMask = createBufferRows(visibilityType);
         Value bufferCTAMask =
             createCTASetMask(fb, visibilityType, /*dim=*/0, effectCTAs);
         Value currentCTA = createCurrentCTAMask(fb);
@@ -3313,7 +3405,8 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
             arith::SelectOp::create(fb, ownerMask, withSeen, clearedVisibility);
         tti::createStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
                                       updatedVisibility, visibilityType,
-                                      /*currentCTAOnly=*/false);
+                                      /*currentCTAOnly=*/false,
+                                      /*storeMask=*/nullptr, visibilityStrides);
 
         // A new generic access supersedes fence coverage for an older access
         // from the same source. Clear that source's fence bit in outstanding
@@ -3322,9 +3415,8 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
         if (hasTracking) {
           if (trackingType.getShape()[4] == 1) {
             Value tracking = tti::createLoadScratchMemory(
-                fb, fb.getLoc(), trackingPtr, trackingType);
-            Value trackingBuffers =
-                convertAndBroadcast(fb, bufferVector, {1}, trackingType);
+                fb, fb.getLoc(), trackingPtr, trackingType, trackingStrides);
+            Value trackingBuffers = createBufferRows(trackingType);
             Value trackingBufferCTAMask =
                 createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs);
             Value trackingOriginCTAMask =
@@ -3339,14 +3431,21 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
                 arith::AndIOp::create(fb, tracking, trackingClear);
             Value updatedTracking = arith::SelectOp::create(
                 fb, trackingMask, clearedTracking, tracking);
-            tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
-                                          updatedTracking, trackingType,
-                                          /*currentCTAOnly=*/false);
+            tti::createStoreScratchMemory(
+                fb, fb.getLoc(), trackingPtr, updatedTracking, trackingType,
+                /*currentCTAOnly=*/false,
+                /*storeMask=*/nullptr, trackingStrides);
           } else {
+            RankedTensorType fullBankType =
+                tti::getSlicedTensorType(trackingBackingType, {0, 1, 2, 3},
+                                         trackingBackingType.getElementType());
             RankedTensorType bankType = tti::getSlicedTensorType(
                 trackingType, {0, 1, 2, 3}, trackingType.getElementType());
-            Value trackingBuffers =
-                convertAndBroadcast(fb, bufferVector, {1}, bankType);
+            SmallVector<int64_t> bankStrides;
+            if (singleBuffer)
+              bankStrides.assign(trackingStrides.begin(),
+                                 trackingStrides.begin() + 4);
+            Value trackingBuffers = createBufferRows(bankType);
             Value ownerMask =
                 createCTASetMask(fb, bankType, /*dim=*/0, effectCTAs);
             Value trackingMask =
@@ -3356,17 +3455,20 @@ void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
             Value originId =
                 tti::ExperimentalClusterCTAIdOp::create(fb, fb.getLoc());
             for (int phase = 0; phase < 2; ++phase) {
+              // Row pointers retain the full allocation's origin/phase spacing.
               Value bankPtr = createTrackingOriginPhasePointer(
-                  fb, trackingPtr, trackingType, bankType, originId, phase);
-              Value tracking = tti::createLoadScratchMemory(fb, fb.getLoc(),
-                                                            bankPtr, bankType);
+                  fb, trackingPtr, trackingBackingType, fullBankType, originId,
+                  phase);
+              Value tracking = tti::createLoadScratchMemory(
+                  fb, fb.getLoc(), bankPtr, bankType, bankStrides);
               Value clearedTracking =
                   arith::AndIOp::create(fb, tracking, trackingClear);
               Value updated = arith::SelectOp::create(
                   fb, trackingMask, clearedTracking, tracking);
               tti::createStoreScratchMemory(fb, fb.getLoc(), bankPtr, updated,
                                             bankType,
-                                            /*currentCTAOnly=*/false);
+                                            /*currentCTAOnly=*/false,
+                                            /*storeMask=*/nullptr, bankStrides);
             }
           }
         }
@@ -3461,18 +3563,21 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
   auto barrierStatesType = cast<RankedTensorType>(barrierStates.type);
   auto visibilityType = cast<RankedTensorType>(visibility.type);
   auto trackingType = cast<RankedTensorType>(tracking.type);
-  SmallVector<Value> args = {
-      tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
-      pred,
-      arith::ConstantIntOp::create(b, thread, 32),
-      barriers.value,
-      barrierStates.value,
-      visibility.value,
-      tracking.value,
-      barrierCTAs};
+  uint32_t mbarLength = getMemDescLength(mbar);
+  bool sliceBarrierTracking =
+      hasUniqueBarrierDescriptors(barriers.value, mbarLength);
+  SmallVector<Value> args = {tti::ExperimentalMemDescToI32Op::create(b, mbar),
+                             arith::ConstantIntOp::create(b, mbarLength, 32),
+                             pred,
+                             arith::ConstantIntOp::create(b, thread, 32),
+                             barriers.value,
+                             barrierStates.value,
+                             visibility.value,
+                             tracking.value,
+                             barrierCTAs};
   ManglingArgs specializationArgs{barriersType, barrierStatesType,
-                                  visibilityType, trackingType};
+                                  visibilityType, trackingType,
+                                  (uint64_t)sliceBarrierTracking};
   if (filterByBuffer) {
     args.append({bufferMask, effectCTAs});
   }
@@ -3481,8 +3586,9 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
       filterByBuffer ? "track_proxy_accesses_for_buffer"
                      : "track_proxy_accesses",
       args, /*assertInfo=*/std::nullopt, specializationArgs,
-      [barrierStatesType, visibilityType, trackingType,
-       filterByBuffer](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [barrierStatesType, visibilityType, trackingBackingType = trackingType,
+       filterByBuffer,
+       sliceBarrierTracking](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -3501,10 +3607,60 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
         fb.setInsertionPointToStart(ifBlock);
         Value barrierStates = tti::createLoadScratchMemory(
             fb, fb.getLoc(), barrierStatesPtr, barrierStatesType);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, descriptor);
+        Value currentPhases = arith::AndIOp::create(
+            fb, barrierStates,
+            tti::createConstIntTensor(fb, fb.getLoc(), 1, barrierStatesType));
+        RankedTensorType trackingType = trackingBackingType;
+        SmallVector<int64_t> trackingStrides;
+        SmallVector<int> phaseDims{2, 3};
+        Value anyMatch;
+        if (sliceBarrierTracking) {
+          auto indexType =
+              cast<RankedTensorType>(barriers.getType()).clone(fb.getI32Type());
+          Value indices = triton::MakeRangeOp::create(
+              fb, indexType, 0, indexType.getNumElements());
+          Value selectedIndices = arith::SelectOp::create(
+              fb, barriersEqBar, indices,
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, indexType));
+          Value barrierIndex = reduceAll<arith::OrIOp>(fb, selectedIndices);
+          anyMatch = reduceAll<arith::OrIOp>(fb, barriersEqBar);
+
+          // Remove only K, retaining each recipient CTA's current phase.
+          Value selectedPhases = arith::SelectOp::create(
+              fb,
+              convertAndBroadcast(fb, barriersEqBar, {1}, barrierStatesType),
+              currentPhases,
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType));
+          currentPhases = reduceLastDim<arith::OrIOp>(fb, selectedPhases);
+          phaseDims = {2};
+
+          ArrayRef<int64_t> shape = trackingBackingType.getShape();
+          int64_t barrierStride = shape[0] * shape[1] * shape[2];
+          Value offset = arith::MulIOp::create(
+              fb, barrierIndex,
+              arith::ConstantIntOp::create(fb, barrierStride, 32));
+          trackingPtr = triton::AddPtrOp::create(fb, trackingPtr.getType(),
+                                                 trackingPtr, offset);
+          SmallVector<int64_t> compactShape;
+          int64_t stride = 1;
+          for (int dim = 0; dim < trackingBackingType.getRank(); ++dim) {
+            if (dim != 3) {
+              compactShape.push_back(shape[dim]);
+              trackingStrides.push_back(stride);
+            }
+            stride *= shape[dim];
+          }
+          trackingType = tti::getIntTensorType(
+              entryBlock->getParent(), compactShape,
+              trackingBackingType.getElementType().getIntOrFloatBitWidth());
+        }
         Value visibility = tti::createLoadScratchMemory(
             fb, fb.getLoc(), visibilityPtr, visibilityType);
         Value tracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), trackingPtr, trackingType);
+            fb, fb.getLoc(), trackingPtr, trackingType, trackingStrides);
         Value currentCTA = createCurrentCTAMask(fb);
         Value sourceMask =
             createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
@@ -3526,22 +3682,22 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
         Value source =
             arith::SelectOp::create(fb, sourceMask, visibility, zeroVisibility);
         source = reduce<arith::OrIOp>(fb, source, {2, 3});
-        source = convertAndBroadcast(fb, source, {0, 1, 4}, trackingType);
+        source = convertAndBroadcast(
+            fb, source, {0, 1, sliceBarrierTracking ? 3 : 4}, trackingType);
 
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
-        Value barriersEqBar =
-            createCmpIntTensorScalar(fb, barriers, descriptor);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
+        Value barrierMask;
+        if (sliceBarrierTracking)
+          barrierMask = triton::SplatOp::create(
+              fb, trackingType.clone(fb.getI1Type()), anyMatch);
+        else
+          barrierMask =
+              convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
         Value barrierCTAMask =
             createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
         Value trackMask =
-            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
-        Value currentPhases = arith::AndIOp::create(
-            fb, barrierStates,
-            tti::createConstIntTensor(fb, fb.getLoc(), 1, barrierStatesType));
+            arith::AndIOp::create(fb, barrierMask, barrierCTAMask);
         currentPhases =
-            convertAndBroadcast(fb, currentPhases, {2, 3}, trackingType);
+            convertAndBroadcast(fb, currentPhases, phaseDims, trackingType);
         Value phaseIndices =
             createDimIndices(fb, trackingType, trackingType.getRank() - 1);
         auto phaseIndicesType = cast<RankedTensorType>(phaseIndices.getType());
@@ -3563,11 +3719,12 @@ void FunctionBuilder::createTrackProxyAccessesCallImpl(
           Value updated =
               arith::SelectOp::create(fb, trackMask, withSource, tracking);
           createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
-                                         trackingType, trackMask);
+                                         trackingType, trackMask,
+                                         trackingStrides);
         } else {
-          tti::createStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
-                                        withSource, trackingType,
-                                        /*currentCTAOnly=*/false, trackMask);
+          tti::createStoreScratchMemory(
+              fb, fb.getLoc(), trackingPtr, withSource, trackingType,
+              /*currentCTAOnly=*/false, trackMask, trackingStrides);
         }
 
         fb.setInsertionPointToEnd(thenBlock);
@@ -3595,15 +3752,15 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
   auto barriersType = cast<RankedTensorType>(barriers.type);
   auto visibilityType = cast<RankedTensorType>(visibility.type);
   auto trackingType = cast<RankedTensorType>(tracking.type);
-  SmallVector<Value> args = {
-      tti::ExperimentalMemDescToI32Op::create(b, mbar),
-      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
-      phase,
-      pred,
-      arith::ConstantIntOp::create(b, thread, 32),
-      barriers.value,
-      visibility.value,
-      tracking.value};
+  uint32_t mbarLength = getMemDescLength(mbar);
+  SmallVector<Value> args = {tti::ExperimentalMemDescToI32Op::create(b, mbar),
+                             arith::ConstantIntOp::create(b, mbarLength, 32),
+                             phase,
+                             pred,
+                             arith::ConstantIntOp::create(b, thread, 32),
+                             barriers.value,
+                             visibility.value,
+                             tracking.value};
   ManglingArgs specializationArgs;
   specializationArgs.append(barriersType);
   specializationArgs.append(visibilityType);
@@ -3617,12 +3774,15 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
     args.push_back(waiting.value);
     specializationArgs.append(waitingType);
   }
+  bool sliceBarrierTracking =
+      hasUniqueBarrierDescriptors(barriers.value, mbarLength);
+  specializationArgs.append(static_cast<uint64_t>(sliceBarrierTracking));
 
   createCallToCachedFunction(
       b, "complete_barrier_wait", args, /*assertInfo=*/std::nullopt,
       specializationArgs,
-      [clearWaiting, visibilityType, trackingType,
-       waitingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [clearWaiting, visibilityType, trackingType, waitingType,
+       sliceBarrierTracking](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value phase = entryBlock->getArgument(2);
@@ -3638,14 +3798,31 @@ void FunctionBuilder::createCompleteBarrierWaitCall(ImplicitLocOpBuilder &b,
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
         Value currentCTA = createCurrentCTAMask(fb);
+        Value barrierIndex, anyMatch;
+        if (sliceBarrierTracking) {
+          auto indexType =
+              cast<RankedTensorType>(barriers.getType()).clone(fb.getI32Type());
+          Value indices = triton::MakeRangeOp::create(
+              fb, indexType, 0, indexType.getNumElements());
+          Value selectedIndices = arith::SelectOp::create(
+              fb, barriersEqBar, indices,
+              tti::createConstIntTensor(fb, fb.getLoc(), 0, indexType));
+          barrierIndex = reduceAll<arith::OrIOp>(fb, selectedIndices);
+          anyMatch = reduceAll<arith::OrIOp>(fb, barriersEqBar);
+        }
 
         Value visibility = tti::createLoadScratchMemory(
             fb, fb.getLoc(), visibilityPtr, visibilityType);
-        Value tracking =
-            createLoadTrackingPhase(fb, trackingPtr, trackingType, phase);
+        Value tracking = createLoadTrackingPhase(fb, trackingPtr, trackingType,
+                                                 phase, barrierIndex);
         auto trackingPhaseType = cast<RankedTensorType>(tracking.getType());
-        Value proxyBarrierMask =
-            convertAndBroadcast(fb, barriersEqBar, {3}, trackingPhaseType);
+        Value proxyBarrierMask;
+        if (sliceBarrierTracking)
+          proxyBarrierMask = triton::SplatOp::create(
+              fb, trackingPhaseType.clone(fb.getI1Type()), anyMatch);
+        else
+          proxyBarrierMask =
+              convertAndBroadcast(fb, barriersEqBar, {3}, trackingPhaseType);
         Value barrierCTAMask =
             createCTASetMask(fb, trackingPhaseType, /*dim=*/2, currentCTA);
         Value selected =

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1423,7 +1423,8 @@ private:
                                                   effectCTAs);
         } else {
           funcBuilder.createSetProxyAccessCall(b, bufferMask, baseThread, pred,
-                                               op, readCTAs);
+                                               op, readCTAs,
+                                               materialized.bufferIndex);
         }
       }
       if (effect.rw == RW::Read) {

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -711,14 +711,37 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #frontier_smem = #ttg.shared_memory
 #frontier_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8200 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
-  // The helper consumes the analysis-derived completion mask directly.
-  // CHECK-LABEL: tt.func private @__triton_consan_track_proxy_accesses_for_buffer
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8208 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // Slice dynamic K=2 while preserving the multi-atom completion mask and
+  // the full phase stride. A missing match must leave old tracking unchanged.
+  // CHECK-LABEL: tt.func private @__triton_consan_track_proxy_accesses_for_buffer{{.*}}_I1(
   // CHECK-SAME: %arg8: i32, %arg9: tensor<8xi1{{.*}}, %arg10: i32
+  // CHECK: %[[FILTER_K_EQ:.*]] = arith.cmpi eq, {{.*}} : tensor<2xi64,
+  // CHECK: %[[FILTER_K_RANGE:.*]] = tt.make_range {end = 2 : i32, start = 0 : i32}
+  // CHECK: %[[FILTER_K_INDICES:.*]] = arith.select %[[FILTER_K_EQ]], %[[FILTER_K_RANGE]], {{.*}}tensor<2xi32,
+  // CHECK: %[[FILTER_K_INDEX:.*]] = "tt.reduce"(%[[FILTER_K_INDICES]]) <{axis = 0 : i32}>
+  // CHECK: %[[FILTER_K_ANY:.*]] = "tt.reduce"(%[[FILTER_K_EQ]]) <{axis = 0 : i32}>
+  // CHECK: %[[FILTER_K_STRIDE:.*]] = arith.constant 8 : i32
+  // CHECK-NEXT: %[[FILTER_K_OFFSET:.*]] = arith.muli %[[FILTER_K_INDEX]], %[[FILTER_K_STRIDE]] : i32
+  // CHECK-NEXT: %[[FILTER_K_PTR:.*]] = tt.addptr {{.*}}, %[[FILTER_K_OFFSET]] : !tt.ptr<i64>, i32
+  // CHECK: arith.constant dense<16> : tensor<2xi32,
+  // CHECK: %[[FILTER_K_TRACKING:.*]] = tt.load {{.*}} : tensor<1x8x1x1x2x!tt.ptr<i64>,
   // CHECK: ttg.convert_layout %arg9 {force_warp_shuffle}
+  // CHECK: %[[FILTER_K_ANY_MASK:.*]] = tt.splat %[[FILTER_K_ANY]] : i1 -> tensor<1x8x1x1x2xi1,
+  // CHECK: %[[FILTER_K_CTA_MASK:.*]] = arith.andi %[[FILTER_K_ANY_MASK]],
+  // CHECK: %[[FILTER_K_PHASE_MASK:.*]] = arith.cmpi eq,
+  // CHECK: %[[FILTER_K_BARRIER_MASK:.*]] = arith.andi %[[FILTER_K_CTA_MASK]], %[[FILTER_K_PHASE_MASK]]
+  // CHECK: ttg.convert_layout %arg9 {force_warp_shuffle}
+  // CHECK: %[[FILTER_K_BUFFER_MASK:.*]] = arith.andi %[[FILTER_K_BARRIER_MASK]],
+  // CHECK: %[[FILTER_K_MASK:.*]] = arith.andi %[[FILTER_K_BUFFER_MASK]],
+  // CHECK: %[[FILTER_K_WITH_SOURCE:.*]] = arith.ori %[[FILTER_K_TRACKING]],
+  // CHECK: %[[FILTER_K_UPDATED:.*]] = arith.select %[[FILTER_K_MASK]], %[[FILTER_K_WITH_SOURCE]], %[[FILTER_K_TRACKING]]
+  // CHECK: tt.splat %[[FILTER_K_PTR]] : !tt.ptr<i64> -> tensor<1x8x1x1x2x!tt.ptr<i64>,
+  // CHECK: arith.constant dense<16> : tensor<2xi32,
+  // CHECK: tt.store {{.*}}, %[[FILTER_K_UPDATED]] {ignore_cta} : tensor<1x8x1x1x2x!tt.ptr<i64>,
   // CHECK-LABEL: @tma_completion_tracks_contained_proxy_frontier
   tt.func public @tma_completion_tracks_contained_proxy_frontier(
-      %desc: !tt.tensordesc<1024xi32, #frontier_shared>) {
+      %desc: !tt.tensordesc<1024xi32, #frontier_shared>, %choose: i1) {
     // The first explicit region is contained in the TMA destination. The third
     // region only partially overlaps it, so only its overlapping atom may be
     // published by TMA completion. Its remainder and the fourth, disjoint
@@ -732,10 +755,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
         : (tensor<128xi32, #frontier_src>) -> !ttg.memdesc<128xi32, #frontier_shared, #frontier_smem, mutable>
     %dst = ttg.local_alloc {allocation.offset = 0 : i32}
         : () -> !ttg.memdesc<1024xi32, #frontier_shared, #frontier_smem, mutable>
-    %bar = ttg.local_alloc {allocation.offset = 8192 : i32}
+    %bar0 = ttg.local_alloc {allocation.offset = 8192 : i32}
         : () -> !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
-    ttng.init_barrier %bar, 1
+    %bar1 = ttg.local_alloc {allocation.offset = 8200 : i32}
+        : () -> !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
+    ttng.init_barrier %bar0, 1
         : !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
+    ttng.init_barrier %bar1, 1
+        : !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
+    %bar = arith.select %choose, %bar1, %bar0 : !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
     ttng.barrier_expect %bar, 4096, %true
         : !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
     ttng.fence_async_shared {bCluster = false}
@@ -752,6 +780,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
         : !tt.tensordesc<1024xi32, #frontier_shared>,
           !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
           -> !ttg.memdesc<1024xi32, #frontier_shared, #frontier_smem, mutable>
+    ttng.wait_barrier %bar, %c0, %true : !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
+    ttng.inval_barrier %bar0 : !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
+    ttng.inval_barrier %bar1 : !ttg.memdesc<1xi64, #frontier_barrier, #frontier_smem, mutable>
     tt.return
   }
 }
@@ -3165,6 +3196,206 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     ttng.arrive_barrier %bar, 1 : !ttg.memdesc<4xi64, #phase_clear_barrier, #phase_clear_smem, mutable>
     ttng.wait_barrier %bar, %zero, %true : !ttg.memdesc<4xi64, #phase_clear_barrier, #phase_clear_smem, mutable>
     ttng.inval_barrier %bar : !ttg.memdesc<4xi64, #phase_clear_barrier, #phase_clear_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A dynamic one-buffer proxy access keeps every observer and both phase banks,
+// with offsets derived from the four-row backing allocation, not the B=1 view.
+#proxy_row_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1, CGALayout = [[1]]}>
+#proxy_row_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#proxy_row_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CGALayout = [[1]]}>
+#proxy_row_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32} {
+  // A wait loads only its selected K row and its caller-supplied phase.
+  // The original K=2 origin/phase strides remain 32/64 elements.
+  // CHECK-LABEL: tt.func private @__triton_consan_complete_barrier_wait_
+  // CHECK-SAME: (%{{[^:]+}}: i32, %{{[^:]+}}: i32, %[[WAIT_K_PHASE:[^:]+]]: i32,
+  // CHECK: %[[WAIT_K_EQ:.*]] = arith.cmpi eq, {{.*}} : tensor<2xi64,
+  // CHECK: %[[WAIT_K_RANGE:.*]] = tt.make_range {end = 2 : i32, start = 0 : i32}
+  // CHECK: %[[WAIT_K_INDICES:.*]] = arith.select %[[WAIT_K_EQ]], %[[WAIT_K_RANGE]], {{.*}}tensor<2xi32,
+  // CHECK: %[[WAIT_K_INDEX:.*]] = "tt.reduce"(%[[WAIT_K_INDICES]]) <{axis = 0 : i32}>
+  // CHECK: %[[WAIT_K_ANY:.*]] = "tt.reduce"(%[[WAIT_K_EQ]]) <{axis = 0 : i32}>
+  // CHECK: %[[WAIT_K_ONE:.*]] = arith.constant 1 : i32
+  // CHECK: %[[WAIT_K_PARITY:.*]] = arith.andi %[[WAIT_K_PHASE]], %[[WAIT_K_ONE]] : i32
+  // CHECK: %[[WAIT_K_PHASE_STRIDE:.*]] = arith.constant 64 : i32
+  // CHECK: %[[WAIT_K_PHASE_OFFSET:.*]] = arith.muli %[[WAIT_K_PARITY]], %[[WAIT_K_PHASE_STRIDE]] : i32
+  // CHECK: %[[WAIT_K_PHASE_PTR:.*]] = tt.addptr {{.*}}, %[[WAIT_K_PHASE_OFFSET]] : !tt.ptr<i64>, i32
+  // CHECK: %[[WAIT_K_STRIDE:.*]] = arith.constant 16 : i32
+  // CHECK: %[[WAIT_K_OFFSET:.*]] = arith.muli %[[WAIT_K_INDEX]], %[[WAIT_K_STRIDE]] : i32
+  // CHECK: %[[WAIT_K_PTR:.*]] = tt.addptr %[[WAIT_K_PHASE_PTR]], %[[WAIT_K_OFFSET]] : !tt.ptr<i64>, i32
+  // CHECK-DAG: tt.splat %[[WAIT_K_PTR]] : !tt.ptr<i64> -> tensor<2x4x2x1x2x!tt.ptr<i64>,
+  // CHECK-DAG: arith.constant dense<32> : tensor<2xi32,
+  // CHECK: %[[WAIT_K_TRACKING:.*]] = tt.load {{.*}} : tensor<2x4x2x1x2x!tt.ptr<i64>,
+  // CHECK: %[[WAIT_K_ANY_MASK:.*]] = tt.splat %[[WAIT_K_ANY]] : i1 -> tensor<2x4x2x1x2xi1,
+  // CHECK: %[[WAIT_K_MASK:.*]] = arith.andi %[[WAIT_K_ANY_MASK]],
+  // CHECK: %[[WAIT_K_ZERO:.*]] = arith.constant dense<0> : tensor<2x4x2x1x2xi64,
+  // CHECK: arith.select %[[WAIT_K_MASK]], %[[WAIT_K_TRACKING]], %[[WAIT_K_ZERO]]
+  // Clearing waiting bits still uses the original full K comparison.
+  // CHECK: {{ttg.convert_layout|tt.expand_dims}} %[[WAIT_K_EQ]]
+  // CHECK: %[[WAIT_K_FULL_MASK:.*]] = tt.broadcast {{.*}} -> tensor<2x2x2xi1,
+  // CHECK: %[[WAIT_K_CLEAR_MASK:.*]] = arith.andi %[[WAIT_K_FULL_MASK]],
+  // CHECK: arith.select %[[WAIT_K_CLEAR_MASK]],
+  // CHECK-LABEL: tt.func private @__triton_consan_transfer_visible_accesses_
+  // CHECK-SAME: (%{{[^:]+}}: i32, %{{[^:]+}}: i32, %[[TRANSFER_K_PHASE:[^:]+]]: i32,
+  // CHECK: %[[TRANSFER_K_EQ:.*]] = arith.cmpi eq, {{.*}} : tensor<2xi64,
+  // CHECK: %[[TRANSFER_K_RANGE:.*]] = tt.make_range {end = 2 : i32, start = 0 : i32}
+  // CHECK: %[[TRANSFER_K_INDICES:.*]] = arith.select %[[TRANSFER_K_EQ]], %[[TRANSFER_K_RANGE]], {{.*}}tensor<2xi32,
+  // CHECK: %[[TRANSFER_K_INDEX:.*]] = "tt.reduce"(%[[TRANSFER_K_INDICES]]) <{axis = 0 : i32}>
+  // CHECK: %[[TRANSFER_K_ANY:.*]] = "tt.reduce"(%[[TRANSFER_K_EQ]]) <{axis = 0 : i32}>
+  // Write tracking has no origin axis: its full phase stride is 32.
+  // CHECK: %[[TRANSFER_K_WRITE_ONE:.*]] = arith.constant 1 : i32
+  // CHECK: %[[TRANSFER_K_WRITE_PHASE:.*]] = arith.andi %[[TRANSFER_K_PHASE]], %[[TRANSFER_K_WRITE_ONE]] : i32
+  // CHECK: %[[TRANSFER_K_WRITE_PHASE_STRIDE:.*]] = arith.constant 32 : i32
+  // CHECK: %[[TRANSFER_K_WRITE_PHASE_OFFSET:.*]] = arith.muli %[[TRANSFER_K_WRITE_PHASE]], %[[TRANSFER_K_WRITE_PHASE_STRIDE]] : i32
+  // CHECK: %[[TRANSFER_K_WRITE_PHASE_PTR:.*]] = tt.addptr {{.*}}, %[[TRANSFER_K_WRITE_PHASE_OFFSET]] : !tt.ptr<i8>, i32
+  // CHECK: %[[TRANSFER_K_WRITE_STRIDE:.*]] = arith.constant 16 : i32
+  // CHECK: %[[TRANSFER_K_WRITE_OFFSET:.*]] = arith.muli %[[TRANSFER_K_INDEX]], %[[TRANSFER_K_WRITE_STRIDE]] : i32
+  // CHECK: %[[TRANSFER_K_WRITE_PTR:.*]] = tt.addptr %[[TRANSFER_K_WRITE_PHASE_PTR]], %[[TRANSFER_K_WRITE_OFFSET]] : !tt.ptr<i8>, i32
+  // CHECK: tt.splat %[[TRANSFER_K_WRITE_PTR]] : !tt.ptr<i8> -> tensor<2x4x2x1x!tt.ptr<i8>,
+  // CHECK: %[[TRANSFER_K_WRITE_TRACKING:.*]] = tt.load {{.*}} : tensor<2x4x2x1x!tt.ptr<i8>,
+  // CHECK: %[[TRANSFER_K_WRITE_ANY:.*]] = tt.splat %[[TRANSFER_K_ANY]] : i1 -> tensor<2x4x2x1xi1,
+  // CHECK: %[[TRANSFER_K_WRITE_MASK:.*]] = arith.andi %[[TRANSFER_K_WRITE_ANY]],
+  // CHECK: %[[TRANSFER_K_WRITE_ZERO:.*]] = arith.constant dense<0> : tensor<2x4x2x1xi8,
+  // CHECK: arith.select %[[TRANSFER_K_WRITE_MASK]], %[[TRANSFER_K_WRITE_TRACKING]], %[[TRANSFER_K_WRITE_ZERO]]
+  // Read tracking retains both origins at their original stride 32.
+  // CHECK: %[[TRANSFER_K_READ_ONE:.*]] = arith.constant 1 : i32
+  // CHECK: %[[TRANSFER_K_READ_PHASE:.*]] = arith.andi %[[TRANSFER_K_PHASE]], %[[TRANSFER_K_READ_ONE]] : i32
+  // CHECK: %[[TRANSFER_K_READ_PHASE_STRIDE:.*]] = arith.constant 64 : i32
+  // CHECK: %[[TRANSFER_K_READ_PHASE_OFFSET:.*]] = arith.muli %[[TRANSFER_K_READ_PHASE]], %[[TRANSFER_K_READ_PHASE_STRIDE]] : i32
+  // CHECK: %[[TRANSFER_K_READ_PHASE_PTR:.*]] = tt.addptr {{.*}}, %[[TRANSFER_K_READ_PHASE_OFFSET]] : !tt.ptr<i{{32|64}}>, i32
+  // CHECK: %[[TRANSFER_K_READ_STRIDE:.*]] = arith.constant 16 : i32
+  // CHECK: %[[TRANSFER_K_READ_OFFSET:.*]] = arith.muli %[[TRANSFER_K_INDEX]], %[[TRANSFER_K_READ_STRIDE]] : i32
+  // CHECK: %[[TRANSFER_K_READ_PTR:.*]] = tt.addptr %[[TRANSFER_K_READ_PHASE_PTR]], %[[TRANSFER_K_READ_OFFSET]] : !tt.ptr<i{{32|64}}>, i32
+  // CHECK-DAG: tt.splat %[[TRANSFER_K_READ_PTR]] : !tt.ptr<i{{32|64}}> -> tensor<2x4x2x1x2x!tt.ptr<i{{32|64}}>,
+  // CHECK-DAG: arith.constant dense<32> : tensor<2xi32,
+  // CHECK: %[[TRANSFER_K_READ_TRACKING:.*]] = tt.load {{.*}} : tensor<2x4x2x1x2x!tt.ptr<i{{32|64}}>,
+  // CHECK: %[[TRANSFER_K_READ_ANY:.*]] = tt.splat %[[TRANSFER_K_ANY]] : i1 -> tensor<2x4x2x1x2xi1,
+  // CHECK: %[[TRANSFER_K_READ_MASK:.*]] = arith.andi %[[TRANSFER_K_READ_ANY]],
+  // CHECK: %[[TRANSFER_K_READ_ZERO:.*]] = arith.constant dense<0> : tensor<2x4x2x1x2xi{{32|64}},
+  // CHECK: arith.select %[[TRANSFER_K_READ_MASK]], %[[TRANSFER_K_READ_TRACKING]], %[[TRANSFER_K_READ_ZERO]]
+  // K=2 is selected dynamically. Keep all four buffer atoms, both origin
+  // CTAs and both phases, using the full table's origin/phase strides.
+  // CHECK-LABEL: tt.func private @__triton_consan_track_proxy_accesses_{{.*}}_I1(
+  // CHECK: %[[PROXY_K_EQ:.*]] = arith.cmpi eq, {{.*}} : tensor<2xi64,
+  // CHECK: %[[PROXY_K_RANGE:.*]] = tt.make_range {end = 2 : i32, start = 0 : i32}
+  // CHECK: %[[PROXY_K_INDICES:.*]] = arith.select %[[PROXY_K_EQ]], %[[PROXY_K_RANGE]], {{.*}}tensor<2xi32,
+  // CHECK: %[[PROXY_K_INDEX:.*]] = "tt.reduce"(%[[PROXY_K_INDICES]]) <{axis = 0 : i32}>
+  // CHECK: %[[PROXY_K_ANY:.*]] = "tt.reduce"(%[[PROXY_K_EQ]]) <{axis = 0 : i32}>
+  // CHECK: %[[PROXY_K_SELECTED_PHASES:.*]] = arith.select {{.*}}tensor<2x2xi{{32|64}},
+  // CHECK: %[[PROXY_K_PHASES:.*]] = "tt.reduce"(%[[PROXY_K_SELECTED_PHASES]]) <{axis = 1 : i32}>
+  // CHECK: %[[PROXY_K_STRIDE:.*]] = arith.constant 16 : i32
+  // CHECK-NEXT: %[[PROXY_K_OFFSET:.*]] = arith.muli %[[PROXY_K_INDEX]], %[[PROXY_K_STRIDE]] : i32
+  // CHECK-NEXT: %[[PROXY_K_PTR:.*]] = tt.addptr {{.*}}, %[[PROXY_K_OFFSET]] : !tt.ptr<i64>, i32
+  // CHECK: arith.constant dense<32> : tensor<2xi32,
+  // CHECK: arith.constant dense<64> : tensor<2xi32,
+  // CHECK: %[[PROXY_K_TRACKING:.*]] = tt.load {{.*}} : tensor<2x4x2x2x2x!tt.ptr<i64>,
+  // CHECK: %[[PROXY_K_ANY_MASK:.*]] = tt.splat %[[PROXY_K_ANY]] : i1 -> tensor<2x4x2x2x2xi1,
+  // CHECK: %[[PROXY_K_CTA_MASK:.*]] = arith.andi %[[PROXY_K_ANY_MASK]], {{.*}} : tensor<2x4x2x2x2xi1,
+  // CHECK: ttg.convert_layout %[[PROXY_K_PHASES]]{{.*}} : tensor<2xi{{32|64}},
+  // CHECK: %[[PROXY_K_PHASE_BCAST:.*]] = tt.broadcast {{.*}} -> tensor<2x4x2x2x2xi{{32|64}},
+  // CHECK: %[[PROXY_K_PHASE_VALUES:.*]] = arith.trunci %[[PROXY_K_PHASE_BCAST]]
+  // CHECK: %[[PROXY_K_PHASE_MASK:.*]] = arith.cmpi eq, %[[PROXY_K_PHASE_VALUES]],
+  // CHECK: %[[PROXY_K_MASK:.*]] = arith.andi %[[PROXY_K_CTA_MASK]], %[[PROXY_K_PHASE_MASK]]
+  // CHECK: %[[PROXY_K_UPDATED:.*]] = arith.ori %[[PROXY_K_TRACKING]],
+  // CHECK: tt.splat %[[PROXY_K_PTR]] : !tt.ptr<i64> -> tensor<2x4x2x2x2x!tt.ptr<i64>,
+  // CHECK: arith.constant dense<32> : tensor<2xi32,
+  // CHECK: arith.constant dense<64> : tensor<2xi32,
+  // CHECK: tt.store {{.*}}, %[[PROXY_K_UPDATED]], %[[PROXY_K_MASK]] {ignore_cta} : tensor<2x4x2x2x2x!tt.ptr<i64>,
+  // CHECK-LABEL: tt.func private @__triton_consan_set_proxy_access_nw1_I32_
+  // CHECK-SAME: (%[[PROXY_ROW_INDEX:[^:]+]]: i32,
+  // CHECK: %[[PROXY_ROW_STRIDE:.*]] = arith.constant 2 : i32
+  // CHECK-NEXT: %[[PROXY_ROW_OFFSET:.*]] = arith.muli %[[PROXY_ROW_INDEX]], %[[PROXY_ROW_STRIDE]] : i32
+  // CHECK-NEXT: tt.addptr {{.*}}, %[[PROXY_ROW_OFFSET]] : !tt.ptr<i64>, i32
+  // CHECK: arith.constant dense<16> : tensor<2xi32
+  // CHECK: tt.load {{.*}} : tensor<2x1x2x1x2x!tt.ptr<i64>
+  // CHECK: arith.constant dense<16> : tensor<2xi32
+  // CHECK: tt.store {{.*}} : tensor<2x1x2x1x2x!tt.ptr<i64>
+  // CHECK: %[[PROXY_ROW_ORIGIN:.*]] = tti.experimental_cluster_cta_id
+  // CHECK-NEXT: %[[PROXY_ROW_BANK_SIZE:.*]] = arith.constant 32 : i32
+  // CHECK-NEXT: %[[PROXY_ROW_BANK_OFFSET:.*]] = arith.muli %[[PROXY_ROW_ORIGIN]], %[[PROXY_ROW_BANK_SIZE]] : i32
+  // CHECK-NEXT: tt.addptr {{.*}}, %[[PROXY_ROW_BANK_OFFSET]] : !tt.ptr<i64>, i32
+  // CHECK: arith.constant dense<16> : tensor<2xi32
+  // CHECK: tt.load {{.*}} : tensor<2x1x2x2x!tt.ptr<i64>
+  // CHECK: arith.constant dense<16> : tensor<2xi32
+  // CHECK: tt.store {{.*}} : tensor<2x1x2x2x!tt.ptr<i64>
+  // CHECK: %[[PROXY_ROW_PHASE_STRIDE:.*]] = arith.constant 2 : i32
+  // CHECK-NEXT: %[[PROXY_ROW_PHASE_ORIGIN:.*]] = arith.addi %[[PROXY_ROW_ORIGIN]], %[[PROXY_ROW_PHASE_STRIDE]] : i32
+  // CHECK-NEXT: %[[PROXY_ROW_NEXT_BANK_SIZE:.*]] = arith.constant 32 : i32
+  // CHECK-NEXT: arith.muli %[[PROXY_ROW_PHASE_ORIGIN]], %[[PROXY_ROW_NEXT_BANK_SIZE]] : i32
+  // CHECK: tt.load {{.*}} : tensor<2x1x2x2x!tt.ptr<i64>
+  // CHECK: tt.store {{.*}} : tensor<2x1x2x2x!tt.ptr<i64>
+  // CHECK: tt.return
+  // CHECK-LABEL: @single_buffer_dynamic_proxy_ring
+  // CHECK-SAME: (%{{[^:]+}}: i32, %[[PROXY_DYNAMIC_PHASE:[^:]+]]: i32,
+  tt.func public @single_buffer_dynamic_proxy_ring(%idx: i32, %phase: i32, %out: !tt.tensordesc<64xi32, #proxy_row_shared>) {
+    %zero = arith.constant 0 : i32
+    %one = arith.constant 1 : i32
+    %true = arith.constant true
+    %value = arith.constant dense<0> : tensor<64xi32, #proxy_row_blocked>
+    %slot = arith.andi %idx, %one : i32
+    %ring = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x64xi32, #proxy_row_shared, #proxy_row_smem, mutable>
+    %buf0 = ttg.memdesc_index %ring[%zero] : !ttg.memdesc<2x64xi32, #proxy_row_shared, #proxy_row_smem, mutable> -> !ttg.memdesc<64xi32, #proxy_row_shared, #proxy_row_smem, mutable>
+    %buf1 = ttg.memdesc_index %ring[%one] : !ttg.memdesc<2x64xi32, #proxy_row_shared, #proxy_row_smem, mutable> -> !ttg.memdesc<64xi32, #proxy_row_shared, #proxy_row_smem, mutable>
+    %barriers = ttg.local_alloc {allocation.offset = 512 : i32} : () -> !ttg.memdesc<2x2xi64, #proxy_row_barrier, #proxy_row_smem, mutable>
+    %bar0 = ttg.memdesc_index %barriers[%zero] : !ttg.memdesc<2x2xi64, #proxy_row_barrier, #proxy_row_smem, mutable> -> !ttg.memdesc<2xi64, #proxy_row_barrier, #proxy_row_smem, mutable>
+    %bar1 = ttg.memdesc_index %barriers[%one] : !ttg.memdesc<2x2xi64, #proxy_row_barrier, #proxy_row_smem, mutable> -> !ttg.memdesc<2xi64, #proxy_row_barrier, #proxy_row_smem, mutable>
+    ttng.init_barrier %bar0, 1 : !ttg.memdesc<2xi64, #proxy_row_barrier, #proxy_row_smem, mutable>
+    ttng.init_barrier %bar1, 1 : !ttg.memdesc<2xi64, #proxy_row_barrier, #proxy_row_smem, mutable>
+    %dynamic = ttg.memdesc_index %ring[%slot] : !ttg.memdesc<2x64xi32, #proxy_row_shared, #proxy_row_smem, mutable> -> !ttg.memdesc<64xi32, #proxy_row_shared, #proxy_row_smem, mutable>
+    // CHECK: internal ConSan error: active memdesc resolved to no buffer state
+    // CHECK: arith.select {{.*}} : i32
+    // CHECK: %[[PROXY_ROW_SELECTED:.*]] = arith.select {{.*}} : i32
+    // CHECK: tt.call @__triton_consan_set_proxy_access_nw1_I32_{{.*}}(%[[PROXY_ROW_SELECTED]],
+    // CHECK: ttg.local_store
+    ttg.local_store %value, %dynamic : tensor<64xi32, #proxy_row_blocked> -> !ttg.memdesc<64xi32, #proxy_row_shared, #proxy_row_smem, mutable>
+    %dynamic_barrier = ttg.memdesc_index %barriers[%slot] : !ttg.memdesc<2x2xi64, #proxy_row_barrier, #proxy_row_smem, mutable> -> !ttg.memdesc<2xi64, #proxy_row_barrier, #proxy_row_smem, mutable>
+    // CHECK: %[[PROXY_K_BARRIER:.*]] = ttg.memdesc_index {{.*}}[%{{.*}}]
+    // CHECK: tt.call @__triton_consan_track_visible_accesses_
+    // CHECK: %[[PROXY_K_BARRIER_I32:.*]] = tti.experimental_memdesc_to_i32 %[[PROXY_K_BARRIER]]
+    // CHECK: tt.call @__triton_consan_track_proxy_accesses_{{.*}}_I1(%[[PROXY_K_BARRIER_I32]],
+    ttng.arrive_barrier %dynamic_barrier, 1, %true : !ttg.memdesc<2xi64, #proxy_row_barrier, #proxy_row_smem, mutable>
+    // CHECK: ttng.wait_barrier {{.*}}, %[[PROXY_DYNAMIC_PHASE]],
+    // CHECK: tt.call @__triton_consan_transfer_visible_accesses{{.*}}(%{{[^,]+}}, %{{[^,]+}}, %[[PROXY_DYNAMIC_PHASE]],
+    // CHECK: tt.call @__triton_consan_complete_barrier_wait{{.*}}(%{{[^,]+}}, %{{[^,]+}}, %[[PROXY_DYNAMIC_PHASE]],
+    ttng.wait_barrier %dynamic_barrier, %phase, %true : !ttg.memdesc<2xi64, #proxy_row_barrier, #proxy_row_smem, mutable>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %out[%zero] %dynamic : !tt.tensordesc<64xi32, #proxy_row_shared>, !ttg.memdesc<64xi32, #proxy_row_shared, #proxy_row_smem, mutable>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    ttng.inval_barrier %bar0 : !ttg.memdesc<2xi64, #proxy_row_barrier, #proxy_row_smem, mutable>
+    ttng.inval_barrier %bar1 : !ttg.memdesc<2xi64, #proxy_row_barrier, #proxy_row_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Partially overlapping buffers span multiple state atoms and retain the full
+// mask path rather than silently dropping either part of the generic access.
+#proxy_alias_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#proxy_alias_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#proxy_alias_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, ttg.shared = 384 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32} {
+  // CHECK-LABEL: tt.func private @__triton_consan_set_proxy_access_nw1_T4xI1_
+  // CHECK: tt.load {{.*}} : tensor<1x4x1x1x1x!tt.ptr<i64>
+  // CHECK: tt.store {{.*}} : tensor<1x4x1x1x1x!tt.ptr<i64>
+  // CHECK-LABEL: @multi_atom_proxy_access
+  tt.func public @multi_atom_proxy_access(%out: !tt.tensordesc<64xi32, #proxy_alias_shared>) {
+    %zero = arith.constant 0 : i32
+    %value = arith.constant dense<0> : tensor<64xi32, #proxy_alias_blocked>
+    %left = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64xi32, #proxy_alias_shared, #proxy_alias_smem, mutable>
+    %right = ttg.local_alloc {allocation.offset = 128 : i32} : () -> !ttg.memdesc<64xi32, #proxy_alias_shared, #proxy_alias_smem, mutable>
+    // CHECK: tt.call @__triton_consan_set_proxy_access_nw1_T4xI1_
+    ttg.local_store %value, %left : tensor<64xi32, #proxy_alias_blocked> -> !ttg.memdesc<64xi32, #proxy_alias_shared, #proxy_alias_smem, mutable>
+    // CHECK: tt.call @__triton_consan_set_proxy_access_nw1_T4xI1_
+    ttg.local_store %value, %right : tensor<64xi32, #proxy_alias_blocked> -> !ttg.memdesc<64xi32, #proxy_alias_shared, #proxy_alias_smem, mutable>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_local_to_global %out[%zero] %left : !tt.tensordesc<64xi32, #proxy_alias_shared>, !ttg.memdesc<64xi32, #proxy_alias_shared, #proxy_alias_smem, mutable>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
     tt.return
   }
 }


### PR DESCRIPTION
ConSan expands full proxy buffer and barrier tables even when existing descriptor analysis proves a single selected row. Use those proofs to narrow proxy updates and completed-phase loads, retaining full-table fallback when the proof is unavailable. Preserve all physical strides, origin/CTA/thread masks, both phase banks, no-match behavior, and the full waiting-bit clear mask.

Include the two adaptations needed to combine the upstream changes: convert completed-copy observer masks to the compact visibility integer type, and clear rank-three copy-commit tables along their issuer axis.

This patch depends on [#11446](https://github.com/triton-lang/triton/pull/11446)–[#11452](https://github.com/triton-lang/triton/pull/11452) and [#11626](https://github.com/triton-lang/triton/pull/11626). Its exact prepared base is local integration commit `e118eeea489cb581d90bec5b8bfe1fc1783cc637`: stack head `cb75befccddbb77d7237853d11c6b2140297fc90` plus the current mbarrier change set at `7efc58faf2c1813c3da3588ba57ed1bedcb28413`. Both integration adaptations are included in this patch. Rebase and revalidate if the dependencies change before landing.

Validation:

- Normal native build and `make`; three focused lit files passed. Existing GPU regressions: 127 passed, seven expected skips.
- A saved attention-backward dQ specialization compiled in **119.78s**, versus **330.11s** with the prior integrated stack before row optimizations. Input, compiler options, PTXAS binary/flags, CPU allocation and memory limit match.
- One complete bitwise-mode native attention grade passed in **430.13s of GPU-lock hold time**, under the unchanged **590s** work cap. All four witnesses and functional, FPSan, ConSan, GSan and performance phases passed. This application result also uses the separate conservative GSan initializer-memory bound; the candidate cache was cold, while normal shared native cubins remained available.
- The actual optimized FPSan candidate also passed its complete grade in **424.78s of GPU-lock hold time**, with the full recorded tolerance budget and all four witnesses. This used the same initializer-memory bound and fresh candidate cache. The same candidate previously took 1,080.05s with the earlier integrated compiler; the two application runs used different GB300 devices of the same worker.

The patch contains generic compiler code and regression tests only. Captured application IR and runtime artifacts are not included.
