### PR TITLE
[KERNELS] Support unscaled FP8 E4M3 matmul with FP16/BF16

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -360,7 +360,7 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
         if device_capability < 10 and (a_dtype.is_nvfp4 or b_dtype.is_nvfp4 or c_dtype.is_nvfp4):
             pytest.skip("NVFP4 matmul only tested on Blackwell or newer")
         if device_capability < 9 and (a_dtype.uses_fp8e4nv or b_dtype.uses_fp8e4nv or c_dtype.uses_fp8e4nv):
-            pytest.skip("FP8 E4M3FN is not supported on A100")
+            pytest.skip("FP8 E4M3FN tests require Hopper or newer")
         if b_dtype.is_any_float8 and device_capability < 9:
             pytest.skip("Float8 not tested on A100")
         if act_dtype_str == "float16" and b_dtype.has_mx_scale and device_capability >= 10:

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -154,13 +154,12 @@ def _build_test_op_cases():
         Case(*even_shape, "ragged", "float8_e5m2", "float8_e5m2", epilogue_subtile=val)
         for val in (1, 2, 4)
     ])
-    if is_cuda():
-        test_cases.extend([
-            Case(*odd_shape2, "plain", lhs, rhs, dtype, b_transpose=b_transpose)
-            for dtype in ("float16", "bfloat16")
-            for lhs, rhs in (("float8_e4m3fn", dtype), (dtype, "float8_e4m3fn"))
-            for b_transpose in (False, True)
-        ])
+    test_cases.extend([
+        Case(*odd_shape2, "plain", lhs, rhs, dtype, b_transpose=b_transpose)
+        for dtype in ("float16", "bfloat16")
+        for lhs, rhs in (("float8_e4m3fn", dtype), (dtype, "float8_e4m3fn"))
+        for b_transpose in (False, True)
+    ])
     # fp32
     test_cases.extend([
         Case(1024, 1000, 2048, "ragged", "float32", "float32", b_transpose=True)
@@ -373,6 +372,9 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
     elif is_hip():
         if a_dtype.is_nvfp4 or b_dtype.is_nvfp4 or c_dtype.is_nvfp4:
             pytest.skip("NVFP4 matmul not tested on AMD GPU")
+        if (a_dtype.has_global_scale != b_dtype.has_global_scale
+                and not (a_dtype.has_mx_scale or b_dtype.has_mx_scale)):
+            pytest.skip("Unscaled mixed FP8 matmul is only tested on CUDA")
         if a_dtype.is_any_float8 and b_dtype.has_mx_scale and not (is_hip_cdna4() or is_hip_gfx1250()):
             pytest.skip("float8 x mx only supported on CDNA4 and gfx1250")
         if a_dtype.is_any_float8 and b_dtype.name == "mxfloat8_e4m3fn":

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -659,6 +659,32 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
                f"ref_y_scale: {ref_y_scale}, tri_y_scale: {tri_y_scale.item()}"
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("fp8_lhs", [False, True])
+@pytest.mark.parametrize("b_transpose", [False, True])
+@pytest.mark.parametrize("block_m, is_persistent", [(32, False), (16, True), (64, True), (128, True)])
+def test_matmul_unscaled_mixed_fp8(dtype, fp8_lhs, b_transpose, block_m, is_persistent, device):
+    if not is_cuda() or torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("requires Hopper or newer")
+
+    torch.manual_seed(0)
+    m, n, k = 273, 544, 576
+    a_dtype, b_dtype = (torch.float8_e4m3fn, dtype) if fp8_lhs else (dtype, torch.float8_e4m3fn)
+    a = torch.randn((m, k), device=device).to(a_dtype)
+    b = torch.randn((k, n), device=device).to(b_dtype)
+    if b_transpose:
+        b = b.mT.contiguous().mT
+
+    # Small tiles swap operands; larger tiles stress shared memory and TMEM.
+    with opt_flags.scoped_opt_flags_constraints(dict(
+        block_m=block_m, block_n=256, block_k=128, split_k=1, is_persistent=is_persistent,
+    )):
+        actual = matmul(a, b, None, precision_config=PrecisionConfig(out_dtype=dtype))
+
+    expected = torch.matmul(a.float(), b.float()).to(dtype)
+    assert_close(expected, actual)
+
+
 @pytest.mark.parametrize("is_persistent", [False, True])
 @pytest.mark.parametrize("n", [960, 1024, 1536, 1568, 1600, 1632, 1664])
 def test_mxfp8_act_scale_store_zeroes_partial_group(n, is_persistent, device):

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -41,7 +41,7 @@ class DType:
         self.is_nvfp4 = dtype_str in {"nvfp4_e2m1", "nvfp4_e2m1_fiber"}
         self.has_mx_scale = dtype_str.startswith("mx") or self.is_nvfp4
         self.is_any_float8 = "float8" in dtype_str
-        self.uses_fp8e4nv = dtype_str in {"mxfloat8_e4m3fn", "nvfp4_e2m1", "nvfp4_e2m1_fiber"}
+        self.uses_fp8e4nv = dtype_str in {"float8_e4m3fn", "mxfloat8_e4m3fn", "nvfp4_e2m1", "nvfp4_e2m1_fiber"}
         if dtype_str in {"float4_e2m1", "mxfloat4_e2m1", "nvfp4_e2m1", "nvfp4_e2m1_fiber"}:
             self.torch_dtype = torch.uint8
         else:
@@ -154,6 +154,13 @@ def _build_test_op_cases():
         Case(*even_shape, "ragged", "float8_e5m2", "float8_e5m2", epilogue_subtile=val)
         for val in (1, 2, 4)
     ])
+    if is_cuda():
+        test_cases.extend([
+            Case(*odd_shape2, "plain", lhs, rhs, dtype, b_transpose=b_transpose)
+            for dtype in ("float16", "bfloat16")
+            for lhs, rhs in (("float8_e4m3fn", dtype), (dtype, "float8_e4m3fn"))
+            for b_transpose in (False, True)
+        ])
     # fp32
     test_cases.extend([
         Case(1024, 1000, 2048, "ragged", "float32", "float32", b_transpose=True)
@@ -353,7 +360,7 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
         if device_capability < 10 and (a_dtype.is_nvfp4 or b_dtype.is_nvfp4 or c_dtype.is_nvfp4):
             pytest.skip("NVFP4 matmul only tested on Blackwell or newer")
         if device_capability < 9 and (a_dtype.uses_fp8e4nv or b_dtype.uses_fp8e4nv or c_dtype.uses_fp8e4nv):
-            pytest.skip("MXFP8/NVFP4 tensors use fp8e4nv, which is not supported on A100")
+            pytest.skip("FP8 E4M3FN is not supported on A100")
         if b_dtype.is_any_float8 and device_capability < 9:
             pytest.skip("Float8 not tested on A100")
         if act_dtype_str == "float16" and b_dtype.has_mx_scale and device_capability >= 10:
@@ -442,7 +449,8 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
         if block_m == 16:
             pytest.skip("PassManager::run failed from Triton compiler")
     # TODO: should construct the test case differently rather than overriding here
-    if b_dtype.is_any_float8 and device_capability < 10:
+    if (b_dtype.is_any_float8 and device_capability < 10
+            and not (weight_dtype_str == "float8_e4m3fn" and act_dtype_str in ("float16", "bfloat16"))):
         b_transpose = True
 
     torch.manual_seed(0)
@@ -526,7 +534,7 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
 
     # --- create precision config ---
     wrap_list = lambda vals: torch.tensor(vals, dtype=torch.float32, device=device)
-    flex_a = InFlexData(c_dtype.torch_dtype, wrap_list([1.25])) if c_dtype.has_global_scale else InFlexData()
+    flex_a = InFlexData(a_dtype.torch_dtype, wrap_list([1.25])) if a_dtype.has_global_scale else InFlexData()
     flex_b = InFlexData(b_dtype.torch_dtype, wrap_list([1.25])) if b_dtype.has_global_scale else InFlexData()
     if c_dtype.has_global_scale:
         flex_c = OutFlexData(c_dtype.torch_dtype, wrap_list([4.00]), wrap_list([0]), None)
@@ -659,34 +667,26 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
                f"ref_y_scale: {ref_y_scale}, tri_y_scale: {tri_y_scale.item()}"
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("fp8_lhs", [False, True])
-@pytest.mark.parametrize("b_transpose", [False, True])
-@pytest.mark.parametrize("shape, constraints", [
-    ((273, 544, 576), dict(block_m=block_m, block_n=256, block_k=128, split_k=1, is_persistent=is_persistent))
-    for block_m, is_persistent in [(32, False), (16, True), (64, True)]
-] + [
-    ((273, 544, 576), dict(block_m=128, block_n=256, block_k=128, split_k=1, is_persistent=True, swap_xw=False)),
-    ((128, 256, 1024), {}),
-    ((273, 544, 576), {}),
+@pytest.mark.parametrize("shape, fp8_lhs, constraints", [
+    ((273, 544, 576), True, dict(block_m=64, block_n=256, block_k=128, split_k=1, is_persistent=True)),
+    ((273, 544, 576), False, dict(block_m=128, block_n=256, block_k=128, split_k=1, is_persistent=True, swap_xw=False)),
+    ((128, 256, 1024), True, {}),
+    ((273, 544, 576), False, {}),
 ])
-def test_matmul_unscaled_mixed_fp8(dtype, fp8_lhs, b_transpose, shape, constraints, device, opt_flags_scope):
+def test_matmul_mixed_fp8_resource_limits(shape, fp8_lhs, constraints, device, opt_flags_scope):
     if not is_cuda() or torch.cuda.get_device_capability()[0] < 9:
         pytest.skip("requires Hopper or newer")
 
     torch.manual_seed(0)
     m, n, k = shape
-    a_dtype, b_dtype = (torch.float8_e4m3fn, dtype) if fp8_lhs else (dtype, torch.float8_e4m3fn)
+    a_dtype, b_dtype = (torch.float8_e4m3fn, torch.bfloat16) if fp8_lhs else (torch.bfloat16, torch.float8_e4m3fn)
     a = torch.randn((m, k), device=device).to(a_dtype)
-    b = torch.randn((k, n), device=device).to(b_dtype)
-    if b_transpose:
-        b = b.mT.contiguous().mT
+    b = torch.randn((n, k), device=device).to(b_dtype).mT
 
-    # Cover swapped operands, large tiles, and the default split-K planner.
     with opt_flags.scoped_opt_flags_constraints(constraints):
-        actual = matmul(a, b, None, precision_config=PrecisionConfig(out_dtype=dtype))
+        actual = matmul(a, b, None, precision_config=PrecisionConfig(out_dtype=torch.bfloat16))
 
-    expected = torch.matmul(a.float(), b.float()).to(dtype)
+    expected = torch.matmul(a.float(), b.float()).to(torch.bfloat16)
     assert_close(expected, actual)
 
 

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -662,23 +662,24 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("fp8_lhs", [False, True])
 @pytest.mark.parametrize("b_transpose", [False, True])
-@pytest.mark.parametrize("block_m, is_persistent", [(32, False), (16, True), (64, True), (128, True)])
-def test_matmul_unscaled_mixed_fp8(dtype, fp8_lhs, b_transpose, block_m, is_persistent, device):
+@pytest.mark.parametrize("shape, constraints", [
+    ((273, 544, 576), dict(block_m=block_m, block_n=256, block_k=128, split_k=1, is_persistent=is_persistent))
+    for block_m, is_persistent in [(32, False), (16, True), (64, True), (128, True)]
+] + [((128, 256, 1024), {})])
+def test_matmul_unscaled_mixed_fp8(dtype, fp8_lhs, b_transpose, shape, constraints, device, opt_flags_scope):
     if not is_cuda() or torch.cuda.get_device_capability()[0] < 9:
         pytest.skip("requires Hopper or newer")
 
     torch.manual_seed(0)
-    m, n, k = 273, 544, 576
+    m, n, k = shape
     a_dtype, b_dtype = (torch.float8_e4m3fn, dtype) if fp8_lhs else (dtype, torch.float8_e4m3fn)
     a = torch.randn((m, k), device=device).to(a_dtype)
     b = torch.randn((k, n), device=device).to(b_dtype)
     if b_transpose:
         b = b.mT.contiguous().mT
 
-    # Small tiles swap operands; larger tiles stress shared memory and TMEM.
-    with opt_flags.scoped_opt_flags_constraints(dict(
-        block_m=block_m, block_n=256, block_k=128, split_k=1, is_persistent=is_persistent,
-    )):
+    # Cover swapped operands, large tiles, and the default split-K planner.
+    with opt_flags.scoped_opt_flags_constraints(constraints):
         actual = matmul(a, b, None, precision_config=PrecisionConfig(out_dtype=dtype))
 
     expected = torch.matmul(a.float(), b.float()).to(dtype)

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -685,8 +685,8 @@ def test_matmul_mixed_fp8_resource_limits(shape, fp8_lhs, constraints, device, o
     a = torch.randn((m, k), device=device).to(a_dtype)
     b = torch.randn((n, k), device=device).to(b_dtype).mT
 
-    with opt_flags.scoped_opt_flags_constraints(constraints):
-        actual = matmul(a, b, None, precision_config=PrecisionConfig(out_dtype=torch.bfloat16))
+    opt_flags.update_opt_flags_constraints(constraints)
+    actual = matmul(a, b, None, precision_config=PrecisionConfig(out_dtype=torch.bfloat16))
 
     expected = torch.matmul(a.float(), b.float()).to(torch.bfloat16)
     assert_close(expected, actual)
@@ -705,13 +705,12 @@ def test_matmul_mixed_fp8_preserves_fp16_precision(fp8_lhs, is_persistent, devic
     # Rounding the FP16 operand to BF16 would erase the residual.
     b[0, :] = 1 + 2**-10
     b[1, :] = 1
-    if fp8_lhs:
-        a = a.to(torch.float8_e4m3fn)
-    else:
-        a, b = b.mT.contiguous(), a.mT.contiguous().to(torch.float8_e4m3fn)
+    a = a.to(torch.float8_e4m3fn)
+    if not fp8_lhs:
+        a, b = b.mT.contiguous(), a.mT.contiguous()
 
-    with opt_flags.scoped_opt_flags_constraints(dict(is_persistent=is_persistent, split_k=1)):
-        actual = matmul(a, b, None, precision_config=PrecisionConfig(out_dtype=torch.float16))
+    opt_flags.update_opt_flags_constraints(dict(is_persistent=is_persistent, split_k=1))
+    actual = matmul(a, b, None, precision_config=PrecisionConfig(out_dtype=torch.float16))
 
     expected = torch.full((128, 128), 2**-10, dtype=torch.float16, device=device)
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -664,8 +664,12 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
 @pytest.mark.parametrize("b_transpose", [False, True])
 @pytest.mark.parametrize("shape, constraints", [
     ((273, 544, 576), dict(block_m=block_m, block_n=256, block_k=128, split_k=1, is_persistent=is_persistent))
-    for block_m, is_persistent in [(32, False), (16, True), (64, True), (128, True)]
-] + [((128, 256, 1024), {})])
+    for block_m, is_persistent in [(32, False), (16, True), (64, True)]
+] + [
+    ((273, 544, 576), dict(block_m=128, block_n=256, block_k=128, split_k=1, is_persistent=True, swap_xw=False)),
+    ((128, 256, 1024), {}),
+    ((273, 544, 576), {}),
+])
 def test_matmul_unscaled_mixed_fp8(dtype, fp8_lhs, b_transpose, shape, constraints, device, opt_flags_scope):
     if not is_cuda() or torch.cuda.get_device_capability()[0] < 9:
         pytest.skip("requires Hopper or newer")
@@ -684,6 +688,31 @@ def test_matmul_unscaled_mixed_fp8(dtype, fp8_lhs, b_transpose, shape, constrain
 
     expected = torch.matmul(a.float(), b.float()).to(dtype)
     assert_close(expected, actual)
+
+
+@pytest.mark.parametrize("fp8_lhs", [False, True])
+@pytest.mark.parametrize("is_persistent", [False, True])
+def test_matmul_mixed_fp8_preserves_fp16_precision(fp8_lhs, is_persistent, device, opt_flags_scope):
+    if not is_cuda() or torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("requires Hopper or newer")
+
+    a = torch.zeros((128, 128), dtype=torch.float16, device=device)
+    b = torch.zeros_like(a)
+    a[:, 0] = 1
+    a[:, 1] = -1
+    # Rounding the FP16 operand to BF16 would erase the residual.
+    b[0, :] = 1 + 2**-10
+    b[1, :] = 1
+    if fp8_lhs:
+        a = a.to(torch.float8_e4m3fn)
+    else:
+        a, b = b.mT.contiguous(), a.mT.contiguous().to(torch.float8_e4m3fn)
+
+    with opt_flags.scoped_opt_flags_constraints(dict(is_persistent=is_persistent, split_k=1)):
+        actual = matmul(a, b, None, precision_config=PrecisionConfig(out_dtype=torch.float16))
+
+    expected = torch.full((128, 128), 2**-10, dtype=torch.float16, device=device)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("is_persistent", [False, True])

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -372,9 +372,6 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
     elif is_hip():
         if a_dtype.is_nvfp4 or b_dtype.is_nvfp4 or c_dtype.is_nvfp4:
             pytest.skip("NVFP4 matmul not tested on AMD GPU")
-        if (a_dtype.has_global_scale != b_dtype.has_global_scale
-                and not (a_dtype.has_mx_scale or b_dtype.has_mx_scale)):
-            pytest.skip("Unscaled mixed FP8 matmul is only tested on CUDA")
         if a_dtype.is_any_float8 and b_dtype.has_mx_scale and not (is_hip_cdna4() or is_hip_gfx1250()):
             pytest.skip("float8 x mx only supported on CDNA4 and gfx1250")
         if a_dtype.is_any_float8 and b_dtype.name == "mxfloat8_e4m3fn":
@@ -676,8 +673,10 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
     ((273, 544, 576), False, {}),
 ])
 def test_matmul_mixed_fp8_resource_limits(shape, fp8_lhs, constraints, device, opt_flags_scope):
-    if not is_cuda() or torch.cuda.get_device_capability()[0] < 9:
+    if is_cuda() and torch.cuda.get_device_capability()[0] < 9:
         pytest.skip("requires Hopper or newer")
+    if is_hip() and constraints.get("is_persistent"):
+        pytest.skip("Persistent kernel not supported on AMD GPU")
 
     torch.manual_seed(0)
     m, n, k = shape
@@ -695,8 +694,10 @@ def test_matmul_mixed_fp8_resource_limits(shape, fp8_lhs, constraints, device, o
 @pytest.mark.parametrize("fp8_lhs", [False, True])
 @pytest.mark.parametrize("is_persistent", [False, True])
 def test_matmul_mixed_fp8_preserves_fp16_precision(fp8_lhs, is_persistent, device, opt_flags_scope):
-    if not is_cuda() or torch.cuda.get_device_capability()[0] < 9:
+    if is_cuda() and torch.cuda.get_device_capability()[0] < 9:
         pytest.skip("requires Hopper or newer")
+    if is_hip() and is_persistent:
+        pytest.skip("Persistent kernel not supported on AMD GPU")
 
     a = torch.zeros((128, 128), dtype=torch.float16, device=device)
     b = torch.zeros_like(a)

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -31,7 +31,7 @@ from .matmul_details.opt_flags import (
 )
 from .matmul_details.opt_flags_details import opt_flags_nvidia
 from .specialize import FnSpecs, SpecializationModule, ClosureArg
-from .tensor import Storage, Tensor, UINT8, FP4, FP64, wrap_torch_tensor, RaggedTensorMetadata, is_tma_compliant, make_tma, convert_layout
+from .tensor import Storage, Tensor, UINT8, FP4, FP8_E4M3FN, FP16, BF16, FP64, wrap_torch_tensor, RaggedTensorMetadata, is_tma_compliant, make_tma, convert_layout
 from .tensor import dtype_to_torch_dtype, torch_dtype_to_dtype
 from .reduce import reduce
 from .reduce import PostprocessFn as ReducePostprocessFn
@@ -307,8 +307,6 @@ def matmul(a, b, bias,
             or isinstance(b_scale_layout, HopperMXScaleLayout)):
         if not b_is_shuffled:
             assert b.stride(-2) == 1, "`w` must be column-major with Hopper-swizzled MX scales or non-strided MX value layouts"
-    is_hopper_fp8 = is_cuda() and not target_info.cuda_capability_geq(10, 0) and b.dtype.bitwidth == 8
-    if is_hopper_fp8: assert b.stride(-2) == 1, "`w` must be column-major when it has data-type FP8 on capability < 10"
     # unpack a scale
     a_scale = precision_config.a_mx_scale
     a_has_mx = a_scale is not None
@@ -319,6 +317,10 @@ def matmul(a, b, bias,
     if not isinstance(a, Tensor):
         dtype = FP4 if a_has_mx and a.dtype == torch.uint8 else None
         a = wrap_torch_tensor(a, dtype=dtype)
+    is_hopper_fp8 = is_cuda() and not target_info.cuda_capability_geq(10, 0) and b.dtype.bitwidth == 8
+    # Mixed FP8/16-bit dots widen FP8 tiles and support either weight layout.
+    if is_hopper_fp8 and not (b.dtype == FP8_E4M3FN and a.dtype in (FP16, BF16) and not (a_has_mx or b_has_mx)):
+        assert b.stride(-2) == 1, "`w` must be column-major when it has data-type FP8 on capability < 10"
     intermediate_out_dtype = precision_config.intermediate_out_dtype
     if intermediate_out_dtype is None:
         intermediate_out_dtype = torch.float64 if a.dtype == b.dtype == FP64 else torch.float32

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -31,7 +31,7 @@ from .matmul_details.opt_flags import (
 )
 from .matmul_details.opt_flags_details import opt_flags_nvidia
 from .specialize import FnSpecs, SpecializationModule, ClosureArg
-from .tensor import Storage, Tensor, UINT8, FP4, FP8_E4M3FN, FP16, BF16, FP64, wrap_torch_tensor, RaggedTensorMetadata, is_tma_compliant, make_tma, convert_layout
+from .tensor import Storage, Tensor, UINT8, FP4, FP64, wrap_torch_tensor, RaggedTensorMetadata, is_tma_compliant, make_tma, convert_layout
 from .tensor import dtype_to_torch_dtype, torch_dtype_to_dtype
 from .reduce import reduce
 from .reduce import PostprocessFn as ReducePostprocessFn
@@ -317,9 +317,9 @@ def matmul(a, b, bias,
     if not isinstance(a, Tensor):
         dtype = FP4 if a_has_mx and a.dtype == torch.uint8 else None
         a = wrap_torch_tensor(a, dtype=dtype)
-    is_hopper_fp8 = is_cuda() and not target_info.cuda_capability_geq(10, 0) and b.dtype.bitwidth == 8
     # Mixed FP8/16-bit dots widen FP8 tiles and support either weight layout.
-    if is_hopper_fp8 and not (b.dtype == FP8_E4M3FN and a.dtype in (FP16, BF16) and not (a_has_mx or b_has_mx)):
+    if (is_cuda() and not target_info.cuda_capability_geq(10, 0) and b.dtype.bitwidth == 8
+            and not opt_flags_nvidia.is_unscaled_mixed_fp8(precision_config, a.dtype, b.dtype)):
         assert b.stride(-2) == 1, "`w` must be column-major when it has data-type FP8 on capability < 10"
     intermediate_out_dtype = precision_config.intermediate_out_dtype
     if intermediate_out_dtype is None:

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -26,6 +26,16 @@ def get_scaled_dot_format_string(dtype: tl.dtype):
 
 
 @triton.jit
+def matmul_dot(x, w, acc, max_num_imprecise_acc: tl.constexpr, allow_tf32: tl.constexpr):
+    if (x.dtype == tl.float8e4nv and (w.dtype == tl.float16 or w.dtype == tl.bfloat16)
+            or w.dtype == tl.float8e4nv and (x.dtype == tl.float16 or x.dtype == tl.bfloat16)):
+        return tl.dot_scaled(x, None, get_scaled_dot_format_string(x.dtype), w, None,
+                             get_scaled_dot_format_string(w.dtype), acc=acc, fast_math=True)
+    else:
+        return tl.dot(x, w, acc, max_num_imprecise_acc=max_num_imprecise_acc, allow_tf32=allow_tf32)
+
+
+@triton.jit
 def xcd_swizzle(pid, domain_size, XCD_SWIZZLE: tl.constexpr):
     """
     Swizzle the program id based on integer XCD_SWIZZLE.

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -26,7 +26,9 @@ def get_scaled_dot_format_string(dtype: tl.dtype):
 
 
 @triton.jit
-def matmul_dot(x, w, acc, max_num_imprecise_acc: tl.constexpr, allow_tf32: tl.constexpr):
+def matmul_dot(x, w, acc, swap_xw: tl.constexpr, max_num_imprecise_acc: tl.constexpr, allow_tf32: tl.constexpr):
+    if swap_xw:
+        x, w = w.T, x.T
     # Expose the 16-bit dot before the compiler chooses operand layouts.
     if x.dtype == tl.float8e4nv and (w.dtype == tl.float16 or w.dtype == tl.bfloat16):
         x = x.to(w.dtype)

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -27,12 +27,12 @@ def get_scaled_dot_format_string(dtype: tl.dtype):
 
 @triton.jit
 def matmul_dot(x, w, acc, max_num_imprecise_acc: tl.constexpr, allow_tf32: tl.constexpr):
-    if (x.dtype == tl.float8e4nv and (w.dtype == tl.float16 or w.dtype == tl.bfloat16)
-            or w.dtype == tl.float8e4nv and (x.dtype == tl.float16 or x.dtype == tl.bfloat16)):
-        return tl.dot_scaled(x, None, get_scaled_dot_format_string(x.dtype), w, None,
-                             get_scaled_dot_format_string(w.dtype), acc=acc, fast_math=True)
-    else:
-        return tl.dot(x, w, acc, max_num_imprecise_acc=max_num_imprecise_acc, allow_tf32=allow_tf32)
+    # Expose the 16-bit dot before the compiler chooses operand layouts.
+    if x.dtype == tl.float8e4nv and (w.dtype == tl.float16 or w.dtype == tl.bfloat16):
+        x = x.to(w.dtype)
+    elif w.dtype == tl.float8e4nv and (x.dtype == tl.float16 or x.dtype == tl.bfloat16):
+        w = w.to(x.dtype)
+    return tl.dot(x, w, acc, max_num_imprecise_acc=max_num_imprecise_acc, allow_tf32=allow_tf32)
 
 
 @triton.jit

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -496,10 +496,7 @@ def _matmul(
             if is_x_microscaled:
                 XMxScalePtrs += (MX_SCALE_BLOCK_K * SPLIT_K) * stride_x_mx_k
         else:
-            if SWAP_XW:
-                acc = matmul_dot(w.T, x.T, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
-            else:
-                acc = matmul_dot(x, w, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
+            acc = matmul_dot(x, w, acc, SWAP_XW, MAX_NUM_IMPRECISE_ACC, ALLOW_TF32)
         if is_x_fp4:
             XPtrs += ((BLOCK_K // 2) * SPLIT_K) * stride_x_k
         else:

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -16,6 +16,7 @@ from triton_kernels.target_info import cuda_capability_geq
 from ._common import (
     compute_offsets,
     get_scaled_dot_format_string,
+    matmul_dot,
     make_matmul_repr,
     matmul_launch_metadata,
     compute_pids,
@@ -496,9 +497,9 @@ def _matmul(
                 XMxScalePtrs += (MX_SCALE_BLOCK_K * SPLIT_K) * stride_x_mx_k
         else:
             if SWAP_XW:
-                acc = tl.dot(w.T, x.T, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
+                acc = matmul_dot(w.T, x.T, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
             else:
-                acc = tl.dot(x, w, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
+                acc = matmul_dot(x, w, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
         if is_x_fp4:
             XPtrs += ((BLOCK_K // 2) * SPLIT_K) * stride_x_k
         else:

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -500,10 +500,7 @@ def _p_matmul(
                     else:
                         acc = tl.dot_scaled(x, x_scales, x_format, w, w_scales, w_format, acc=acc, fast_math=True)
             else:
-                if SWAP_XW:
-                    acc = matmul_dot(w.T, x.T, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
-                else:
-                    acc = matmul_dot(x, w, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
+                acc = matmul_dot(x, w, acc, SWAP_XW, MAX_NUM_IMPRECISE_ACC, ALLOW_TF32)
 
             if is_x_microscaled and XMxScalePtrs is not None:
                 XMxScalePtrs += (MX_SCALE_BLOCK_K * SPLIT_K) * stride_x_mx_k

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -248,7 +248,9 @@ def _p_matmul(
     # A widened FP8 lhs needs tensor memory alongside the accumulator.
     dot_lhs_type: tl.constexpr = w_type if SWAP_XW else x_type
     dot_rhs_type: tl.constexpr = x_type if SWAP_XW else w_type
-    upcast_lhs: tl.constexpr = dot_lhs_type == tl.float8e4nv and (dot_rhs_type == tl.float16 or dot_rhs_type == tl.bfloat16)
+    upcast_lhs: tl.constexpr = (not is_x_microscaled and not is_w_microscaled
+                              and dot_lhs_type == tl.float8e4nv
+                              and (dot_rhs_type == tl.float16 or dot_rhs_type == tl.bfloat16))
     dot_m: tl.constexpr = BLOCK_N if SWAP_XW else BLOCK_M
     dot_n: tl.constexpr = BLOCK_M if SWAP_XW else BLOCK_N
     acc_columns: tl.constexpr = tl.cdiv(dot_m, 128) * dot_n

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -23,6 +23,7 @@ from triton_kernels.tensor_details.layout_details.hopper_value import mxfp4_to_b
 from ._common import (
     compute_offsets,
     get_scaled_dot_format_string,
+    matmul_dot,
     make_matmul_repr,
     matmul_launch_metadata,
     compute_pids,
@@ -244,7 +245,17 @@ def _p_matmul(
         THREADS_PER_BLOCK: tl.constexpr = tl.extra.cuda.num_threads()
         local_absmax = tl.full([THREADS_PER_BLOCK], 0.0, tl.uint32)
 
-    DISALLOW_ACC_MULTI_BUFFER: tl.constexpr = is_w_microscaled and BLOCK_M * BLOCK_N >= 128 * 256
+    # A widened FP8 lhs needs tensor memory alongside the accumulator.
+    dot_lhs_type: tl.constexpr = w_type if SWAP_XW else x_type
+    dot_rhs_type: tl.constexpr = x_type if SWAP_XW else w_type
+    upcast_lhs: tl.constexpr = dot_lhs_type == tl.float8e4nv and (dot_rhs_type == tl.float16 or dot_rhs_type == tl.bfloat16)
+    dot_m: tl.constexpr = BLOCK_N if SWAP_XW else BLOCK_M
+    dot_n: tl.constexpr = BLOCK_M if SWAP_XW else BLOCK_N
+    acc_columns: tl.constexpr = tl.cdiv(dot_m, 128) * dot_n
+    DISALLOW_ACC_MULTI_BUFFER: tl.constexpr = (
+        is_w_microscaled and BLOCK_M * BLOCK_N >= 128 * 256
+        or upcast_lhs and acc_columns >= 256
+    )
 
     loop_start = 0 if CLC else tl.program_id(0)
     loop_end = 1 if CLC else num_blocks
@@ -487,9 +498,9 @@ def _p_matmul(
                         acc = tl.dot_scaled(x, x_scales, x_format, w, w_scales, w_format, acc=acc, fast_math=True)
             else:
                 if SWAP_XW:
-                    acc = tl.dot(w.T, x.T, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
+                    acc = matmul_dot(w.T, x.T, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
                 else:
-                    acc = tl.dot(x, w, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
+                    acc = matmul_dot(x, w, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
 
             if is_x_microscaled and XMxScalePtrs is not None:
                 XMxScalePtrs += (MX_SCALE_BLOCK_K * SPLIT_K) * stride_x_mx_k

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -307,7 +307,6 @@ def _p_matmul(
             else:
                 offs_x_m = tl.load(GatherIndx + slice_off_m.to(index_type) + offs_m, mask=mask_m, other=-1)
         if X_TMA_MODE is None:
-            XBase = X + off_x_z.to(index_type) * stride_x_z
             offs_m = off_m + tl.arange(0, BLOCK_M)
             offs_m = tl.max_contiguous(tl.multiple_of(offs_m % shape_m, BLOCK_M), BLOCK_M)
             # no needs to bounds-check here because `offs_m` wraps around M dim
@@ -315,7 +314,6 @@ def _p_matmul(
                 tl.static_assert(HAS_GATHER)
                 offs_m = tl.load(GatherIndx + slice_off_m.to(index_type) + offs_m)
             offs_x_m = offs_m.to(index_type)[:, None] * stride_x_m
-            offs_x_k = (off_k_x0.to(index_type) // block_div + tl.arange(0, BLOCK_K // block_div))[None, :] * stride_x_k
 
         XMxScalePtrs = None
         if is_x_microscaled and stride_x_mx_z is not None: # x is mx but not using TMA
@@ -378,8 +376,11 @@ def _p_matmul(
                 x = x.reshape(BLOCK_M, BLOCK_K // block_div)
             else:
                 tl.static_assert(X_TMA_MODE is None)
-                XPtrs = XBase + offs_x_m + offs_x_k
-                XBase += (BLOCK_K // block_div) * SPLIT_K * stride_x_k
+                offs_x_k = (off_k_x0.to(index_type) // block_div
+                            + ki.to(index_type) * (BLOCK_K // block_div) * SPLIT_K
+                            + tl.arange(0, BLOCK_K // block_div))[None, :] * stride_x_k
+                # Keep the aligned base pointer outside the flattened loop's conditional prologue.
+                XPtrs = X + (off_x_z.to(index_type) * stride_x_z + offs_x_m + offs_x_k)
                 mask_k = tl.arange(0, BLOCK_K // block_div) * block_div < K - off_k_x
                 if EVEN_K:
                     if SPLIT_K > 1:

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import triton
 from triton_kernels import target_info
 from triton_kernels.target_info import get_cdna_version, get_rdna_version, cuda_capability_geq
-from triton_kernels.tensor import FP4, FP32, Tensor, torch_dtype_to_dtype
+from triton_kernels.tensor import FP4, FP8_E4M3FN, FP32, Tensor, torch_dtype_to_dtype
 import torch
 from triton_kernels.tensor_details.layout_details.hopper_scale import HopperMXScaleLayout
 from triton_kernels.tensor_details.layout_details.strided import StridedLayout
@@ -225,6 +225,7 @@ def make_default_opt_flags_nvidia(
     constraints_supported = {"block_m", "block_n", "block_k", "split_k", "is_persistent", "clc", "epilogue_subtile", "num_stages", "idle_sms", "max_allowable_mn", "num_warps", "disable_mx4_block_swap", "swap_xw", "group_m", "use_output_tma"}
     unsupported = set(constraints.keys()) - constraints_supported
     assert not unsupported, f"Given unsupported constraint: {unsupported}"
+    is_mixed_fp8 = opt_flags_nvidia.is_unscaled_mixed_fp8(precision_config, lhs_dtype, rhs_dtype)
     is_large_ragged_nvfp4 = (
         routing_data is not None
         and m >= _MIN_NVFP4_RAGGED_TRAIN_ROWS
@@ -314,7 +315,11 @@ def make_default_opt_flags_nvidia(
         is_persistent = True
     else:
         has_simple_epilogue = precision_config.max_num_imprecise_acc is None
-        is_persistent = supports_persistent and has_simple_epilogue and (tiles_per_sm >= 2.0 or lhs_dtype.bitwidth <= 8) and (out_dtype.bitwidth < 32 or lhs_dtype.bitwidth == 32 or rhs_dtype.bitwidth == 32)
+        is_persistent = (
+            supports_persistent and has_simple_epilogue
+            and (tiles_per_sm >= 2.0 or lhs_dtype.bitwidth <= 8 or is_mixed_fp8)
+            and (out_dtype.bitwidth < 32 or lhs_dtype.bitwidth == 32 or rhs_dtype.bitwidth == 32)
+        )
         # TMA is slower for batched matmuls with small m/n/k.
         if m * n * k < 131072:
             is_persistent = False
@@ -343,6 +348,14 @@ def make_default_opt_flags_nvidia(
     if is_persistent and opt_flags_nvidia.is_x_scale_swizzled(precision_config):
         # a mx scale has been swizzled to BlackwellActMXScaleLayout, enforce block_m=128 to align with swizzling layout
         block_m = 128
+    swap_xw = constraints.get("swap_xw")
+    if is_mixed_fp8 and rhs_dtype == FP8_E4M3FN and is_persistent:
+        # Convert FP8 in the MMA's lhs registers/TMEM, avoiding a widened RHS buffer.
+        if swap_xw is None and block_n >= 64:
+            swap_xw = True
+        if (swap_xw and not enforce_bitwise_invariance and slice_size >= block_n > block_m
+                and constraints.get("block_m") is None and constraints.get("block_n") is None):
+            block_m, block_n = block_n, block_m
     # block k
     if constraints.get("block_k", None) is not None:
         block_k = constraints["block_k"]
@@ -384,7 +397,6 @@ def make_default_opt_flags_nvidia(
     )
 
     num_warps = opt_flags_nvidia.compute_num_warps(block_m, block_n, is_persistent, precision_config, constraints)
-    swap_xw = constraints.get("swap_xw")
     if is_large_ragged_nvfp4 and constraints.get("num_warps", None) is None:
         # Eight warps overrun GB300 TMEM for the large ragged NVFP4 tile.
         num_warps = 4

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -430,6 +430,8 @@ def make_default_opt_flags_nvidia(
         if ns > num_stages:
             epilogue_subtile, num_stages = ep, ns
 
+    # A smaller epilogue may fit a stage; clamp only after comparing candidates.
+    num_stages = max(1, num_stages)
     if constraints.get("num_stages", None):
         num_stages = constraints["num_stages"]
     elif is_large_ragged_nvfp4 and not any(

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_amd.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_amd.py
@@ -23,8 +23,11 @@ def compute_block_nk(n, block_m, grid_m, num_xcds, lhs_dtype, rhs_dtype, precisi
     if get_rdna_version() in (3, 4) and block_m == 64:
         block_n = 256
 
-    # block_k needs to match the cacheline size (128B)
-    block_k = int(128 // min(lhs_width, rhs_width))
+    # Match a 128B cacheline, accounting for widened unscaled FP8 operands.
+    if precision_config.a_mx_scale is None and precision_config.b_mx_scale is None:
+        block_k = int(128 // max(lhs_width, rhs_width))
+    else:
+        block_k = int(128 // min(lhs_width, rhs_width))
 
     # TODO: block_k = 128 seems to work better for now.
     #       perhaps due to increased number of k loops to pipeline

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -79,13 +79,14 @@ def compute_block_n(n: int, arch, precision_config):
 def compute_block_k(m: int, k: int | None, is_persistent: bool, lhs_dtype, rhs_dtype, precision_config, has_y_acc_in):
     lhs_width = lhs_dtype.bitwidth
     rhs_width = rhs_dtype.bitwidth
-    # block_k needs to match the cacheline size (1024 bits)
-    block_k = int(1024 // min(lhs_width, rhs_width))
     has_native_mxfp = target_info.cuda_capability_geq(10, 0)
     if (not has_native_mxfp and target_info.cuda_capability_geq(9, 0)
             and is_unscaled_mixed_fp8(precision_config, lhs_dtype, rhs_dtype)):
         # Limit register pressure from Hopper's FP8-to-16-bit conversion.
         block_k = 64
+    else:
+        # block_k needs to match the cacheline size (1024 bits)
+        block_k = int(1024 // min(lhs_width, rhs_width))
     if rhs_width == 4 and not has_native_mxfp:
         block_k = 128
     elif is_persistent and is_x_scale_swizzled(precision_config):
@@ -161,20 +162,28 @@ def compute_num_stages(
         return 3
     if swap_xw is None:
         swap_xw = compute_swap_xw(precision_config, block_m, is_persistent, lhs_dtype, rhs_dtype)
+    is_mixed_fp8 = is_unscaled_mixed_fp8(precision_config, lhs_dtype, rhs_dtype)
     act_size = lhs_dtype.bitwidth / 8
     weight_size = rhs_dtype.bitwidth / 8
     has_native_mxfp = target_info.cuda_capability_geq(10, 0)
-    if has_native_mxfp and lhs_dtype in (FP16, BF16) and precision_config.b_mx_scale is not None:
+    if has_native_mxfp and precision_config.b_mx_scale is not None and lhs_dtype in [FP16, BF16]:
+        # For fp16/bf16 x mxfp, we upcast weight on the fly, so size
+        # smem_capacity accordingly.
+        # w/o this, gets the following error:
+        # "triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 263356, Hardware limit: 232448. Reducing block sizes or `num_stages` may help"
+        # for x.shape = [2048, >=4096] bf16 x [32, >=4096, >=4096] float8_e4m3fn
+        # block_m=64, block_n=256, block_k=128, split_k=1, is_persistent=True -> leading to num_stages=4
         weight_size = 2
-    if has_native_mxfp and rhs_dtype in (FP16, BF16) and precision_config.a_mx_scale is not None:
+    if has_native_mxfp and precision_config.a_mx_scale is not None and rhs_dtype in [FP16, BF16]:
+        # For mxfp x fp16/bf16, we upcast activations on the fly, so size
+        # smem_capacity accordingly.
         act_size = 2
 
     stage_size = block_m * block_k * act_size + block_k * block_n * weight_size
     device_props = torch.cuda.get_device_properties(0)
     smem_capacity = device_props.shared_memory_per_block_optin
     smem_capacity //= occupancy_target
-    if (is_unscaled_mixed_fp8(precision_config, lhs_dtype, rhs_dtype)
-            and (lhs_dtype if swap_xw else rhs_dtype) == FP8_E4M3FN):
+    if is_mixed_fp8 and (lhs_dtype if swap_xw else rhs_dtype) == FP8_E4M3FN:
         # A computed RHS needs one widened tile in addition to its input ring.
         # The regular pipeline replaces one raw FP8 slot with that widened tile.
         rhs_elements = block_k * (block_m if swap_xw else block_n)
@@ -214,8 +223,7 @@ def compute_num_stages(
         # pipelined layout conversion before store of the accumulator
         # note: layout conversion has some padding
         epilogue_smem = int((block_m + 4) * acc_block_n * acc_size)
-        if (has_native_mxfp and not swap_xw and block_m == 64 and epilogue_subtile > 1
-                and is_unscaled_mixed_fp8(precision_config, lhs_dtype, rhs_dtype)):
+        if has_native_mxfp and not swap_xw and block_m == 64 and epilogue_subtile > 1 and is_mixed_fp8:
             # The first accumulator split needs FP32 redistribution scratch
             # alongside the output tile, before any activation reduction.
             epilogue_smem += block_m * (block_n // 2) * 4
@@ -246,7 +254,9 @@ def compute_num_stages(
         if x_transpose:
             smem_capacity -= int(block_m * block_k * act_size)
         if rhs_dtype == FP32 and not w_transpose:
-            # Different TMA and MMA layouts require an extra B tile for conversion.
+            # For fp32 B, a non-transposed input requires a transpose after its
+            # TMA load before MMA. Persistent lowering materializes one extra
+            # BLOCK_K x BLOCK_N tile for that conversion.
             smem_capacity -= int(block_k * block_n * weight_size)
     if is_persistent and not has_native_mxfp and epilogue_reduction_n > 1:
         # Hopper fused reductions materialize an additional reduced-N output

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -7,6 +7,12 @@ from triton_kernels.tensor_details.layout import HopperMXScaleLayout
 from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellActMXScaleLayout, BlackwellMXScaleLayout
 
 
+def is_unscaled_mixed_fp8(precision_config, lhs_dtype, rhs_dtype):
+    return (precision_config.a_mx_scale is None and precision_config.b_mx_scale is None
+            and (lhs_dtype == FP8_E4M3FN and rhs_dtype in (FP16, BF16)
+                 or rhs_dtype == FP8_E4M3FN and lhs_dtype in (FP16, BF16)))
+
+
 def is_x_scale_swizzled(precision_config):
     return (precision_config is not None and precision_config.a_mx_scale is not None
             and isinstance(precision_config.a_mx_scale, Tensor)
@@ -76,6 +82,10 @@ def compute_block_k(m: int, k: int | None, is_persistent: bool, lhs_dtype, rhs_d
     # block_k needs to match the cacheline size (1024 bits)
     block_k = int(1024 // min(lhs_width, rhs_width))
     has_native_mxfp = target_info.cuda_capability_geq(10, 0)
+    if (not has_native_mxfp and target_info.cuda_capability_geq(9, 0)
+            and is_unscaled_mixed_fp8(precision_config, lhs_dtype, rhs_dtype)):
+        # Limit register pressure from Hopper's FP8-to-16-bit conversion.
+        block_k = 64
     if rhs_width == 4 and not has_native_mxfp:
         block_k = 128
     elif is_persistent and is_x_scale_swizzled(precision_config):
@@ -149,23 +159,26 @@ def compute_num_stages(
 ):
     if precision_config.max_num_imprecise_acc is not None:
         return 3
+    if swap_xw is None:
+        swap_xw = compute_swap_xw(precision_config, block_m, is_persistent, lhs_dtype, rhs_dtype)
     act_size = lhs_dtype.bitwidth / 8
     weight_size = rhs_dtype.bitwidth / 8
     has_native_mxfp = target_info.cuda_capability_geq(10, 0)
-    is_unscaled = precision_config.a_mx_scale is None and precision_config.b_mx_scale is None
-    if (lhs_dtype in (FP16, BF16) and
-        (has_native_mxfp and precision_config.b_mx_scale is not None or is_unscaled and rhs_dtype == FP8_E4M3FN)):
-        # Mixed 16-bit dots stage widened FP8/MXFP weights in shared memory.
+    if has_native_mxfp and lhs_dtype in (FP16, BF16) and precision_config.b_mx_scale is not None:
         weight_size = 2
-    if (has_native_mxfp and rhs_dtype in (FP16, BF16)
-            and (precision_config.a_mx_scale is not None or is_unscaled and lhs_dtype == FP8_E4M3FN)):
-        # Blackwell also needs space for widened activation tiles.
+    if has_native_mxfp and rhs_dtype in (FP16, BF16) and precision_config.a_mx_scale is not None:
         act_size = 2
 
     stage_size = block_m * block_k * act_size + block_k * block_n * weight_size
     device_props = torch.cuda.get_device_properties(0)
     smem_capacity = device_props.shared_memory_per_block_optin
     smem_capacity //= occupancy_target
+    if (is_unscaled_mixed_fp8(precision_config, lhs_dtype, rhs_dtype)
+            and (lhs_dtype if swap_xw else rhs_dtype) == FP8_E4M3FN):
+        # A computed RHS needs one widened tile in addition to its input ring.
+        # The regular pipeline replaces one raw FP8 slot with that widened tile.
+        rhs_elements = block_k * (block_m if swap_xw else block_n)
+        smem_capacity -= rhs_elements * (2 if is_persistent else 1)
     if has_native_mxfp:
         # 4-bit e2m1 operands are padded 2x
         # https://docs.nvidia.com/cuda/parallel-thread-execution/#packing-format-used-for-matrix-a-and-b-by-kind-mxf8f6f4-in-shared-memory
@@ -201,8 +214,11 @@ def compute_num_stages(
         # pipelined layout conversion before store of the accumulator
         # note: layout conversion has some padding
         epilogue_smem = int((block_m + 4) * acc_block_n * acc_size)
-        if swap_xw is None:
-            swap_xw = compute_swap_xw(precision_config, block_m, is_persistent, lhs_dtype, rhs_dtype)
+        if (has_native_mxfp and not swap_xw and block_m == 64 and epilogue_subtile > 1
+                and is_unscaled_mixed_fp8(precision_config, lhs_dtype, rhs_dtype)):
+            # The first accumulator split needs FP32 redistribution scratch
+            # alongside the output tile, before any activation reduction.
+            epilogue_smem += block_m * (block_n // 2) * 4
         if swap_xw:
             # The fp32 accumulator stays in TMEM for the Blackwell SWAP_XW
             # persistent path. Fused reductions such as swiglu still need smem
@@ -229,8 +245,7 @@ def compute_num_stages(
         smem_capacity -= epilogue_smem
         if x_transpose:
             smem_capacity -= int(block_m * block_k * act_size)
-        if (rhs_dtype == FP32 and not w_transpose or has_native_mxfp and is_unscaled and lhs_dtype == FP8_E4M3FN
-                and rhs_dtype in (FP16, BF16) and w_transpose != swap_xw):
+        if rhs_dtype == FP32 and not w_transpose:
             # Different TMA and MMA layouts require an extra B tile for conversion.
             smem_capacity -= int(block_k * block_n * weight_size)
     if is_persistent and not has_native_mxfp and epilogue_reduction_n > 1:

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -2,7 +2,7 @@ import torch
 import triton
 from triton_kernels import target_info
 from triton_kernels.numerics_details.mxfp_details._downcast_to_mxfp import MXFP_BLOCK_SIZE, NVFP_BLOCK_SIZE
-from triton_kernels.tensor import FP4, FP16, FP32, BF16, Tensor
+from triton_kernels.tensor import FP4, FP8_E4M3FN, FP16, FP32, BF16, Tensor
 from triton_kernels.tensor_details.layout import HopperMXScaleLayout
 from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellActMXScaleLayout, BlackwellMXScaleLayout
 
@@ -152,17 +152,14 @@ def compute_num_stages(
     act_size = lhs_dtype.bitwidth / 8
     weight_size = rhs_dtype.bitwidth / 8
     has_native_mxfp = target_info.cuda_capability_geq(10, 0)
-    if has_native_mxfp and precision_config.b_mx_scale is not None and lhs_dtype in [FP16, BF16]:
-        # For fp16/bf16 x mxfp, we upcast weight on the fly, so size
-        # smem_capacity accordingly.
-        # w/o this, gets the following error:
-        # "triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 263356, Hardware limit: 232448. Reducing block sizes or `num_stages` may help"
-        # for x.shape = [2048, >=4096] bf16 x [32, >=4096, >=4096] float8_e4m3fn
-        # block_m=64, block_n=256, block_k=128, split_k=1, is_persistent=True -> leading to num_stages=4
+    is_unscaled = precision_config.a_mx_scale is None and precision_config.b_mx_scale is None
+    if (lhs_dtype in (FP16, BF16) and
+        (has_native_mxfp and precision_config.b_mx_scale is not None or is_unscaled and rhs_dtype == FP8_E4M3FN)):
+        # Mixed 16-bit dots stage widened FP8/MXFP weights in shared memory.
         weight_size = 2
-    if has_native_mxfp and precision_config.a_mx_scale is not None and rhs_dtype in [FP16, BF16]:
-        # For mxfp x fp16/bf16, we upcast activations on the fly, so size
-        # smem_capacity accordingly.
+    if (has_native_mxfp and rhs_dtype in (FP16, BF16)
+            and (precision_config.a_mx_scale is not None or is_unscaled and lhs_dtype == FP8_E4M3FN)):
+        # Blackwell also needs space for widened activation tiles.
         act_size = 2
 
     stage_size = block_m * block_k * act_size + block_k * block_n * weight_size
@@ -232,10 +229,9 @@ def compute_num_stages(
         smem_capacity -= epilogue_smem
         if x_transpose:
             smem_capacity -= int(block_m * block_k * act_size)
-        if rhs_dtype == FP32 and not w_transpose:
-            # For fp32 B, a non-transposed input requires a transpose after its
-            # TMA load before MMA. Persistent lowering materializes one extra
-            # BLOCK_K x BLOCK_N tile for that conversion.
+        if (rhs_dtype == FP32 and not w_transpose or has_native_mxfp and is_unscaled and lhs_dtype == FP8_E4M3FN
+                and rhs_dtype in (FP16, BF16) and w_transpose != swap_xw):
+            # Different TMA and MMA layouts require an extra B tile for conversion.
             smem_capacity -= int(block_k * block_n * weight_size)
     if is_persistent and not has_native_mxfp and epilogue_reduction_n > 1:
         # Hopper fused reductions materialize an additional reduced-N output

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -247,7 +247,4 @@ def compute_num_stages(
         # extra epilogue/scale smem that a 5-stage persistent kernel can
         # exceed H100's launch limit.
         max_stages = 4
-    num_stages = min(smem_capacity // int(stage_size), max_stages)
-    if num_stages == 0:
-        num_stages = 1
-    return num_stages
+    return min(smem_capacity // int(stage_size), max_stages)


### PR DESCRIPTION
Unscaled E4M3FN paired with FP16/BF16 currently fails `triton_kernels.matmul` dtype or Hopper weight-layout checks. Both kernels now widen only the FP8 tile to its partner's dtype before `tl.dot`, preserving input storage and FP16 precision. The multiply uses 16-bit tensor cores.

Persistent kernels prefer FP8 on the MMA's lhs and use smaller K tiles on Hopper. Account for staged inputs, widened RHS tiles and epilogue scratch separately, leave Blackwell TMEM headroom, and select a fitting epilogue before clamping stages. Keep gathered-input offsets separate from the aligned base pointer when flattening persistent loops. AMD sizes unscaled K tiles using the wider operand, so mixed FP8/16-bit tiles fit gfx942 shared memory.

With the [unchanged upstream compiler](https://github.com/triton-lang/triton/commit/2074a1b8a5cd283ce584f8ebca825c4f0b215fc1), **520 mixed-dtype cases pass on H100 and 264 on GB300; all fail against the base library**. The existing `test_op` grid now covers all four mixed dtype pairs, both weight layouts, regular/persistent kernels, bias, scaling and gather/scatter. Eight focused cases retain memory-limit, default-planner and exact FP16 precision coverage. The 256 H100 / 128 GB300 skips are unchanged inapplicable inner-expert combinations. Two existing FP16 gather/split-K and ragged-K cases also pass on both libraries and GPUs.

AMD runtime CI passes all 132 newly enabled mixed cases on [gfx942](https://github.com/triton-lang/triton/actions/runs/34404235031/job/102643281846), [gfx950](https://github.com/triton-lang/triton/actions/runs/34404235031/job/102643281882), and [gfx950 with ROCm 10.1](https://github.com/triton-lang/triton/actions/runs/34404235031/job/102643281817), including the 32 gfx942 cases that exceeded shared memory before the tile-size fix. HIP retains its unsupported persistent/TMA exclusion.

### BF16

**Relative speed: BF16 × BF16 = 1.00×. Higher is faster.** Speed is baseline latency divided by measured latency.

| GPU | M × N × K | FP8 × BF16 | BF16 × FP8 | FP8 × FP8 |
|---|---|---:|---:|---:|
| H100 | 16 × 4096 × 4096 | 0.95× | 0.73× | 1.19× |
| H100 | 128 × 4096 × 4096 | 0.86× | 1.06× | 1.21× |
| H100 | 2048 × 4096 × 4096 | 0.85× | 0.85× | 1.90× |
| H100 | 4096 × 8192 × 8192 | 0.81× | 0.81× | 1.79×* |
| GB300 | 16 × 4096 × 4096 | 1.42× | 1.49× | 1.64× |
| GB300 | 128 × 4096 × 4096 | 1.42× | 1.32× | 1.61× |
| GB300 | 2048 × 4096 × 4096 | 0.96× | 0.96× | 1.97× |
| GB300 | 4096 × 8192 × 8192 | 0.86× | 0.94× | 1.84× |

**Peak tensor memory saved relative to BF16 × BF16. Higher means more memory saved.**

| GPU | M × N × K | FP8 × BF16 | BF16 × FP8 | FP8 × FP8 |
|---|---|---:|---:|---:|
| H100 | 16 × 4096 × 4096 | 0.1% | 46.7% | 46.9% |
| H100 | 128 × 4096 × 4096 | 1.0% | 32.0% | 33.0% |
| H100 | 2048 × 4096 × 4096 | 12.5% | 25.0% | 37.5% |
| H100 | 4096 × 8192 × 8192 | 12.5% | 25.0% | 37.5% |
| GB300 | 16 × 4096 × 4096 | 0.9% | 47.1% | 47.2% |
| GB300 | 128 × 4096 × 4096 | 4.8% | 34.6% | 35.5% |
| GB300 | 2048 × 4096 × 4096 | 12.5% | 25.0% | 37.5% |
| GB300 | 4096 × 8192 × 8192 | 12.5% | 25.0% | 37.5% |

Measured at [Size unscaled AMD matmul tiles for the wider operand](https://github.com/triton-lang/triton/commit/a00f0cc854c41c23d895f2aedb7d14dc15849dbf). FP8 means E4M3FN. Each GPU/shape uses identical E4M3-rounded values, row-major A, column-major B, BF16 output, and default planner/precision settings.

Latency is the median of five warm CUDA-graph measurements; input conversion, compilation, and host dispatch are excluded. Peak active PyTorch tensor allocation is measured separately after warmup in a fresh process per case, before reference computation or graph capture. It includes inputs, output, workspace, and cached library buffers; it excludes CUDA context and unused allocator reservations. Five-sample max–min spans reached 13.2% of the median on H100 and 3.3% on GB300.

For M ≥ 2048, mixed FP8/BF16 matmul delivers **0.81–0.85× BF16 speed on H100** and **0.86–0.96× on GB300**, while saving about **12.5–25% peak tensor memory**. Small-M results depend on GPU and operand order.

\* The largest H100 FP8 × FP8 case exceeds the default max-error tolerance in four outputs (2.21% vs 2%; RMS 0.217% vs 0.4%). Its default timing is shown. All other benchmark cases pass, including every mixed case.

### FP16

Both FP16 × FP8 and FP8 × FP16 pass the existing grid and exact precision tests: **260 cases on H100 and 132 on GB300**.

**Relative speed: FP16 × FP16 = 1.00×. Higher is faster.**

| GPU | M × N × K | FP8 × FP16 | FP16 × FP8 | FP8 × FP8 |
|---|---|---:|---:|---:|
| H100 | 16 × 4096 × 4096 | 0.97× | 1.08× | 1.18× |
| H100 | 128 × 4096 × 4096 | 0.86× | 1.17× | 1.22× |
| H100 | 2048 × 4096 × 4096 | 0.98× | 1.01× | 1.95× |
| H100 | 4096 × 8192 × 8192 | 0.89× | 0.93× | 1.76× |
| GB300 | 16 × 4096 × 4096 | 1.41× | 1.48× | 1.63× |
| GB300 | 128 × 4096 × 4096 | 1.42× | 1.32× | 1.61× |
| GB300 | 2048 × 4096 × 4096 | 0.96× | 0.96× | 1.97× |
| GB300 | 4096 × 8192 × 8192 | 0.86× | 0.94× | 1.88× |

**Peak tensor memory saved relative to FP16 × FP16. Higher means more memory saved.**

| GPU | M × N × K | FP8 × FP16 | FP16 × FP8 | FP8 × FP8 |
|---|---|---:|---:|---:|
| H100 | 16 × 4096 × 4096 | 0.1% | 46.7% | 46.9% |
| H100 | 128 × 4096 × 4096 | 1.0% | 32.0% | 33.0% |
| H100 | 2048 × 4096 × 4096 | 12.5% | 25.0% | 37.5% |
| H100 | 4096 × 8192 × 8192 | 12.5% | 25.0% | 37.5% |
| GB300 | 16 × 4096 × 4096 | 0.9% | 47.1% | 47.2% |
| GB300 | 128 × 4096 × 4096 | 4.8% | 34.6% | 35.5% |
| GB300 | 2048 × 4096 × 4096 | 12.5% | 25.0% | 37.5% |
| GB300 | 4096 × 8192 × 8192 | 12.5% | 25.0% | 37.5% |

Measured at [Size unscaled AMD matmul tiles for the wider operand](https://github.com/triton-lang/triton/commit/a00f0cc854c41c23d895f2aedb7d14dc15849dbf), with the same input values, compiler and measurement protocol as the BF16 section. All four arms produce FP16 output. All 32 benchmark cases pass the default accuracy tolerances and finite-output checks. Five-sample max–min spans reached 12.2% of the median on H100 and 5.1% on GB300.

| Files | Added | Removed | Net |
|---|---:|---:|---:|
| Tests | +62 | -4 | +58 |
| Non-tests | +87 | -29 | +58 |
| All | +149 | -33 | +116 |

### Reviewer's guide

- `python/triton_kernels/triton_kernels/`: shared mixed-dot conversion, Hopper layout support, tile and memory planning, and aligned gathered-input addresses.
- `python/triton_kernels/tests/`: extend the existing matmul dtype grid; retain focused resource-limit and FP16 precision regressions.

<!-- codex-thread: 01a08407-6560-7b03-a1e1-c4a009de5e66 -->
