### PR TITLE
[BACKEND] Allow warpshuffles when warp and block can read off broadcasted copies

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -181,41 +181,47 @@ private:
   RankedTensorType dstTy;
 };
 
-// This struct represents the factorization of a warp-local layout conversion
-// into three components: a register-only permutation, a lane-only permutation,
-// and a set of swaps between lane and register basis vectors. Algebraically, it
-// represents the factorization P = P_mixed \circ P_lane \circ P_reg. It is used
-// to aid in the implementation of the layout conversion using warp-shuffles.
+// For permutation cases, this struct represents the factorization of a
+// warp-local layout conversion into three components: a register-only
+// permutation, a lane-only permutation, and a set of swaps between lane and
+// register basis vectors. Algebraically, it represents the factorization
+// P = P_mixed \circ P_lane \circ P_reg. It is used to aid in the implementation
+// of the layout conversion using warp-shuffles.
 //
-// `pReg` and `pLane` are square layouts each with only one input and output
-// dimension. `mixedTranspositions` holds pairs of integers (i, j)
-// corresponding to the transposition (r_i l_j) of the i-th register basis
-// vector with the j-th lane basis vector along with 16-bit selectors for byte
-// permute instructions (where each of the four nybbles is in the range [0, 7]).
+// `pReg` is a square permutation of the padded registers. `shuffleMap` maps
+// register/lane/warp/block coordinates to source lanes for the shuffle stage.
+// `mixedTranspositions` holds the register bit and source/destination lane bits
+// for each exchange, along with 16-bit selectors for byte permute instructions
+// (where each of the four nybbles is in the range [0, 7]). A lane bit of -1
+// denotes a constant-zero predicate for a one-sided exchange.
 // `nPack` gives the number of basis vectors that can be used for register
 // packing while ensuring packed elements arrive at the same destination lane.
 struct DecomposedWarpConversion {
   struct TranspositionInfo {
-    std::pair<int, int> transposition;
+    int regBit;
+    int srcLane;
+    int dstLane;
     uint16_t topPreSel = 0x3210;
     uint16_t botPreSel = 0x7654;
     uint16_t topPostSel = 0x3210;
     uint16_t botPostSel = 0x7654;
   };
 
-  triton::LinearLayout pReg, pLane;
+  triton::LinearLayout pReg, shuffleMap;
   SmallVector<TranspositionInfo> mixedTranspositions;
   int nPack;
 };
 
-// Produces a decomposition of a permutation describing a warp-local layout
-// conversion as described in `DecomposedWarpConversion` above.
+// Produces a warp-local decomposition.
 //
-// This function handles cases where the numbers of register and lane basis
-// vectors differ between the two layouts. This is done by padding the smaller
+// For permutation cases, the numbers of register and lane basis vectors may
+// differ between the two layouts. This is handled by padding the smaller
 // dimension(s) with zero vectors, ensuring that the layout conversion can be
-// represented as a permutation. The layouts must not contain broadcasted
-// register bases.
+// represented as a permutation.
+//
+// Supports permutation layouts with warp/CTA-dependent lane selection. Source
+// registers must not depend on warp/CTA coordinates.
+// The layouts must not contain broadcasted register bases.
 DecomposedWarpConversion
 getWarpLayoutConvertDecomposition(const triton::LinearLayout &srcLayout,
                                   const triton::LinearLayout &dstLayout,

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -10,11 +10,11 @@ namespace mlir::triton {
 bool squareSublayoutIsIdentity(const LinearLayout &ll,
                                ArrayRef<StringAttr> dimNames);
 
-// Compute B.invertAndCompose(A), mapping block bits broadcast by A to the
-// corresponding input block bits instead of block zero. This keeps replicated
-// memory accesses local without changing the composition.
-[[nodiscard]] LinearLayout invertAndComposeBlockLocal(const LinearLayout &A,
-                                                      const LinearLayout &B);
+// Compute B.invertAndCompose(A), mapping bits broadcast by A in localDims to
+// the corresponding input bits without changing the composition.
+[[nodiscard]] LinearLayout
+invertAndComposeLocal(const LinearLayout &A, const LinearLayout &B,
+                      ArrayRef<StringAttr> localDims);
 
 // For each output dimension d, ensure that the layout's output size (i.e., its
 // codomain) does not exceed shape[d]. Do this without changing the size of the

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -525,10 +525,10 @@ unsigned ScanLoweringHelper::getScratchSizeInBytes() {
   return elementSizeInBytes * getScratchSizeInElems();
 }
 
-static SmallVector<DecomposedWarpConversion::TranspositionInfo>
-getTranspositionSelectors(SmallVector<std::pair<int, int>> &mixedTranspositions,
-                          std::vector<std::vector<int32_t>> &regBases,
-                          int bitwidth);
+static void computeTranspositionSelectors(
+    SmallVector<DecomposedWarpConversion::TranspositionInfo>
+        &mixedTranspositions,
+    std::vector<std::vector<int32_t>> &regBases, int nPack);
 
 DecomposedWarpConversion
 getWarpLayoutConvertDecomposition(const LinearLayout &srcLayout,
@@ -542,7 +542,7 @@ getWarpLayoutConvertDecomposition(const LinearLayout &srcLayout,
   // matrix with zero columns possibly inserted. A layout conversion can be
   // viewed as a map P': H_src -> H_dst which factors ll_src = ll_dst \circ P'.
   //
-  // For a conversion not needing data movement between different warps, we
+  // For permutation cases not needing data movement between different warps, we
   // choose the following representation, where P is a permutation matrix and
   // K_1 and K_2 are (possibly trivial) spaces meant to ensure equally sized
   // lane and register dimensions between layouts:
@@ -561,7 +561,7 @@ getWarpLayoutConvertDecomposition(const LinearLayout &srcLayout,
   // subsequences of consecutive lane bits from cycles involving both bit types.
   // Further explanation of this method is below.
   //
-  // The decomposition is performed in three stages. First, we compute the
+  // For permutations, the decomposition has three stages. First, we compute the
   // permutation matrix `P` by using `invertAndCompose` to generate a skeleton
   // and then fill in any zero columns. Second, we walk the cycles of `P` to
   // factor out mixed transpositions to build `mixedTranspositions`, `pReg`, and
@@ -579,6 +579,11 @@ getWarpLayoutConvertDecomposition(const LinearLayout &srcLayout,
   auto *ctx = srcLayout.getInDimNames().begin()->getContext();
   StringAttr kReg = StringAttr::get(ctx, "register");
   StringAttr kLane = StringAttr::get(ctx, "lane");
+  StringAttr kWarp = StringAttr::get(ctx, "warp");
+  StringAttr kBlock = StringAttr::get(ctx, "block");
+  auto conversion = dstLayout.invertAndCompose(srcLayout);
+  uint32_t ownerLaneMask =
+      getOutputBasisMask(conversion, {kWarp, kBlock}, kLane);
 
   // Determine the target sizes of the register and lane dimensions for padding.
   int nSrcRegBases = srcLayout.getInDimSizeLog2(kReg);
@@ -594,6 +599,16 @@ getWarpLayoutConvertDecomposition(const LinearLayout &srcLayout,
   auto T = dstLayout.sublayout(inDimNames, outDimNames);
   S = S.resizeInDim(kReg, 1 << nRegBases).resizeInDim(kLane, 1 << nLaneBases);
   T = T.resizeInDim(kReg, 1 << nRegBases).resizeInDim(kLane, 1 << nLaneBases);
+
+  // Project out source lane bits selected by warp/CTA coordinates.
+  if (ownerLaneMask) {
+    auto bases = S.getBases();
+    for (auto [bit, basis] : llvm::enumerate(bases[kLane]))
+      if (ownerLaneMask & (uint32_t{1} << bit))
+        std::fill(basis.begin(), basis.end(), 0);
+    S = LinearLayout(std::move(bases), S.getOutDims(),
+                     /*requireSurjective=*/false);
+  }
 
   // We compute T^transpose \circ S, which serves as a skeleton for `P`, then
   // fill in zero columns, prioritizing producing fixed points. As we only need
@@ -626,16 +641,17 @@ getWarpLayoutConvertDecomposition(const LinearLayout &srcLayout,
     pBases[inDim][srcIdx][dstDimIdx] = 1 << dstIdx;
   }
 
-  // We walk the cycles of `P` to build the bases for `pReg` and `pLane` while
-  // factoring out mixed transpositions from cycles that include both register
-  // and lane basis vectors. `pReg` and `pLane` themselves only have one input
-  // and output dimension each.
-  LinearLayout::BasesT pRegBases, pLaneBases;
+  // Walk the cycles of `P`, building the register permutation and inverse
+  // lane map while factoring out mixed register/lane transpositions.
+  LinearLayout::BasesT pRegBases;
+  auto shuffleBases =
+      conversion.sublayout({kReg, kLane, kWarp, kBlock}, kLane).getBases();
   auto &regBases = pRegBases[kReg];
-  auto &laneBases = pLaneBases[kLane];
+  auto &laneBases = shuffleBases[kLane];
   regBases.resize(nRegBases, {0});
-  laneBases.resize(nLaneBases, {0});
-  SmallVector<std::pair<int, int>> mixedTranspositions;
+  shuffleBases[kReg].assign(nRegBases, {0});
+  laneBases.assign(nLaneBases, {0});
+  SmallVector<DecomposedWarpConversion::TranspositionInfo> mixedTranspositions;
 
   llvm::BitVector visited(nRegBases + nLaneBases, false);
   auto flatIdx = [&](StringAttr dim, int32_t index) {
@@ -664,12 +680,9 @@ getWarpLayoutConvertDecomposition(const LinearLayout &srcLayout,
       // indicates a contiguous subsequence of lane basis vectors. Note that the
       // transposition does not commute with the other two cycles.
       //
-      // The following variables are used to track the start and end points of
-      // such subsequences.
+      // Track the start of each lane subsequence.
       int32_t /*r_m*/ regStartIdx = -1;
       int32_t /*l_j*/ laneStartIdx = -1;
-      int32_t /*l_k*/ laneEndIdx = -1;
-      int32_t /*r_i*/ regEndIdx = -1;
 
       do {
         // Determine the next basis vector in the current cycle.
@@ -683,29 +696,26 @@ getWarpLayoutConvertDecomposition(const LinearLayout &srcLayout,
             nextIdx = llvm::Log2_32(nextVal);
           }
         }
-        // Set a `pReg` or `pLane` vector, or mark an r->l or l->r transition.
+        // Record a register edge, an inverse lane edge, or a mixed transition.
         if (currDim == kReg && nextDim == kReg) {
           regBases[currIdx][0] = 1 << nextIdx;
         } else if (currDim == kLane && nextDim == kLane) {
-          laneBases[currIdx][0] = 1 << nextIdx;
+          laneBases[nextIdx][0] = (1u << currIdx) & ~ownerLaneMask;
         } else if (currDim == kReg && nextDim == kLane) {
           regStartIdx = currIdx;
           laneStartIdx = nextIdx;
         } else {
-          regEndIdx = nextIdx;
-          laneEndIdx = currIdx;
-        }
-        // If a subsequence of the form (.. r_m l_j .. l_k r_i ..) has been
-        // found, perform the prescribed factorization.
-        if (regEndIdx >= 0) {
+          // Factor (.. r_m l_j .. l_k r_i ..) at this l_k -> r_i edge.
           // Assign r_m to map to r_i as in (.. r_m r_i ..).
-          regBases[regStartIdx][0] = 1 << regEndIdx;
-          // Assign l_k to map to l_j as in (l_j .. l_k).
-          laneBases[laneEndIdx][0] = 1 << laneStartIdx;
-          // Record (r_i l_j) as a factor.
-          mixedTranspositions.emplace_back(regEndIdx, laneStartIdx);
-          // Reset the auxiliary variables.
-          regStartIdx = laneStartIdx = laneEndIdx = regEndIdx = -1;
+          regBases[regStartIdx][0] = 1 << nextIdx;
+          // Padded endpoints need no lane predicate when warp/CTA selects
+          // source lanes. Omit their artificial closing edge as well.
+          int srcLane = ownerLaneMask && nextIdx >= nDstRegBases ? -1 : currIdx;
+          int dstLane =
+              ownerLaneMask && regStartIdx >= nSrcRegBases ? -1 : laneStartIdx;
+          if (srcLane >= 0 && dstLane >= 0)
+            laneBases[dstLane][0] = 1 << srcLane;
+          mixedTranspositions.push_back({nextIdx, srcLane, dstLane});
         }
 
         currDim = nextDim;
@@ -719,33 +729,31 @@ getWarpLayoutConvertDecomposition(const LinearLayout &srcLayout,
   int m = mixedTranspositions.size();
   int nPackPrelim = llvm::Log2_32(std::clamp(32 / bitwidth, 1, 4));
   int nPack = std::min(nPackPrelim, nRegBases - m);
-  auto processedTranspos =
-      getTranspositionSelectors(mixedTranspositions, regBases, nPack);
+  computeTranspositionSelectors(mixedTranspositions, regBases, nPack);
 
   auto pReg = LinearLayout(std::move(pRegBases), {{kReg, 1 << nRegBases}},
                            /*requireSurjective=*/true);
-  auto pLane = LinearLayout(std::move(pLaneBases), {{kLane, 1 << nLaneBases}},
-                            /*requireSurjective=*/true);
-  return {std::move(pReg), std::move(pLane), std::move(processedTranspos),
-          nPack};
+  for (const auto &t : mixedTranspositions)
+    if (t.srcLane >= 0)
+      shuffleBases[kReg][t.regBit][0] ^= 1u << t.srcLane;
+  auto shuffleMap =
+      LinearLayout(std::move(shuffleBases), {{kLane, 1 << nLaneBases}},
+                   /*requireSurjective=*/false);
+  return {std::move(pReg), std::move(shuffleMap),
+          std::move(mixedTranspositions), nPack};
 }
 
-static SmallVector<DecomposedWarpConversion::TranspositionInfo>
-getTranspositionSelectors(SmallVector<std::pair<int, int>> &mixedTranspositions,
-                          std::vector<std::vector<int32_t>> &regBases,
-                          int nPack) {
+static void computeTranspositionSelectors(
+    SmallVector<DecomposedWarpConversion::TranspositionInfo>
+        &mixedTranspositions,
+    std::vector<std::vector<int32_t>> &regBases, int nPack) {
   // When possible, we fuse permutations of 'low' register bits together
   // with a mixed transposition, resulting in byte permute instructions instead
   // of `select` instructions. After processing, no low register bits appear in
-  // the returned list of mixed transpositions.
+  // the mixed transpositions.
 
-  SmallVector<DecomposedWarpConversion::TranspositionInfo> ret;
-  ret.reserve(mixedTranspositions.size());
-  if (nPack == 0) {
-    for (auto &t : mixedTranspositions)
-      ret.push_back(DecomposedWarpConversion::TranspositionInfo{t});
-    return ret;
-  }
+  if (nPack == 0)
+    return;
   // This algorithm performs further algebraic processing.
   //
   // Suppose nPack > 0 and for simplicity that P is a cycle. We are given an
@@ -814,8 +822,8 @@ getTranspositionSelectors(SmallVector<std::pair<int, int>> &mixedTranspositions,
   };
 
   llvm::SmallSet<int32_t, 6> pairedRegBits;
-  for (auto [rBit, lBit] : mixedTranspositions)
-    pairedRegBits.insert(rBit);
+  for (const auto &t : mixedTranspositions)
+    pairedRegBits.insert(t.regBit);
 
   // A low bit in a mixed transposition must be replaced by a high bit. The
   // choice of high bit can affect instruction count. If the first high bit
@@ -823,8 +831,8 @@ getTranspositionSelectors(SmallVector<std::pair<int, int>> &mixedTranspositions,
   // choice. We reorder the transpositions to guarantee this during processing.
   // This also guarantees the correct ordering for the lowering algorithm.
   auto next = [&](int b) { return llvm::Log2_32(regBases[b][0]); };
-  auto nextHighFree = [&](auto p) {
-    int curr = p.first;
+  auto nextHighFree = [&](const auto &t) {
+    int curr = t.regBit;
     do {
       if (curr >= nPack)
         return true;
@@ -865,9 +873,8 @@ getTranspositionSelectors(SmallVector<std::pair<int, int>> &mixedTranspositions,
     return potentialPartner;
   };
 
-  for (auto p : mixedTranspositions) {
-    int rBit = p.first;
-    int lBit = p.second;
+  for (auto &info : mixedTranspositions) {
+    int rBit = info.regBit;
     SmallVector<int> cycle;
     int currBit = rBit;
     do {
@@ -922,18 +929,16 @@ getTranspositionSelectors(SmallVector<std::pair<int, int>> &mixedTranspositions,
     auto [topPreSel, botPreSel] = generateSelectors(head, tail, preShufLoBits);
     regBases[tail][0] = 1 << head;
 
-    DecomposedWarpConversion::TranspositionInfo info;
-    info.transposition = {partnerBit, lBit};
+    info.regBit = partnerBit;
     info.topPreSel = topPreSel;
     info.botPreSel = botPreSel;
     info.topPostSel = topPostSel;
     info.botPostSel = botPostSel;
-
-    ret.push_back(info);
   }
-  if (nPack == 2 && regBases[0][0] == 2 && regBases[1][0] == 1 && ret.size()) {
+  if (nPack == 2 && regBases[0][0] == 2 && regBases[1][0] == 1 &&
+      !mixedTranspositions.empty()) {
     // If (r0 r1) remains in pReg, fold it into a mixed transposition.
-    auto &t = ret.front();
+    auto &t = mixedTranspositions.front();
     for (int lowBit : {0, 1, 0}) {
       t.topPreSel = permuteSelector(t.topPreSel, lowBit);
       t.botPreSel = permuteSelector(t.botPreSel, lowBit);
@@ -941,7 +946,6 @@ getTranspositionSelectors(SmallVector<std::pair<int, int>> &mixedTranspositions,
     regBases[0][0] = 1;
     regBases[1][0] = 2;
   }
-  return ret;
 }
 
 SmallVector<std::pair<SmallVector<int64_t>, SmallVector<int64_t>>>
@@ -1215,22 +1219,32 @@ bool cvtReordersRegisters(RankedTensorType srcTy, RankedTensorType dstTy) {
 }
 
 bool cvtNeedsWarpShuffle(triton::gpu::ConvertLayoutOp op) {
-  if (op.getForceWarpShuffle())
-    return true;
+  bool forceWarpShuffle = op.getForceWarpShuffle();
   auto srcTy = op.getSrc().getType();
   auto dstTy = op.getType();
-  auto layout = minimalCvtLayout(srcTy, dstTy);
+  if (!forceWarpShuffle && cvtReordersRegisters(srcTy, dstTy))
+    return false;
   MLIRContext *ctx = srcTy.getContext();
   auto kRegister = StringAttr::get(ctx, "register");
-  auto kLane = StringAttr::get(ctx, "lane");
-  if (to_vector(layout.getOutDimNames()) ==
-      SmallVector<StringAttr, 2>{kRegister, kLane}) {
-    auto srcLayout = toLinearLayout(srcTy).removeZeroBasesAlongDim(kRegister);
-    auto dstLayout = toLinearLayout(dstTy).removeZeroBasesAlongDim(kRegister);
-    auto factors = getWarpLayoutConvertDecomposition(srcLayout, dstLayout, 32);
-    return (factors.mixedTranspositions.size() < 2);
+  auto srcLayout = toLinearLayout(srcTy).removeZeroBasesAlongDim(kRegister);
+  auto dstLayout = toLinearLayout(dstTy).removeZeroBasesAlongDim(kRegister);
+  bool canShuffle = isPermutationMatrixLayout(srcLayout) &&
+                    isPermutationMatrixLayout(dstLayout);
+  if (canShuffle) {
+    auto kWarp = StringAttr::get(ctx, "warp");
+    auto kBlock = StringAttr::get(ctx, "block");
+    auto conversion =
+        invertAndComposeLocal(srcLayout, dstLayout, {kWarp, kBlock});
+    canShuffle = conversion.isIdentityOnOutDim(kWarp) &&
+                 conversion.isIdentityOnOutDim(kBlock) &&
+                 conversion.sublayoutIsZero({kWarp, kBlock}, kRegister);
   }
-  return false;
+  assert((!forceWarpShuffle || canShuffle) &&
+         "force_warp_shuffle requires a supported shuffle decomposition");
+  return forceWarpShuffle ||
+         (canShuffle &&
+          getWarpLayoutConvertDecomposition(srcLayout, dstLayout, 32)
+                  .mixedTranspositions.size() < 2);
 }
 
 bool cvtNeedsSharedMemory(triton::gpu::ConvertLayoutOp op) {

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1266,7 +1266,7 @@ bool isCvtDimSync(const triton::LinearLayout &srcLayout,
            dstLayout.getFreeVariableMasks()[dim] == 0;
   } else {
     assert(dim == kBlock);
-    return invertAndComposeBlockLocal(srcLayout, dstLayout)
+    return invertAndComposeLocal(srcLayout, dstLayout, {kBlock})
         .isIdentityOnOutDim(dim);
   }
 }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -174,7 +174,7 @@ struct ConvertLayoutOpConversion
     auto reps = LinearLayout::identity1D(nReps, kReg, kReps);
 
     auto totalStoreCvt = srcLayout.invertAndCompose(smem);
-    auto totalLoadCvt = invertAndComposeBlockLocal(smem, dstLayout);
+    auto totalLoadCvt = invertAndComposeLocal(smem, dstLayout, {kBlock});
 
     // The permutation exists by construction of the reps dimension in
     // optimalSwizzling

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -41,53 +41,29 @@ struct ConvertLayoutOpConversion
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
 
-    auto kBlock = str_attr("block");
-    auto kWarp = str_attr("warp");
-    auto kLane = str_attr("lane");
     auto kRegister = str_attr("register");
 
     auto srcLayout = toLinearLayout(srcTy).removeZeroBasesAlongDim(kRegister);
     auto dstLayout = toLinearLayout(dstTy).removeZeroBasesAlongDim(kRegister);
     LinearLayout conversion = minimalCvtLayout(srcLayout, dstLayout);
 
-    auto dims = conversion.getInDimNames();
-    auto srcEnc = cast<RankedTensorType>(srcTy).getEncoding();
-    auto dstEnc = cast<RankedTensorType>(dstTy).getEncoding();
-    if ((isGenericLinearEncoding(srcEnc) || isGenericLinearEncoding(dstEnc)) &&
-        llvm::range_size(dims) > 1)
-      return op.emitError("ConvertLayoutOp  supports GenericLinearEncoding "
-                          " only when the conversion is transfer between "
-                          "values in the same thread.");
     assert(to_vector(conversion.getInDimNames()) ==
            to_vector(conversion.getOutDimNames()));
-    if (llvm::is_contained(dims, kBlock) || llvm::is_contained(dims, kWarp)) {
-      // Transfer between values in the same CTA, or across CTAs. We move values
-      // through (distributed) shared memory.
-      transferSwizzlingLocalMem(op, adaptor.getSrc(), srcLayout, dstLayout,
-                                rewriter);
-      return success();
-    } else if (llvm::is_contained(dims, kLane)) {
-      // Case 3. Transfer between values in the same warp, in which case we try
-      //         to move values using warp shuffles, though if the pattern is
-      //         expensive enough we fall back to using shared memory
-      if (cvtNeedsWarpShuffle(op))
-        return transferWithinWarp(op, srcLayout, dstLayout, adaptor, rewriter);
-
-      transferSwizzlingLocalMem(op, adaptor.getSrc(), srcLayout, dstLayout,
-                                rewriter);
-      return success();
-    } else if (llvm::is_contained(dims, kRegister)) {
-      // Case 4. Transfer between values in the same thread, in which case we
-      //         simply reorder the elements of adaptor.getSrc().
-      return transferWithinThread(op, conversion, adaptor, rewriter);
-    } else {
-      // Cast 5. The two layouts are equivalent. We should probably remove
-      // these in RemoveLayoutConversion.
+    if (conversion.getNumInDims() == 0) {
       assert(adaptor.getSrc().getType() ==
              getTypeConverter()->convertType(dstTy));
       rewriter.replaceOp(op, adaptor.getSrc());
       return success();
     }
+    if (conversion.getNumInDims() == 1)
+      return transferWithinThread(op, conversion, adaptor, rewriter);
+
+    if (cvtNeedsWarpShuffle(op))
+      return transferWithinWarp(op, srcLayout, dstLayout, adaptor, rewriter);
+
+    transferSwizzlingLocalMem(op, adaptor.getSrc(), srcLayout, dstLayout,
+                              rewriter);
+    return success();
   }
 
   LogicalResult
@@ -279,16 +255,14 @@ struct ConvertLayoutOpConversion
     auto elemTy = getTypeConverter()->convertType(srcTy.getElementType());
     int bitwidth = getIntOrFloatOrPtrBitWidth(elemTy);
 
-    auto factors =
+    auto [pReg, shuffleMap, mixedTranspositions, nPack] =
         getWarpLayoutConvertDecomposition(srcLayout, dstLayout, bitwidth);
-    auto &[pReg, pLane, mixedTranspositions, nPack] = factors;
     int m = mixedTranspositions.size();
-    bool pLaneIsTrivial = squareSublayoutIsIdentity(pLane, kLane);
-    assert((m > 0 || !pLaneIsTrivial) && "Shuffles not needed for conversion");
+    bool isXorShuffle = squareSublayoutIsIdentity(shuffleMap, kLane);
 
-    // The desired layout conversion can be expressed as a permutation P of
-    // hardware index bits for the `kLane` and `kReg` dimensions. The `factors`
-    // of P describe a decomposition
+    // In permutation cases, the desired layout conversion can be expressed as
+    // a permutation P of hardware index bits for the `kLane` and `kReg`
+    // dimensions. The `factors` of P describe a decomposition
     //
     //                 P = P_mixed \circ P_lane \circ P_reg,
     //
@@ -300,7 +274,7 @@ struct ConvertLayoutOpConversion
     //    at a time using 1.5 * R selects/permutes and .5 * R shuffles each.
     //  - An in-place `Swap` method which can simultaneously implement P_lane
     //    and multiple mixed transpositions at a time using 2 * m * R selects/
-    //    permutes and either (1 - (1/2)^m) * R shuffles if `pLaneIsTrivial` and
+    //    permutes and either (1 - (1/2)^m) * R shuffles if `isXorShuffle` and
     //    R shuffles otherwise.
     // Here, R denotes the number of 32-bit registers in use after packing (or
     // splitting, if applied to 64-bit types or pointers), and in the `Swap`
@@ -311,21 +285,10 @@ struct ConvertLayoutOpConversion
     // layout, then we broadcast along the register dimension to match size. The
     // removal of broadcasting above and introduction here is expected by the
     // `factors`.
-    int regDim = inVals.size();
-    int pRegDim = pReg.getInDimSize(kReg);
-    if (pRegDim > regDim) {
-      SmallVector<Value> original(inVals.begin(), inVals.end());
-      inVals.clear();
-      inVals.reserve(pRegDim);
-      while (inVals.size() < pRegDim)
-        inVals.append(original.begin(), original.end());
-      regDim = pRegDim;
-    }
-
-    // Apply pReg.
+    int regDim = pReg.getInDimSize(kReg);
     SmallVector<Value> newInVals(regDim);
-    for (const auto &[i, v] : llvm::enumerate(inVals))
-      newInVals[pReg.apply({{kReg, i}})[0].second] = v;
+    for (int r = 0; r < regDim; ++r)
+      newInVals[pReg.apply({{kReg, r}})[0].second] = inVals[r % inVals.size()];
     inVals = std::move(newInVals);
 
     // Pack registers if possible.
@@ -371,12 +334,13 @@ struct ConvertLayoutOpConversion
     };
 
     SmallVector<Value> outVals;
-    if (m == 1 && pLaneIsTrivial && isShippable(mixedTranspositions[0])) {
+    if (m == 1 && isXorShuffle && isShippable(mixedTranspositions[0])) {
       outVals = transferWithinWarpShipImpl(loc, rewriter, inVals, nPack,
                                            mixedTranspositions[0]);
     } else {
-      outVals = transferWithinWarpSwapImpl(loc, rewriter, inVals, nPack, pLane,
-                                           pLaneIsTrivial, mixedTranspositions);
+      outVals =
+          transferWithinWarpSwapImpl(loc, rewriter, inVals, nPack, shuffleMap,
+                                     isXorShuffle, mixedTranspositions);
     }
 
     // Unpack registers if needed.
@@ -416,11 +380,14 @@ struct ConvertLayoutOpConversion
 
   SmallVector<Value> transferWithinWarpSwapImpl(
       Location loc, ConversionPatternRewriter &rewriter, ArrayRef<Value> inVals,
-      int nPack, const LinearLayout &pLane, bool pLaneIsTrivial,
+      int nPack, const LinearLayout &shuffleMap, bool isXorShuffle,
       ArrayRef<TranspositionInfo> mixedTranspositions) const {
     auto *ctx = rewriter.getContext();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto kReg = str_attr("register");
     auto kLane = str_attr("lane");
+    auto kWarp = str_attr("warp");
+    auto kBlock = str_attr("block");
 
     SmallVector<Value> vals(inVals.begin(), inVals.end());
     int numRegs = inVals.size();
@@ -444,24 +411,21 @@ struct ConvertLayoutOpConversion
     // of each transposition together. The two combined `selp` stages each use
     // `numRegs` selects per transposition, while the `shfl` stage only requires
     // code emission when at least one of the `r_i` bits is on, resulting in
-    // `(1 - (1/2)^m) * numRegs` shuffles in total. If `pLane` is nontrivial,
+    // `(1 - (1/2)^m) * numRegs` shuffles in total. If `P_lane` is nontrivial,
     // then we can conjugate its effects through the first two stages and fuse
     // it with the second stage, resulting in `numRegs` shuffles instead.
-    Value laneId = getLaneId(rewriter, loc);
-    auto pLaneInv = pLane.invert();
-    const auto &pLInvBases = pLaneInv.getBases().lookup(kLane);
-
+    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
     // Implement r_i ^= l_j using `numRegs` independent selects or permutes.
     auto applySwap = [&](TranspositionInfo t, bool preShuf) {
-      int rIdx = t.transposition.first - nPack;
-      int origLIdx = t.transposition.second;
-      int lIdx = preShuf ? llvm::Log2_32(pLInvBases[origLIdx][0]) : origLIdx;
+      int rIdx = t.regBit - nPack;
+      int lIdx = preShuf ? t.srcLane : t.dstLane;
       uint16_t topSel = preShuf ? t.topPreSel : t.topPostSel;
       uint16_t botSel = preShuf ? t.botPreSel : t.botPostSel;
 
       SmallVector<Value> newVals(numRegs);
-      Value lBitVal = b.and_(laneId, b.i32_val(1 << lIdx));
-      Value lBitOff = b.icmp_eq(lBitVal, b.i32_val(0));
+      Value lBitOff = b.true_val();
+      if (lIdx >= 0)
+        lBitOff = b.icmp_eq(b.and_(laneId, b.i32_val(1 << lIdx)), b.i32_val(0));
 
       int tileSize = 1 << (rIdx + 1);
       int numTiles = numRegs / tileSize;
@@ -495,18 +459,22 @@ struct ConvertLayoutOpConversion
       vals = applySwap(t, /*preShuf=*/true);
     // Stage 2 (shfl)
     Value laneIdPerm;
-    if (!pLaneIsTrivial)
-      laneIdPerm = triton::gpu::matrixVectorProd(b, pLaneInv, laneId);
+    if (!isXorShuffle) {
+      SmallVector<std::pair<StringAttr, Value>> indices{{kLane, laneId}};
+      if (!shuffleMap.sublayoutIsZero(kWarp, kLane))
+        indices.push_back({kWarp, warpId});
+      if (!shuffleMap.sublayoutIsZero(kBlock, kLane))
+        indices.push_back({kBlock, targetInfo.getClusterCTAId(rewriter, loc)});
+      auto dims = to_vector(llvm::make_first_range(indices));
+      laneIdPerm = applyLinearLayout(loc, rewriter,
+                                     shuffleMap.sublayout(dims, kLane), indices)
+                       .front()
+                       .second;
+    }
+    auto registerToLane = shuffleMap.sublayout(kReg, kLane);
     for (int r = 0; r < numRegs; ++r) {
-      int mask = 0;
-      for (const auto &t : mixedTranspositions) {
-        int rIdx = t.transposition.first - nPack;
-        int lIdx = t.transposition.second;
-        if (r & (1 << rIdx)) {
-          mask |= pLInvBases[lIdx][0];
-        }
-      }
-      if (pLaneIsTrivial) {
+      int mask = registerToLane.apply({{kReg, r << nPack}})[0].second;
+      if (isXorShuffle) {
         if (mask != 0)
           vals[r] = targetInfo.shuffleXor(rewriter, loc, vals[r], mask);
       } else {
@@ -528,8 +496,8 @@ struct ConvertLayoutOpConversion
     // `transferWithinWarpSwapImpl`, but uses auxiliary registers to hold the
     // values to be shuffled, resulting in fewer emitted instructions.
     int numRegs = inVals.size();
-    int rIdx = t.transposition.first - nPack;
-    int lIdx = t.transposition.second;
+    int rIdx = t.regBit - nPack;
+    int lIdx = t.dstLane;
     int tileSize = 1 << (rIdx + 1);
     int numTiles = numRegs / tileSize;
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -414,7 +414,8 @@ struct ConvertLayoutOpConversion
     // `(1 - (1/2)^m) * numRegs` shuffles in total. If `P_lane` is nontrivial,
     // then we can conjugate its effects through the first two stages and fuse
     // it with the second stage, resulting in `numRegs` shuffles instead.
-    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+    Value laneId, warpId;
+    std::tie(laneId, warpId) = getLaneAndWarpId(rewriter, loc);
     // Implement r_i ^= l_j using `numRegs` independent selects or permutes.
     auto applySwap = [&](TranspositionInfo t, bool preShuf) {
       int rIdx = t.regBit - nPack;

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -62,7 +62,8 @@ LogicalResult lowerLocalStore(Location loc, MLIRContext *ctx,
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
   auto sharedLayout = toLinearLayoutIgnoringPadding(memDescTy);
-  auto cvt = invertAndComposeBlockLocal(sharedLayout, regLayout);
+  auto kBlock = str_attr("block");
+  auto cvt = invertAndComposeLocal(sharedLayout, regLayout, {kBlock});
 
   lowerLocalLdSt(loc, ctx, cvt, inVals, llvmElemTy, memDescTy, smemObj,
                  rewriter, targetInfo,
@@ -192,7 +193,8 @@ public:
     auto regLayout =
         toLinearLayout(regTy).removeZeroBasesAlongDim(str_attr("register"));
     auto sharedLayout = toLinearLayoutIgnoringPadding(memDescTy);
-    auto cvt = invertAndComposeBlockLocal(sharedLayout, regLayout);
+    auto kBlock = str_attr("block");
+    auto cvt = invertAndComposeLocal(sharedLayout, regLayout, {kBlock});
 
     auto outVals = lowerLocalLdSt(loc, ctx, cvt, {}, llvmElemTy, memDescTy,
                                   smemObj, rewriter, targetInfo,

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -580,7 +580,8 @@ SmallVector<std::pair<Value, Value>> computeBlockLocalOffsets(
       LinearLayout::identity1D(sharedLayout.getOutDimSize(axisDim), axisDim,
                                axisDim);
   indexedLayout = indexedLayout.transposeOuts(allDims);
-  LinearLayout cvt = invertAndComposeBlockLocal(sharedLayout, indexedLayout);
+  LinearLayout cvt =
+      invertAndComposeLocal(sharedLayout, indexedLayout, {kBlock});
   bool crossCTA = !cvt.isIdentityOnOutDim(kBlock);
   bool blockAffectsOffset = !cvt.sublayoutIsZero({kBlock}, {kOffset});
 

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -510,15 +510,16 @@ void extendXorSpan(uint32_t &span, uint32_t basis, int numCTAs) {
 
 LinearLayout getLocalLoadStoreConversion(ttg::MemDescType memDescTy,
                                          RankedTensorType regTy) {
-  return invertAndComposeBlockLocal(
-      ttg::toLinearLayoutIgnoringPadding(memDescTy),
-      ttg::toLinearLayout(regTy));
+  auto kBlock = StringAttr::get(memDescTy.getContext(), "block");
+  return invertAndComposeLocal(ttg::toLinearLayoutIgnoringPadding(memDescTy),
+                               ttg::toLinearLayout(regTy), {kBlock});
 }
 
 LinearLayout getLocalGatherScatterConversion(ttg::MemDescType memDescTy,
                                              RankedTensorType regTy,
                                              unsigned axis) {
   MLIRContext *ctx = memDescTy.getContext();
+  auto kBlock = StringAttr::get(ctx, "block");
   LinearLayout sharedLayout = ttg::toLinearLayoutIgnoringPadding(memDescTy);
   SmallVector<StringAttr> allDims =
       standardOutDimNames(ctx, memDescTy.getRank());
@@ -532,7 +533,7 @@ LinearLayout getLocalGatherScatterConversion(ttg::MemDescType memDescTy,
       LinearLayout::identity1D(sharedLayout.getOutDimSize(axisDim), axisDim,
                                axisDim);
   indexedLayout = indexedLayout.transposeOuts(allDims);
-  return invertAndComposeBlockLocal(sharedLayout, indexedLayout);
+  return invertAndComposeLocal(sharedLayout, indexedLayout, {kBlock});
 }
 
 uint32_t getXorImageMask(const LinearLayout &layout, StringAttr outDim,
@@ -634,8 +635,9 @@ Value getScratchReadCTAs(ImplicitLocOpBuilder &b, Operation *op,
   if (auto convert = dyn_cast<ttg::ConvertLayoutOp>(op)) {
     LinearLayout srcLayout = ttg::toLinearLayout(convert.getSrc().getType());
     LinearLayout dstLayout = ttg::toLinearLayout(convert.getType());
+    auto kBlock = b.getStringAttr("block");
     Value loadCTAs = getLocalMemoryRecipientCTAs(
-        b, invertAndComposeBlockLocal(srcLayout, dstLayout));
+        b, invertAndComposeLocal(srcLayout, dstLayout, {kBlock}));
     return arith::OrIOp::create(b, ownerCTAs, loadCTAs);
   }
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -520,7 +520,8 @@ LogicalResult AsyncSharedStoreOp::verify() {
 
   auto regLayout = toLinearLayout(srcTy);
   auto sharedLayout = toLinearLayoutIgnoringPadding(dstTy);
-  auto cvt = invertAndComposeBlockLocal(sharedLayout, regLayout);
+  auto kBlock = StringAttr::get(getContext(), "block");
+  auto cvt = invertAndComposeLocal(sharedLayout, regLayout, {kBlock});
   std::optional<int> maybeMaxVecElems;
   if (isPaddedEncoding(dstTy.getEncoding()))
     maybeMaxVecElems = getMinInterval(dstTy.getEncoding());

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MBarrierUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MBarrierUtilities.cpp
@@ -14,11 +14,11 @@ namespace ttng = mlir::triton::nvidia_gpu;
 
 bool isCrossCTALoadStore(ttg::MemDescType memDescTy, RankedTensorType regTy) {
   auto kRegister = StringAttr::get(memDescTy.getContext(), "register");
+  auto kBlock = StringAttr::get(memDescTy.getContext(), "block");
   LinearLayout regLayout =
       ttg::toLinearLayout(regTy).removeZeroBasesAlongDim(kRegister);
-  LinearLayout conversion = invertAndComposeBlockLocal(
-      ttg::toLinearLayoutIgnoringPadding(memDescTy), regLayout);
-  auto kBlock = StringAttr::get(memDescTy.getContext(), "block");
+  LinearLayout conversion = invertAndComposeLocal(
+      ttg::toLinearLayoutIgnoringPadding(memDescTy), regLayout, {kBlock});
   return !conversion.isIdentityOnOutDim(kBlock);
 }
 
@@ -50,7 +50,7 @@ bool isCrossCTAGatherScatter(ttg::MemDescType memDescTy, RankedTensorType regTy,
                                axisDim);
   indexedLayout = indexedLayout.transposeOuts(allDims);
   LinearLayout conversion =
-      invertAndComposeBlockLocal(sharedLayout, indexedLayout);
+      invertAndComposeLocal(sharedLayout, indexedLayout, {kBlock});
   return !conversion.isIdentityOnOutDim(kBlock);
 }
 

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -36,30 +36,23 @@ bool squareSublayoutIsIdentity(const LinearLayout &ll,
       ll, dimNames, [](int b, int32_t basis) { return basis == (1 << b); });
 }
 
-LinearLayout invertAndComposeBlockLocal(const LinearLayout &A,
-                                        const LinearLayout &B) {
+LinearLayout invertAndComposeLocal(const LinearLayout &A, const LinearLayout &B,
+                                   ArrayRef<StringAttr> localDims) {
   auto cvt = B.invertAndCompose(A);
-  assert(!cvt.getInDimNames().empty());
-  auto kBlock =
-      StringAttr::get(cvt.getInDimNames().begin()->getContext(), "block");
-  assert(A.hasInDim(kBlock) && B.hasInDim(kBlock));
-  assert(A.getInDimSize(kBlock) == B.getInDimSize(kBlock));
-
-  // A zero block basis does not affect A's outputs, so force that output
-  // coordinate to equal the corresponding input block bit. This does not
-  // change the composition.
   auto bases = cvt.getBases();
-  int blockOutIdx = cvt.getOutDimIndex(kBlock);
-  uint64_t nonZeroBlockBases =
-      getInputBasisMask(A, kBlock, llvm::to_vector(A.getOutDimNames()));
-  for (unsigned i = 0; i < A.getInDimSizeLog2(kBlock); ++i) {
-    if (nonZeroBlockBases & (uint64_t{1} << i))
-      continue;
-    int blockBit = 1 << i;
+  for (StringAttr dim : localDims) {
+    assert(A.hasInDim(dim) && B.hasInDim(dim));
+    assert(A.getInDimSize(dim) == B.getInDimSize(dim));
+    // A zero source basis leaves its output coordinate free. Choose the
+    // corresponding input bit to keep the replicated value local.
+    int outIdx = cvt.getOutDimIndex(dim);
+    uint64_t nonZeroBases =
+        getInputBasisMask(A, dim, llvm::to_vector(A.getOutDimNames()));
     for (auto &inDimBases : llvm::make_second_range(bases))
       for (auto &basis : inDimBases)
-        basis[blockOutIdx] &= ~blockBit;
-    bases[kBlock][i][blockOutIdx] |= blockBit;
+        basis[outIdx] &= nonZeroBases;
+    for (auto [i, basis] : llvm::enumerate(bases[dim]))
+      basis[outIdx] |= (uint64_t{1} << i) & ~nonZeroBases;
   }
   return LinearLayout(std::move(bases), cvt.getOutDims(),
                       /*requireSurjective=*/false);

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -1133,6 +1133,9 @@ _multi_cta_convert2d_layout_cases = [(src_ctas_per_cga, dst_ctas_per_cga, None, 
                                      for src_ctas_per_cga, dst_ctas_per_cga in _multi_cta_cga_layout_pairs
                                      for src_layout, dst_layout in _multi_cta_2d_layout_pairs]
 _convert2d_layout_cases = _single_cta_convert2d_layout_cases + _multi_cta_convert2d_layout_cases
+# Warp-dependent broadcast with two f16 elements sharing a shuffle.
+_convert2d_layout_cases.append((None, None, None, ttgl.BlockedLayout([1, 16], [THREADS_PER_WARP, 1], [1, 4], [1, 0]),
+                                ttgl.BlockedLayout([1, 16], [8, THREADS_PER_WARP // 8], [4, 1], [1, 0])))
 
 
 @pytest.mark.parametrize("M, N", [[64, 1], [64, 64], [64, 128], [1, 64]])

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1060,6 +1060,132 @@ module attributes {"ttg.num-warps" = 1 : i32} {
 
 // -----
 
+#broadcast_src = #ttg.linear<{register=[[0, 1], [0, 2]], lane=[[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp=[[32, 0], [64, 0], [0, 0]], block=[]}>
+#broadcast_dst = #ttg.linear<{register=[[0, 1], [0, 2], [8, 0]], lane=[[0, 0], [0, 0], [1, 0], [2, 0], [4, 0]], warp=[[32, 0], [64, 0], [16, 0]], block=[]}>
+#broadcast_expanded = #ttg.linear<{register=[[0, 1], [0, 2], [4, 0], [8, 0]], lane=[[0, 0], [0, 0], [0, 0], [1, 0], [2, 0]], warp=[[32, 0], [64, 0], [16, 0]], block=[]}>
+#register_src = #ttg.linear<{register=[[32, 0]], lane=[[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp=[[0, 0], [64, 0], [0, 0]], block=[]}>
+#register_dst = #ttg.linear<{register=[], lane=[[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp=[[32, 0], [64, 0], [0, 0]], block=[]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
+  // The source repeats its rows in warp ^ 4. Packed columns share a source lane.
+  // CHECK-LABEL: @convert_layout_broadcast_warp
+  tt.func @convert_layout_broadcast_warp(%arg0: tensor<128x4xf16, #broadcast_src>) {
+    // CHECK-NOT: nvvm.bar
+    // CHECK-COUNT-4: nvvm.shfl.sync
+    // CHECK-NOT: nvvm.shfl.sync
+    // CHECK-NOT: nvvm.bar
+    // CHECK: llvm.return
+    %0 = ttg.convert_layout %arg0 : tensor<128x4xf16, #broadcast_src> -> tensor<128x4xf16, #broadcast_dst>
+    tt.return
+  }
+
+  // Two register bits select source lanes, exceeding the shuffle heuristic.
+  // CHECK-LABEL: @convert_layout_broadcast_warp_expanded
+  tt.func @convert_layout_broadcast_warp_expanded(%arg0: tensor<128x4xf16, #broadcast_src>) {
+    // CHECK-NOT: nvvm.shfl.sync
+    // CHECK: nvvm.barrier
+    // CHECK: llvm.return
+    %0 = ttg.convert_layout %arg0 : tensor<128x4xf16, #broadcast_src> -> tensor<128x4xf16, #broadcast_expanded>
+    tt.return
+  }
+
+  // Reversing the conversion requires values from another warp.
+  // CHECK-LABEL: @convert_layout_broadcast_warp_reverse
+  tt.func @convert_layout_broadcast_warp_reverse(%arg0: tensor<128x4xf16, #broadcast_dst>) {
+    // CHECK-NOT: nvvm.shfl.sync
+    // CHECK: nvvm.barrier
+    // CHECK: llvm.return
+    %0 = ttg.convert_layout %arg0 : tensor<128x4xf16, #broadcast_dst> -> tensor<128x4xf16, #broadcast_src>
+    tt.return
+  }
+
+  // The source register is warp & 1, so keep the shared-memory fallback.
+  // CHECK-LABEL: @convert_layout_warp_dependent_register
+  tt.func @convert_layout_warp_dependent_register(%arg0: tensor<128x1xf32, #register_src>) {
+    // CHECK-NOT: nvvm.shfl.sync
+    // CHECK: nvvm.barrier
+    // CHECK: llvm.return
+    %0 = ttg.convert_layout %arg0 : tensor<128x1xf32, #register_src> -> tensor<128x1xf32, #register_dst>
+    tt.return
+  }
+}
+
+// -----
+
+#src = #ttg.linear<{register=[[1]], lane=[[2], [4], [8], [16], [32]], warp=[[0]], block=[]}>
+#dst = #ttg.linear<{register=[], lane=[[1], [2], [4], [8], [16]], warp=[[32]], block=[]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
+  // CHECK-LABEL: @convert_layout_warp_broadcast_register_select
+  tt.func @convert_layout_warp_broadcast_register_select(%arg0: tensor<64xi32, #src>) {
+    // CHECK: %[[PRE_TRUE:.*]] = llvm.mlir.constant(true)
+    // CHECK: llvm.select %[[PRE_TRUE]]
+    // CHECK-NOT: nvvm.bar
+    // CHECK-COUNT-2: nvvm.shfl.sync
+    // CHECK: llvm.select
+    // CHECK-NOT: nvvm.bar
+    // CHECK: llvm.return
+    %0 = ttg.convert_layout %arg0 : tensor<64xi32, #src> -> tensor<64xi32, #dst>
+    tt.return
+  }
+}
+
+// -----
+
+#src = #ttg.linear<{register=[[1], [2]], lane=[[4], [8], [16], [32], [64]], warp=[[0]], block=[]}>
+#dst = #ttg.linear<{register=[[4], [1], [2]], lane=[[0], [8], [16], [32], [0]], warp=[[64]], block=[]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
+  // CHECK-LABEL: @convert_layout_warp_broadcast_packed_permutation
+  tt.func @convert_layout_warp_broadcast_packed_permutation(%arg0: tensor<128xi8, #src>) {
+    // Packed output still needs byte permutations with a constant predicate.
+    // CHECK-NOT: nvvm.bar
+    // CHECK-COUNT-2: nvvm.shfl.sync
+    // CHECK: %[[POST_TRUE:.*]] = llvm.mlir.constant(true)
+    // CHECK: llvm.select %[[POST_TRUE]]
+    // CHECK: llvm.select %[[POST_TRUE]]
+    // CHECK-COUNT-2: llvm.call_intrinsic "llvm.nvvm.prmt"
+    // CHECK-NOT: nvvm.bar
+    // CHECK: llvm.return
+    %0 = ttg.convert_layout %arg0 : tensor<128xi8, #src> -> tensor<128xi8, #dst>
+    tt.return
+  }
+}
+
+// -----
+
+#src = #ttg.linear<{register=[], lane=[[1], [2], [4], [8], [16]], warp=[[32], [0]], block=[[0]]}>
+#dst = #ttg.linear<{register=[], lane=[[0], [1], [2], [4], [8]], warp=[[32], [0]], block=[[16]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @convert_layout_cta_broadcast
+  tt.func @convert_layout_cta_broadcast(%arg0: tensor<64xi32, #src>) {
+    // CHECK: nvg.cluster_id
+    // CHECK-NOT: nvvm.bar
+    // CHECK: nvvm.shfl.sync idx
+    // CHECK-NOT: nvvm.shfl.sync
+    // CHECK-NOT: nvvm.bar
+    // CHECK: llvm.return
+    %0 = ttg.convert_layout %arg0 : tensor<64xi32, #src> -> tensor<64xi32, #dst>
+    tt.return
+  }
+}
+
+// -----
+
+#src = #ttg.generic_linear<{register=[[32], [64]], lane=[[1], [2], [4], [8], [16]], warp=[[192], [256]], block=[]}>
+#dst = #ttg.generic_linear<{register=[[32], [16]], lane=[[1], [2], [4], [8], [64]], warp=[[192], [256]], block=[]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // This register/warp swizzle falls back to shared memory.
+  // CHECK-LABEL: @convert_layout_generic_warp_swizzle
+  tt.func @convert_layout_generic_warp_swizzle(%arg0: tensor<512xf64, #src>) {
+    // CHECK-NOT: nvvm.shfl.sync
+    // CHECK: nvvm.bar.warp.sync
+    // CHECK-NOT: nvvm.shfl.sync
+    // CHECK: llvm.return
+    %0 = ttg.convert_layout %arg0 : tensor<512xf64, #src> -> tensor<512xf64, #dst>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked0 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 8], warpsPerCTA = [2, 2], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {

--- a/test/TritonGPU/reduce-data-duplication.mlir
+++ b/test/TritonGPU/reduce-data-duplication.mlir
@@ -86,14 +86,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-// CHECK-LABEL: neg_blocked_to_dot_op_incompatible_threads_gfx940
+// Each source wave holds all rows, so the destination can select its rows with
+// a wave-dependent shuffle despite the different threadsPerWarp arrangement.
+// CHECK-LABEL: blocked_to_dot_op_warp_shuffle_gfx940
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 2], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [16, 4], warpsPerCTA = [2, 2], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx940", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func @neg_blocked_to_dot_op_incompatible_threads_gfx940(%arg0: tensor<32x32xf16, #blocked>) {
-    // CHECK-NOT: ttg.convert_layout
-    // CHECK: ttg.local_alloc
-    // CHECK: ttg.local_load
+  tt.func @blocked_to_dot_op_warp_shuffle_gfx940(%arg0: tensor<32x32xf16, #blocked>) {
+    // CHECK-NOT: ttg.local_alloc
+    // CHECK: ttg.convert_layout
+    // CHECK-NOT: ttg.local_alloc
     %0 = ttg.convert_layout %arg0 : tensor<32x32xf16, #blocked> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked1}>>
     tt.return
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -38,19 +38,19 @@ public:
         triton::gpu::toLinearLayout(dstTy).removeZeroBasesAlongDim(kReg);
     auto conversion = minimalCvtLayout(srcLayout, dstLayout);
     if (llvm::to_vector(conversion.getOutDimNames()) !=
-        SmallVector<StringAttr, 2>{kReg, kLane})
+            SmallVector<StringAttr, 2>{kReg, kLane} ||
+        !cvtNeedsWarpShuffle(op))
       return failure();
 
     auto elemTy = getTypeConverter()->convertType(srcTy.getElementType());
     int bitwidth = elemTy.isIntOrFloat() ? elemTy.getIntOrFloatBitWidth() : 64;
-    auto factors =
+    auto [pReg, shuffleMap, mixedTranspositions, nPack] =
         getWarpLayoutConvertDecomposition(srcLayout, dstLayout, bitwidth);
-    auto &[pReg, pLane, mixedTranspositions, nPack] = factors;
 
     if (mixedTranspositions.size() != 1)
       return failure();
     auto t = mixedTranspositions[0];
-    auto [rBit, lBit] = t.transposition;
+    auto [rBit, lBit] = std::pair{t.regBit, t.dstLane};
 
     // Following `transferWithinWarp` and `getWarpLayoutConvertDecomposition`,
     // an intra-warp layout conversion can be described as a permutation of
@@ -77,9 +77,9 @@ public:
     }
 
     bool isSingleTransposition =
-        mlir::triton::squareSublayoutIsIdentity(pLane, kLane);
+        mlir::triton::squareSublayoutIsIdentity(shuffleMap, kLane);
 
-    const auto &laneBases = pLane.getBases().lookup(kLane);
+    const auto &laneBases = shuffleMap.getBases().lookup(kLane);
     auto next = [&](size_t b) { return llvm::Log2_32(laneBases[b][0]); };
     for (size_t b = 0; b < laneBases.size(); ++b) {
       if (b == 4 || b == 5)
@@ -111,23 +111,10 @@ public:
     };
 
     auto inVals = unpackUniqueTensorElements(loc, adaptor.getSrc(), rewriter);
-    // The input values may require broadcasting so that the conversion can be
-    // described as a permutation. This does not cost anything for simple cases.
-    int regDim = inVals.size();
-    int pRegDim = pReg.getInDimSize(kReg);
-    if (pRegDim > regDim) {
-      SmallVector<Value> original(inVals.begin(), inVals.end());
-      inVals.clear();
-      inVals.reserve(pRegDim);
-      while (inVals.size() < pRegDim)
-        inVals.append(original.begin(), original.end());
-      regDim = pRegDim;
-    }
-
-    // Apply pReg.
+    int regDim = pReg.getInDimSize(kReg);
     SmallVector<Value> newInVals(regDim);
-    for (const auto &[i, v] : llvm::enumerate(inVals))
-      newInVals[pReg.apply({{kReg, i}})[0].second] = v;
+    for (int i = 0; i < regDim; ++i)
+      newInVals[pReg.apply({{kReg, i}})[0].second] = inVals[i % inVals.size()];
     inVals = std::move(newInVals);
 
     // Handle register packing.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -122,7 +122,7 @@ struct ConvertLayoutOpSwizzlingConversion
     auto reps = LinearLayout::identity1D(nReps, kReg, kReps);
 
     auto totalStoreCvt = srcLayout.invertAndCompose(smem);
-    auto totalLoadCvt = invertAndComposeBlockLocal(smem, dstLayout);
+    auto totalLoadCvt = invertAndComposeLocal(smem, dstLayout, {kBlock});
 
     // The permutation exists by construction of the reps dimension in
     // optimalSwizzling

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1298,15 +1298,15 @@ struct AsyncTMACopyGlobalToLocalOpConversion
 
     int rank = op.getCoord().size();
 
+    auto ctx = op.getContext();
+    auto kBlock = str_attr("block");
     auto msgToPackedOffset = getMsgToPackedOffsetLayout(smemTy, tmaMode);
     auto smemLayout = ttg::toLinearLayout(smemTy);
     auto msgToShared =
-        invertAndComposeBlockLocal(smemLayout, msgToPackedOffset);
+        invertAndComposeLocal(smemLayout, msgToPackedOffset, {kBlock});
     auto msgToOffset = getMsgToUnpackedOffsetLayout(msgToPackedOffset, smemTy);
 
-    auto ctx = op.getContext();
     auto kMsg = str_attr("msg");
-    auto kBlock = str_attr("block");
     const auto numCopies = msgToOffset.getInDimSize(kMsg);
     auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
     // We multicast if the flag is on and the block layout has broadcasting
@@ -1674,7 +1674,7 @@ static LogicalResult iterateGatherScatterIndices(
   // of the 0th element of row 4 will not be at the start of the segment.
   LinearLayout sharedLayout = getUnswizzledLayout(smemType);
   LinearLayout msgToShared =
-      invertAndComposeBlockLocal(sharedLayout, msgLayout);
+      invertAndComposeLocal(sharedLayout, msgLayout, {kBlock});
 
   // If there are too few rows, warps will have redundant data.
   auto freeVars = xCoordsLayout.getFreeVariableMasks();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -262,15 +262,16 @@ struct AsyncSharedStoreOpConversion
         loc, adaptor.getMbarrier(),
         typeConverter->convertType(mbarrierTy.getElementType()), rewriter);
 
+    auto kBlock = str_attr("block");
     auto regLayout = toLinearLayout(srcTy);
     auto freeVarMasks = regLayout.getFreeVariableMasks();
-    freeVarMasks[str_attr("block")] = 0;
+    freeVarMasks[kBlock] = 0;
     Value threadPred =
         emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
     Value mapPred = threadPred ? threadPred : b.true_val();
     regLayout = regLayout.removeZeroBasesAlongDim(str_attr("register"));
     auto sharedLayout = toLinearLayoutIgnoringPadding(dstTy);
-    auto cvt = invertAndComposeBlockLocal(sharedLayout, regLayout);
+    auto cvt = invertAndComposeLocal(sharedLayout, regLayout, {kBlock});
     auto values = unpackUniqueTensorElements(loc, adaptor.getSrc(), rewriter);
     Value currentCTAId = targetInfo.getClusterCTAId(rewriter, loc);
     Value mbarrierPtr = mbarrierMemObj.getBase();

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -585,7 +585,7 @@ TEST_F(LinearLayoutTest, InvertAndComposeBlockLocal) {
 
   EXPECT_FALSE(
       regLayout.invertAndCompose(memLayout).isIdentityOnOutDim(S("block")));
-  auto local = invertAndComposeBlockLocal(memLayout, regLayout);
+  auto local = invertAndComposeLocal(memLayout, regLayout, {S("block")});
   auto expected =
       LinearLayout({{S("register"), {}},
                     {S("lane"), {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}},
@@ -608,8 +608,8 @@ TEST_F(LinearLayoutTest, InvertAndComposeBlockLocal) {
                    {S("dim")});
   EXPECT_FALSE(partiallyDistributedReg.invertAndCompose(partiallyBroadcastMem)
                    .isIdentityOnOutDim(S("block")));
-  auto partiallyLocal = invertAndComposeBlockLocal(partiallyBroadcastMem,
-                                                   partiallyDistributedReg);
+  auto partiallyLocal = invertAndComposeLocal(
+      partiallyBroadcastMem, partiallyDistributedReg, {S("block")});
   auto partiallyExpected =
       LinearLayout({{S("register"), {}},
                     {S("lane"), {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}},
@@ -629,7 +629,7 @@ TEST_F(LinearLayoutTest, InvertAndComposeBlockLocal) {
                                      {S("warp"), {}},
                                      {S("block"), {{1}}}},
                                     {S("dim")});
-  EXPECT_EQ(invertAndComposeBlockLocal(partitionedMem, transposedReg),
+  EXPECT_EQ(invertAndComposeLocal(partitionedMem, transposedReg, {S("block")}),
             transposedReg.invertAndCompose(partitionedMem));
 }
 


### PR DESCRIPTION
This is the warp shuffle generalisation of https://github.com/triton-lang/triton/pull/10647

The idea here is to not consider the warp / block bases during the transposition algorithm and then patch-up the result during the lowering, same as in #10647