### PR TITLE
[BUILD] Make the NVIDIA GSan device runtime optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
 option(TRITON_BUILD_PROTON "Build the Triton Proton profiler" ON)
+option(TRITON_BUILD_NVIDIA_GSAN_RUNTIME
+       "Build the CUDA/NVPTX GSan device runtime for the NVIDIA backend" ON)
 option(TRITON_STABLE_ABI "Build with Python Stable ABI (abi3) for Python 3.12+" OFF)
 option(TRITON_BUILD_UT "Build C++ Triton Unit Tests" ON)
 option(TRITON_BUILD_WITH_CCACHE "Build with ccache (if available)" ON)

--- a/setup.py
+++ b/setup.py
@@ -349,6 +349,7 @@ class CMakeBuild(build_ext):
         # environment variables we will pass through to cmake
         passthrough_args = [
             "TRITON_BUILD_PROTON",
+            "TRITON_BUILD_NVIDIA_GSAN_RUNTIME",
             "TRITON_BUILD_WITH_CCACHE",
             "TRITON_PARALLEL_LINK_JOBS",
             "TRITON_OFFLINE_BUILD",

--- a/third_party/nvidia/CMakeLists.txt
+++ b/third_party/nvidia/CMakeLists.txt
@@ -3,53 +3,57 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 add_subdirectory(include)
 add_subdirectory(lib)
 if(TRITON_BUILD_PYTHON_MODULE)
-  set(GSAN_RUNTIME_SRC "${triton_SOURCE_DIR}/python/triton/experimental/gsan/src/GSanLibrary.cu")
-  set(GSAN_RUNTIME_HDRS
-    "${triton_SOURCE_DIR}/python/triton/experimental/gsan/src/GSan.h"
-    "${triton_SOURCE_DIR}/python/triton/experimental/gsan/src/Hash.cuh")
-  set(GSAN_RUNTIME_IR "${CMAKE_CURRENT_SOURCE_DIR}/backend/lib/gsan.ll")
+  if(TRITON_BUILD_NVIDIA_GSAN_RUNTIME)
+    set(GSAN_RUNTIME_SRC "${triton_SOURCE_DIR}/python/triton/experimental/gsan/src/GSanLibrary.cu")
+    set(GSAN_RUNTIME_HDRS
+      "${triton_SOURCE_DIR}/python/triton/experimental/gsan/src/GSan.h"
+      "${triton_SOURCE_DIR}/python/triton/experimental/gsan/src/Hash.cuh")
+    set(GSAN_RUNTIME_IR "${CMAKE_CURRENT_SOURCE_DIR}/backend/lib/gsan.ll")
 
-  find_program(TRITON_GSAN_CLANGXX NAMES clang++
-               PATHS "${LLVM_SYSPATH}/bin"
-               REQUIRED NO_DEFAULT_PATH)
-  if(NOT TRITON_GSAN_CLANGXX)
-    message(FATAL_ERROR "clang++ is required to build gsan.ll")
-  endif()
-
-  set(TRITON_GSAN_INCLUDE_FLAGS "")
-  foreach(include_path IN ITEMS "${TRITON_CUDACRT_PATH}" "${TRITON_CUDART_PATH}")
-    if(NOT "${include_path}" STREQUAL "")
-      list(APPEND TRITON_GSAN_INCLUDE_FLAGS "-I${include_path}")
+    find_program(TRITON_GSAN_CLANGXX NAMES clang++
+                 PATHS "${LLVM_SYSPATH}/bin"
+                 REQUIRED NO_DEFAULT_PATH)
+    if(NOT TRITON_GSAN_CLANGXX)
+      message(FATAL_ERROR "clang++ is required to build gsan.ll")
     endif()
-  endforeach()
 
-  # Keep the device runtime freestanding: do not pull in Clang's CUDA wrapper,
-  # vendored CUDA headers, host SDK headers, or the host C++ standard library.
-  add_custom_command(
-      OUTPUT "${GSAN_RUNTIME_IR}"
-      COMMAND "${CMAKE_COMMAND}" -E make_directory
-              "${PROJECT_SOURCE_DIR}/third_party/nvidia/backend/lib"
-      COMMAND "${TRITON_GSAN_CLANGXX}"
-              -x cuda
-              -std=c++17 -O3 -S -emit-llvm
-              --cuda-device-only
-              -nocudainc
-              -nocudalib
-              -nostdinc
-              -fno-exceptions
-              -fcuda-flush-denormals-to-zero
-              --cuda-gpu-arch=sm_80
-              --cuda-feature=+ptx70
-              ${TRITON_GSAN_INCLUDE_FLAGS}
-              "${GSAN_RUNTIME_SRC}" -o "${GSAN_RUNTIME_IR}"
-      DEPENDS "${GSAN_RUNTIME_SRC}" ${GSAN_RUNTIME_HDRS}
-      COMMENT "Building GSan runtime"
-      VERBATIM)
-  add_custom_target(TritonNVIDIAGSanRuntime ALL DEPENDS "${GSAN_RUNTIME_IR}")
+    set(TRITON_GSAN_INCLUDE_FLAGS "")
+    foreach(include_path IN ITEMS "${TRITON_CUDACRT_PATH}" "${TRITON_CUDART_PATH}")
+      if(NOT "${include_path}" STREQUAL "")
+        list(APPEND TRITON_GSAN_INCLUDE_FLAGS "-I${include_path}")
+      endif()
+    endforeach()
+
+    # Keep the device runtime freestanding: do not pull in Clang's CUDA wrapper,
+    # vendored CUDA headers, host SDK headers, or the host C++ standard library.
+    add_custom_command(
+        OUTPUT "${GSAN_RUNTIME_IR}"
+        COMMAND "${CMAKE_COMMAND}" -E make_directory
+                "${PROJECT_SOURCE_DIR}/third_party/nvidia/backend/lib"
+        COMMAND "${TRITON_GSAN_CLANGXX}"
+                -x cuda
+                -std=c++17 -O3 -S -emit-llvm
+                --cuda-device-only
+                -nocudainc
+                -nocudalib
+                -nostdinc
+                -fno-exceptions
+                -fcuda-flush-denormals-to-zero
+                --cuda-gpu-arch=sm_80
+                --cuda-feature=+ptx70
+                ${TRITON_GSAN_INCLUDE_FLAGS}
+                "${GSAN_RUNTIME_SRC}" -o "${GSAN_RUNTIME_IR}"
+        DEPENDS "${GSAN_RUNTIME_SRC}" ${GSAN_RUNTIME_HDRS}
+        COMMENT "Building GSan runtime"
+        VERBATIM)
+    add_custom_target(TritonNVIDIAGSanRuntime ALL DEPENDS "${GSAN_RUNTIME_IR}")
+  endif()
 
   add_triton_plugin(TritonNVIDIA ${CMAKE_CURRENT_SOURCE_DIR}/triton_nvidia.cc LINK_LIBS TritonNVIDIAGPUToLLVM NVGPUToLLVM)
   target_link_libraries(TritonNVIDIA PRIVATE Python3::Module nanobind-static)
-  add_dependencies(TritonNVIDIA TritonNVIDIAGSanRuntime)
+  if(TRITON_BUILD_NVIDIA_GSAN_RUNTIME)
+    add_dependencies(TritonNVIDIA TritonNVIDIAGSanRuntime)
+  endif()
 endif()
 if(TRITON_BUILD_UT)
   add_subdirectory(unittest)


### PR DESCRIPTION
NVIDIA's GSan device runtime is currently built whenever the Triton Python module is enabled. This requires a CUDA-capable `clang++` and prevents reduced builds that do not include the NVPTX target.

This change adds `TRITON_BUILD_NVIDIA_GSAN_RUNTIME`, enabled by default to preserve existing behavior. When disabled, Triton skips GSan runtime generation and does not add the runtime target as a dependency of the NVIDIA plugin. The option is also forwarded from `setup.py`.

## New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
  - [x] This PR does not need a test because this is a build-graph option
    change; both enabled and disabled configurations were validated with the
    official prebuilt-LLVM build flow.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these
    [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)