### PR TITLE
[BACKEND] Fix invertAndCompose for GeneralLinearLayout

### DIFF
--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -1074,14 +1074,22 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
   //   to the same input element) to take advantage of broadcasting in shared
   //   memory and avoid saving repeated elements in shared memory
 
-  // FIXME: We should check that the other dimensions don't touch the image of
-  // this dimension.
+  // Only factor dimensions whose output bits are untouched by other inputs.
+  auto isIndependent = [&](const LinearLayout &layout, StringAttr dim) {
+    auto otherDims = llvm::to_vector(layout.getInDimNames());
+    llvm::erase(otherDims, dim);
+    return llvm::all_of(outDims, [&](StringAttr outDim) {
+      return !(getOutputBasisMask(layout, {dim}, outDim) &
+               getOutputBasisMask(layout, otherDims, outDim));
+    });
+  };
   SmallVector<StringAttr> identityDims;
   for (auto dim : A.getInDimNames()) {
     if (B.hasInDim(dim)) {
       auto aSub = A.sublayout(dim, outDims);
       auto bSub = B.sublayout(dim, outDims);
-      if (aSub.equalIgnoringOutDimSizes(bSub))
+      if (aSub.equalIgnoringOutDimSizes(bSub) && isIndependent(A, dim) &&
+          isIndependent(B, dim))
         identityDims.push_back(dim);
     }
   }
@@ -1101,8 +1109,6 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
   auto AReduced = A.sublayout(ANonIdentityInDims, outDims);
   auto BReduced = B.sublayout(BNonIdentityInDims, outDims);
 
-  // If one is empty, the other must be empty as well.
-  assert((ANonIdentityInDims.empty()) == (BNonIdentityInDims.empty()));
   auto maybeRet = lstsq(AReduced, BReduced);
   assert(maybeRet && "outer layout does not cover this layout's image");
   auto ret = std::move(*maybeRet);

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -291,6 +291,28 @@ def test_convert_layout_cross_cta_in_warp_specialize(use_worker_partition, devic
     torch.testing.assert_close(y, x, rtol=0, atol=0)
 
 
+@pytest.mark.skipif(is_hip(), reason="Uses 32-thread NVIDIA layouts")
+@pytest.mark.parametrize("src_warp, dst_warp", [(64, 96), (96, 64)])
+def test_convert_layout_overlapping_identity_dims(src_warp, dst_warp, device):
+
+    @gluon.jit
+    def kernel(x_ptr, y_ptr, SRC_WARP: ttgl.constexpr, DST_WARP: ttgl.constexpr):
+        src: ttgl.constexpr = ttgl.DistributedLinearLayout([[32]], [[1], [2], [4], [8], [16]], [[SRC_WARP], [128]], [],
+                                                           [256])
+        dst: ttgl.constexpr = ttgl.DistributedLinearLayout([[32]], [[1], [2], [4], [8], [16]], [[DST_WARP], [128]], [],
+                                                           [256])
+        src_offsets = ttgl.arange(0, 256, layout=src)
+        x = ttgl.load(x_ptr + src_offsets)
+        y = ttgl.convert_layout(x, dst)
+        dst_offsets = ttgl.arange(0, 256, layout=dst)
+        ttgl.store(y_ptr + dst_offsets, y)
+
+    x = torch.arange(256, dtype=torch.int32, device=device)
+    y = torch.empty_like(x)
+    kernel[(1, )](x, y, src_warp, dst_warp, num_warps=4)
+    torch.testing.assert_close(y, x, rtol=0, atol=0)
+
+
 def _swizzled_warp_layouts_1d():
     """1D DistributedLinearLayout test layouts (non-injective, lowered as GenericLinearEncoding)."""
 

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -394,6 +394,26 @@ TEST_F(LinearLayoutTest, InvertAndCompose_Simple) {
   EXPECT_EQ(composition.compose(l2), l1);
 }
 
+TEST_F(LinearLayoutTest, InvertAndCompose_OverlappingIdentityDims) {
+  auto layout = [&](int warpBasis) {
+    return LinearLayout({{S("register"), {{32}}},
+                         {S("lane"), {{1}, {2}, {4}, {8}, {16}}},
+                         {S("warp"), {{warpBasis}, {128}}},
+                         {S("block"), {}}},
+                        {S("dim0")});
+  };
+  auto src = layout(64);
+  auto dst = layout(96);
+  EXPECT_EQ(dst.invertAndCompose(src).compose(src), dst);
+  EXPECT_EQ(src.invertAndCompose(dst).compose(dst), src);
+}
+
+TEST_F(LinearLayoutTest, Invert_UnitInputDim) {
+  LinearLayout layout({{S("x"), {{1}}}, {S("unit"), {}}}, {S("x")});
+  EXPECT_EQ(layout.invert(),
+            LinearLayout({{S("x"), {{1, 0}}}}, {S("x"), S("unit")}));
+}
+
 TEST_F(LinearLayoutTest, Lstsq) {
   LinearLayout superset({{S("storage"), {{1, 1}, {2, 0}}}},
                         {{S("x"), 4}, {S("y"), 2}},


### PR DESCRIPTION
Before, we were being too aggressive when checking which dims were the same. Now we handle correctly dims with swizzling as we could have in `block` in SHMEM layouts and `register` in `GeneralLinearLayout`s
