### PR TITLE
[KERNELS] Correct shared-memory budgeting for FP4 reduction epilogues

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -571,7 +571,10 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
             if c_dtype.is_nvfp4
             else FnSpecs(FnName.QUANTIZE_MXFP8.name, quantize_mxfp8_fn, (), ())
         )
-        epilogue = Epilogue(epilogue_spec, tuple(), tuple(), effective_itemsize=2.0 if c_dtype.is_nvfp4 else 6.0)
+        effective_itemsize = 2.0 if c_dtype.is_nvfp4 else 6.0
+        if c_dtype.is_nvfp4 and fused_activation is not None and fused_activation.specs.reduction_n > 1:
+            effective_itemsize = 4 * fused_activation.specs.reduction_n
+        epilogue = Epilogue(epilogue_spec, tuple(), tuple(), effective_itemsize=effective_itemsize)
 
 
     # --- triton implementation ---

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -182,17 +182,35 @@ def test_compute_num_warps_uses_two_warp_floor():
     (64, 8, 4, 3),
 ])
 def test_fp4_reduction_stage_budget(monkeypatch, block_m, num_warps, epilogue_subtile, expected_stages):
-    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _: SimpleNamespace(
-        shared_memory_per_block_optin=232448, multi_processor_count=148))
+    monkeypatch.setattr(torch.cuda, "get_device_properties",
+                        lambda _: SimpleNamespace(shared_memory_per_block_optin=232448, multi_processor_count=148))
     monkeypatch.setattr(opt_flags_nvidia.target_info, "cuda_capability_geq", lambda *_: True)
     monkeypatch.setattr(opt_flags, "cuda_capability_geq", lambda *_: True)
-    scale = torch.empty((1,), dtype=torch.float8_e4m3fn)
+    scale = torch.empty((1, ), dtype=torch.float8_e4m3fn)
     precision = PrecisionConfig(a_mx_scale=scale, b_mx_scale=scale)
     flags = opt_flags.make_default_opt_flags_nvidia(
-        FP4, FP4, FP4, precision, 1, 256, 512, 1024, None, True, False, False, 8, False, False,
-        {"block_m": block_m, "block_n": 256, "block_k": 256, "num_warps": num_warps,
-         "epilogue_subtile": epilogue_subtile, "is_persistent": True, "split_k": 1},
-        torch.float32, mx_block_size=16, epilogue_reduction_n=2,
+        FP4,
+        FP4,
+        FP4,
+        precision,
+        1,
+        256,
+        512,
+        1024,
+        None,
+        True,
+        False,
+        False,
+        8,
+        False,
+        False,
+        {
+            "block_m": block_m, "block_n": 256, "block_k": 256, "num_warps": num_warps, "epilogue_subtile":
+            epilogue_subtile, "is_persistent": True, "split_k": 1
+        },
+        torch.float32,
+        mx_block_size=16,
+        epilogue_reduction_n=2,
     )
     assert flags.num_stages == expected_stages
 
@@ -205,16 +223,27 @@ def test_fp4_reduction_stage_budget(monkeypatch, block_m, num_warps, epilogue_su
     ({"is_persistent": False}, 4),
 ])
 def test_fp4_reduction_stage_budget_other_epilogues(monkeypatch, overrides, expected_stages):
-    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _: SimpleNamespace(
-        shared_memory_per_block_optin=232448))
+    monkeypatch.setattr(torch.cuda, "get_device_properties",
+                        lambda _: SimpleNamespace(shared_memory_per_block_optin=232448))
     monkeypatch.setattr(opt_flags_nvidia.target_info, "cuda_capability_geq", lambda *_: True)
-    scale = torch.empty((1,), dtype=torch.float8_e4m3fn)
+    scale = torch.empty((1, ), dtype=torch.float8_e4m3fn)
     args = {
         "precision_config": PrecisionConfig(a_mx_scale=scale, b_mx_scale=scale),
-        "is_persistent": True, "block_m": 128, "block_n": 256, "block_k": 256,
-        "out_dtype": FP4, "lhs_dtype": FP4, "rhs_dtype": FP4, "x_transpose": False,
-        "epilogue_effective_itemsize": 8, "has_y_acc_in": False, "mx_block_size": 16,
-        "epilogue_reduction_n": 2, "epilogue_subtile": 2, "num_warps": 8, "occupancy_target": 1,
+        "is_persistent": True,
+        "block_m": 128,
+        "block_n": 256,
+        "block_k": 256,
+        "out_dtype": FP4,
+        "lhs_dtype": FP4,
+        "rhs_dtype": FP4,
+        "x_transpose": False,
+        "epilogue_effective_itemsize": 8,
+        "has_y_acc_in": False,
+        "mx_block_size": 16,
+        "epilogue_reduction_n": 2,
+        "epilogue_subtile": 2,
+        "num_warps": 8,
+        "occupancy_target": 1,
     }
     assert opt_flags_nvidia.compute_num_stages(**(args | overrides)) == expected_stages
 
@@ -223,7 +252,7 @@ def test_fp4_reduction_stage_budget_other_epilogues(monkeypatch, overrides, expe
 @pytest.mark.parametrize("num_warps", [4, 8])
 @pytest.mark.parametrize("epilogue_subtile", [1, 2, 4])
 def test_matmul_fp4_reduction_shared_memory(device, monkeypatch, block_m, num_warps, epilogue_subtile,
-                                           swizzle_lhs_scale):
+                                            swizzle_lhs_scale):
     if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
         pytest.skip("requires CUDA")
     if torch.cuda.get_device_capability()[0] != 10:
@@ -231,10 +260,11 @@ def test_matmul_fp4_reduction_shared_memory(device, monkeypatch, block_m, num_wa
 
     torch.manual_seed(0)
     m, n, k = 255, 512, 1024
-    a, a_scale = downcast_to_mxfp(torch.randn((m, k), device=device, dtype=torch.bfloat16), torch.uint8,
-                                 axis=-1, scale_dtype=torch.float8_e4m3fn, microblock_size=16)
-    b, b_scale = downcast_to_mxfp(torch.randn((n, k), device=device, dtype=torch.bfloat16).T * 0.01,
-                                 torch.uint8, axis=-2, scale_dtype=torch.float8_e4m3fn, microblock_size=16)
+    a, a_scale = downcast_to_mxfp(torch.randn((m, k), device=device, dtype=torch.bfloat16), torch.uint8, axis=-1,
+                                  scale_dtype=torch.float8_e4m3fn, microblock_size=16)
+    b, b_scale = downcast_to_mxfp(
+        torch.randn((n, k), device=device, dtype=torch.bfloat16).T * 0.01, torch.uint8, axis=-2,
+        scale_dtype=torch.float8_e4m3fn, microblock_size=16)
     a, b = wrap_torch_tensor(a, dtype=FP4), wrap_torch_tensor(b, dtype=FP4)
     a_scale, b_scale = wrap_torch_tensor(a_scale), wrap_torch_tensor(b_scale)
     if swizzle_lhs_scale:
@@ -242,14 +272,21 @@ def test_matmul_fp4_reduction_shared_memory(device, monkeypatch, block_m, num_wa
     b_scale = convert_layout(b_scale, BlackwellMXScaleLayout())
     c_scale = torch.empty((m, n // 2 // NVFP_BLOCK_SIZE.value), device=device, dtype=torch.float8_e4m3fn)
     precision = PrecisionConfig(
-        a_mx_scale=a_scale, b_mx_scale=b_scale, c_mx_scale=c_scale,
-        a_microblock_size=16, b_microblock_size=16, c_microblock_size=16,
-        c_value_pack_factor=2, out_dtype=torch.uint8,
+        a_mx_scale=a_scale,
+        b_mx_scale=b_scale,
+        c_mx_scale=c_scale,
+        a_microblock_size=16,
+        b_microblock_size=16,
+        c_microblock_size=16,
+        c_value_pack_factor=2,
+        out_dtype=torch.uint8,
     )
     activation = FusedActivation(FnSpecs("swiglu", swiglu_fn, ("alpha", "limit"), reduction_n=2), (1.0, 7.0))
     epilogue = Epilogue(FnSpecs(FnName.QUANTIZE_NVFP4.name, quantize_nvfp4_fn, (), ()), effective_itemsize=8)
-    constraints = {"block_m": block_m, "block_n": 256, "block_k": 256, "num_warps": num_warps,
-                   "epilogue_subtile": epilogue_subtile, "is_persistent": True, "split_k": 1}
+    constraints = {
+        "block_m": block_m, "block_n": 256, "block_k": 256, "num_warps": num_warps, "epilogue_subtile":
+        epilogue_subtile, "is_persistent": True, "split_k": 1
+    }
     with scoped_opt_flags_constraints(constraints | {"num_stages": 1}):
         expected = matmul(a, b, None, precision_config=precision, fused_activation=activation, epilogue=epilogue)
     expected_scale = c_scale.clone()

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -1,18 +1,23 @@
+from types import SimpleNamespace
+
 import pytest
 import torch
 import triton
 import triton.language as tl
 from triton._internal_testing import is_cuda
 
-from triton_kernels.matmul import matmul, matmul_torch, PrecisionConfig
+from triton_kernels.matmul import Epilogue, FnName, FusedActivation, PrecisionConfig, matmul, matmul_torch
+from triton_kernels.matmul_details import opt_flags
 from triton_kernels.matmul_details._matmul import _compute_packed_n_w
 from triton_kernels.matmul_details.opt_flags import InapplicableConstraint, scoped_opt_flags_constraints
 from triton_kernels.matmul_details.opt_flags_details import opt_flags_nvidia
-from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, downcast_to_mxfp
-from triton_kernels.tensor import FP4, UINT8, Storage, Tensor, convert_layout, wrap_torch_tensor
+from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, NVFP_BLOCK_SIZE, downcast_to_mxfp, quantize_nvfp4_fn
+from triton_kernels.specialize import FnSpecs
+from triton_kernels.swiglu import swiglu_fn
+from triton_kernels.tensor import BF16, FP4, UINT8, Storage, Tensor, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 from triton_kernels.tensor_details.layout import BlackwellMX4ValueShuffledLayout
-from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellMXScaleLayout
+from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellActMXScaleLayout, BlackwellMXScaleLayout
 from triton_kernels.tensor_details.ragged_tensor import make_ragged_tensor_metadata_torch
 from triton_kernels.testing import assert_close
 
@@ -165,6 +170,109 @@ def test_compute_num_warps_uses_two_warp_floor():
     precision_config = PrecisionConfig()
     assert opt_flags_nvidia.compute_num_warps(16, 256, False, precision_config, {}) == 2
     assert opt_flags_nvidia.compute_num_warps(16, 256, False, precision_config, {"num_warps": 1}) == 1
+
+
+@pytest.mark.parametrize("block_m,num_warps,epilogue_subtile,expected_stages", [
+    (32, 4, 1, 4),
+    (128, 8, 2, 1),
+    (128, 4, 1, 3),
+    (128, 4, 2, 3),
+    (128, 4, 4, 3),
+    (64, 4, 4, 4),
+    (64, 8, 4, 3),
+])
+def test_fp4_reduction_stage_budget(monkeypatch, block_m, num_warps, epilogue_subtile, expected_stages):
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _: SimpleNamespace(
+        shared_memory_per_block_optin=232448, multi_processor_count=148))
+    monkeypatch.setattr(opt_flags_nvidia.target_info, "cuda_capability_geq", lambda *_: True)
+    monkeypatch.setattr(opt_flags, "cuda_capability_geq", lambda *_: True)
+    scale = torch.empty((1,), dtype=torch.float8_e4m3fn)
+    precision = PrecisionConfig(a_mx_scale=scale, b_mx_scale=scale)
+    flags = opt_flags.make_default_opt_flags_nvidia(
+        FP4, FP4, FP4, precision, 1, 256, 512, 1024, None, True, False, False, 8, False, False,
+        {"block_m": block_m, "block_n": 256, "block_k": 256, "num_warps": num_warps,
+         "epilogue_subtile": epilogue_subtile, "is_persistent": True, "split_k": 1},
+        torch.float32, mx_block_size=16, epilogue_reduction_n=2,
+    )
+    assert flags.num_stages == expected_stages
+
+
+@pytest.mark.parametrize("overrides,expected_stages", [
+    ({"epilogue_reduction_n": 1}, 1),
+    ({"epilogue_effective_itemsize": 1}, 3),
+    ({"out_dtype": BF16}, 1),
+    ({"has_y_acc_in": True}, 2),
+    ({"is_persistent": False}, 4),
+])
+def test_fp4_reduction_stage_budget_other_epilogues(monkeypatch, overrides, expected_stages):
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _: SimpleNamespace(
+        shared_memory_per_block_optin=232448))
+    monkeypatch.setattr(opt_flags_nvidia.target_info, "cuda_capability_geq", lambda *_: True)
+    scale = torch.empty((1,), dtype=torch.float8_e4m3fn)
+    args = {
+        "precision_config": PrecisionConfig(a_mx_scale=scale, b_mx_scale=scale),
+        "is_persistent": True, "block_m": 128, "block_n": 256, "block_k": 256,
+        "out_dtype": FP4, "lhs_dtype": FP4, "rhs_dtype": FP4, "x_transpose": False,
+        "epilogue_effective_itemsize": 8, "has_y_acc_in": False, "mx_block_size": 16,
+        "epilogue_reduction_n": 2, "epilogue_subtile": 2, "num_warps": 8, "occupancy_target": 1,
+    }
+    assert opt_flags_nvidia.compute_num_stages(**(args | overrides)) == expected_stages
+
+
+@pytest.mark.parametrize("block_m,swizzle_lhs_scale", [(32, False), (64, False), (128, False), (128, True)])
+@pytest.mark.parametrize("num_warps", [4, 8])
+@pytest.mark.parametrize("epilogue_subtile", [1, 2, 4])
+def test_matmul_fp4_reduction_shared_memory(device, monkeypatch, block_m, num_warps, epilogue_subtile,
+                                           swizzle_lhs_scale):
+    if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
+        pytest.skip("requires CUDA")
+    if torch.cuda.get_device_capability()[0] != 10:
+        pytest.skip("requires Blackwell")
+
+    torch.manual_seed(0)
+    m, n, k = 255, 512, 1024
+    a, a_scale = downcast_to_mxfp(torch.randn((m, k), device=device, dtype=torch.bfloat16), torch.uint8,
+                                 axis=-1, scale_dtype=torch.float8_e4m3fn, microblock_size=16)
+    b, b_scale = downcast_to_mxfp(torch.randn((n, k), device=device, dtype=torch.bfloat16).T * 0.01,
+                                 torch.uint8, axis=-2, scale_dtype=torch.float8_e4m3fn, microblock_size=16)
+    a, b = wrap_torch_tensor(a, dtype=FP4), wrap_torch_tensor(b, dtype=FP4)
+    a_scale, b_scale = wrap_torch_tensor(a_scale), wrap_torch_tensor(b_scale)
+    if swizzle_lhs_scale:
+        a_scale = convert_layout(a_scale, BlackwellActMXScaleLayout(None))
+    b_scale = convert_layout(b_scale, BlackwellMXScaleLayout())
+    c_scale = torch.empty((m, n // 2 // NVFP_BLOCK_SIZE.value), device=device, dtype=torch.float8_e4m3fn)
+    precision = PrecisionConfig(
+        a_mx_scale=a_scale, b_mx_scale=b_scale, c_mx_scale=c_scale,
+        a_microblock_size=16, b_microblock_size=16, c_microblock_size=16,
+        c_value_pack_factor=2, out_dtype=torch.uint8,
+    )
+    activation = FusedActivation(FnSpecs("swiglu", swiglu_fn, ("alpha", "limit"), reduction_n=2), (1.0, 7.0))
+    epilogue = Epilogue(FnSpecs(FnName.QUANTIZE_NVFP4.name, quantize_nvfp4_fn, (), ()), effective_itemsize=8)
+    constraints = {"block_m": block_m, "block_n": 256, "block_k": 256, "num_warps": num_warps,
+                   "epilogue_subtile": epilogue_subtile, "is_persistent": True, "split_k": 1}
+    with scoped_opt_flags_constraints(constraints | {"num_stages": 1}):
+        expected = matmul(a, b, None, precision_config=precision, fused_activation=activation, epilogue=epilogue)
+    expected_scale = c_scale.clone()
+    c_scale.fill_(float("nan"))
+
+    launches = []
+    original_run = triton.runtime.JITFunction.run
+
+    def capture(kernel, *args, **kwargs):
+        result = original_run(kernel, *args, **kwargs)
+        if result.name.startswith("_p_matmul"):
+            launches.append(result.metadata)
+        return result
+
+    monkeypatch.setattr(triton.runtime.JITFunction, "run", capture)
+    with scoped_opt_flags_constraints(constraints):
+        actual = matmul(a, b, None, precision_config=precision, fused_activation=activation, epilogue=epilogue)
+    torch.cuda.synchronize()
+    assert launches
+    assert all(launch.shared <= torch.cuda.get_device_properties(0).shared_memory_per_block_optin
+               for launch in launches)
+    assert torch.equal(actual, expected)
+    assert torch.equal(c_scale.view(torch.uint8), expected_scale.view(torch.uint8))
 
 
 def test_matmul_blackwell_scale_small_n(device):

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -48,6 +48,8 @@ class Epilogue:
     specs: FnSpecs = FnSpecs.default()
     fn_arg_values_matmul: tuple[object, ...] = tuple()
     fn_arg_values_finalize: tuple[object, ...] = tuple()
+    # Shared-memory bytes per output element after the activation's N reduction.
+    # A pairwise FP32 reduction needs 8 bytes even when its output is packed FP4.
     effective_itemsize: float | None = None
 
 class FnName(Enum):

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -426,7 +426,7 @@ def make_default_opt_flags_nvidia(
         ns = opt_flags_nvidia.compute_num_stages(*compute_num_stages_args, epilogue_subtile=ep,
                                                  occupancy_target=occupancy_target,
                                                  swap_xw=swap_xw,
-                                                 w_transpose=w_transpose)
+                                                 w_transpose=w_transpose, num_warps=num_warps)
         if ns > num_stages:
             epilogue_subtile, num_stages = ep, ns
 

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -142,6 +142,7 @@ def compute_num_stages(
     epilogue_reduction_n=1,
     *,
     epilogue_subtile,
+    num_warps,
     occupancy_target,
     swap_xw=None,
     w_transpose=False,
@@ -185,6 +186,9 @@ def compute_num_stages(
         scale_block_size = mx_block_size or int(MXFP_BLOCK_SIZE)
         stage_size += block_n * (block_k // scale_block_size)
 
+    fp4_reduction = (has_native_mxfp and lhs_dtype == rhs_dtype == out_dtype == FP4
+                     and epilogue_reduction_n == 2 and epilogue_effective_itemsize == 8
+                     and not has_y_acc_in)
     if is_persistent:
         # Per-stage wait barrier
         stage_size += 8
@@ -209,6 +213,23 @@ def compute_num_stages(
             # for the unreduced output tile before the narrower TMA-store tile.
             if epilogue_reduction_n > 1 or epilogue_subtile > 1:
                 epilogue_smem += int(block_m * block_n * out_itemsize)
+        if fp4_reduction:
+            # FP32 splitting and packed stores reuse conversion scratch.
+            epilogue_smem = int(block_m * acc_block_n * acc_size)
+            if swap_xw and block_m == 128 and num_warps == 4:
+                # The transposed four-warp layout reuses scratch across
+                # 128-column replicas of the accumulator.
+                epilogue_smem = block_m * min(block_n, 128) * 4
+            elif swap_xw and num_warps == 4 and epilogue_subtile > 1:
+                # Forming four subtiles first splits the accumulator in half.
+                epilogue_smem = max(epilogue_smem, block_m * (block_n // 2) * 4)
+            elif swap_xw and num_warps >= 8:
+                # Subtile splitting can convert the full FP32 tile across warps.
+                epilogue_smem = max(epilogue_smem, block_m * block_n * 4)
+            # Scale-pipeline barriers plus alignment and warp-specialization
+            # bookkeeping are live alongside the operand and conversion buffers.
+            stage_size += 16
+            smem_capacity -= 256
         smem_capacity -= epilogue_smem
         if x_transpose:
             smem_capacity -= int(block_m * block_k * act_size)

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -186,9 +186,8 @@ def compute_num_stages(
         scale_block_size = mx_block_size or int(MXFP_BLOCK_SIZE)
         stage_size += block_n * (block_k // scale_block_size)
 
-    fp4_reduction = (has_native_mxfp and lhs_dtype == rhs_dtype == out_dtype == FP4
-                     and epilogue_reduction_n == 2 and epilogue_effective_itemsize == 8
-                     and not has_y_acc_in)
+    fp4_reduction = (has_native_mxfp and lhs_dtype == rhs_dtype == out_dtype == FP4 and epilogue_reduction_n == 2
+                     and epilogue_effective_itemsize == 8 and not has_y_acc_in)
     if is_persistent:
         # Per-stage wait barrier
         stage_size += 8


### PR DESCRIPTION
## Summary

Persistent Blackwell FP4 matmul can underestimate the shared memory needed to split FP32 accumulators during fused reductions, selecting too many pipeline stages and causing launch failures. It can also double-count reused scratch buffers and select too few stages.

This change makes stage selection account for the selected warp count, accumulator-conversion scratch, buffer reuse, and synchronization/alignment overhead. It applies to FP4 input/output epilogues with a pairwise reduction and an eight-byte effective item size. Other epilogue configurations retain their existing heuristic.

The epilogue size hint is documented as bytes per reduced output element, and the NVFP4 reduction test setup supplies the corresponding FP32 footprint.

Measured on NVIDIA GB300 with Triton 3.8.0. All counts are bytes.
“Real” is compiler-reported allocation; “Before” and “After” are budget estimates.
Tile dimensions, stage count, and the eight-byte epilogue hint are held fixed.

Shared-memory limit: **232,448 bytes per block**.

| Tile M×N×K | Warps / subtiles / stages | Real | Before | After | Before → After decision |
|---|---|---:|---:|---:|---|
| 32×256×256 | 4 / 1 / 5 | 239,760 | 248,360 | 240,504 | Reject → Reject |
| 128×256×256 | 8 / 2 / 2 | 241,724 | 194,576 | 241,968 | Accept → Reject |
| 128×256×256 | 4 / 1 / 3 | 231,516 | 317,464 | 231,752 | Reject → Accept |
| 128×256×256 | 4 / 4 / 3 | 231,516 | 216,088 | 231,752 | Accept → Accept |

The first row uses unswizzled activation scales; the remaining rows use swizzled scales.
The corrected estimates exceed actual allocation by 236–744 bytes.

## Lines Changed

| Type | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | 153 | 5 | +148 |
| Core Logic | 23 | 1 | +22 |
| AutoGenerated | 0 | 0 | 0 |
| Total | 176 | 6 | +170 |

## Reviewers Guide

Within `python/triton_kernels/`:

- `triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py`: shared-memory budget correction.
- `triton_kernels/matmul_details/opt_flags.py`: propagation of the selected warp count.
- `triton_kernels/matmul.py`: documentation of the epilogue size hint.
- `tests/test_matmul_details/test_opt_flags_nvidia.py` and `tests/test_matmul.py`: regression coverage and corrected reduction size hints.

No file movements or generated files.