### PR TITLE
[AMD][Gluon] Export scaled_upcast layout helper for every supported arch

### DIFF
--- a/docs/gluon/api/amd.cdna3.rst
+++ b/docs/gluon/api/amd.cdna3.rst
@@ -16,4 +16,5 @@ AMD CDNA 3
     buffer_atomic_or
     buffer_atomic_xchg
     buffer_atomic_xor
+    get_scaled_upcast_fp4_scale_layout
     mfma

--- a/docs/gluon/api/amd.cdna4.rst
+++ b/docs/gluon/api/amd.cdna4.rst
@@ -26,6 +26,7 @@ AMD CDNA 4
     buffer_atomic_xor
     compute_efficient_padded_shared_layout
     get_mfma_scale_layout
+    get_scaled_upcast_fp4_scale_layout
     load_shared_fp4_repacked
     mfma
     mfma_scaled

--- a/docs/gluon/api/amd.cdna5.rst
+++ b/docs/gluon/api/amd.cdna5.rst
@@ -20,6 +20,7 @@ AMD CDNA 5
 
     buffer_load
     buffer_store
+    get_scaled_upcast_fp4_scale_layout
     get_wmma_scale_layout
     load_shared_fp4_repacked
     make_partitioned_dot_layouts

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -4144,12 +4144,13 @@ def test_amd_scaled_downcast_fp8_cdna(target, fp8_format, ir_dtype):
 ], ids=["cdna3", "cdna4", "cdna5"])
 def test_amd_scaled_upcast_fp4_compact_scale_cdna(target, threads_per_warp, expect_layout):
     scaled_upcast = _get_amd_scaled_upcast(target)
+    get_scaled_upcast_fp4_scale_layout = _get_amd_scaled_upcast_fp4_scale_layout(target)
 
     @gluon.jit
     def kernel(THREADS_PER_WARP: ttgl.constexpr, EXPECT_LAYOUT: ttgl.constexpr):
         packed_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 4], THREADS_PER_WARP, [1, 1], [1, 0])
         src = ttgl.full([16, 32], 0x11, ttgl.uint8, packed_layout)
-        scale_layout: ttgl.constexpr = ttgl.amd.get_scaled_upcast_fp4_scale_layout(src, 32, ttgl.bfloat16, axis=1)
+        scale_layout: ttgl.constexpr = get_scaled_upcast_fp4_scale_layout(src, 32, ttgl.bfloat16, axis=1)
         ttgl.static_assert(scale_layout == EXPECT_LAYOUT)
         scale = ttgl.full([16, 2], 0x02, ttgl.uint8, scale_layout)
         scaled_upcast(src, scale, ttgl.bfloat16, axis=1)
@@ -4191,12 +4192,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 """)
 
 
-def _get_amd_scaled_upcast(target):
+def _get_amd_arch(target):
     if target == HIP_TARGET_CDNA3:
-        return ttgl.amd.cdna3.scaled_upcast
+        return ttgl.amd.cdna3
     if target == HIP_TARGET_CDNA4:
-        return ttgl.amd.cdna4.scaled_upcast
-    return ttgl.amd.cdna5.scaled_upcast
+        return ttgl.amd.cdna4
+    if target == HIP_TARGET_CDNA5:
+        return ttgl.amd.cdna5
+    raise ValueError(f"Unsupported AMD target: {target}")
+
+
+def _get_amd_scaled_upcast(target):
+    return _get_amd_arch(target).scaled_upcast
+
+
+def _get_amd_scaled_upcast_fp4_scale_layout(target):
+    return _get_amd_arch(target).get_scaled_upcast_fp4_scale_layout
 
 
 @pytest.mark.parametrize("target", [HIP_TARGET_CDNA3, HIP_TARGET_CDNA4, HIP_TARGET_CDNA5])

--- a/python/triton/experimental/gluon/language/amd/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/__init__.py
@@ -1,6 +1,5 @@
 from .._core import builtin
 from ._layouts import AMDMFMALayout, AMDWMMALayout
-from ._ops import get_scaled_upcast_fp4_scale_layout
 from . import cdna3, cdna4, cdna5
 from . import rdna3, rdna4
 from . import gfx1250
@@ -9,5 +8,5 @@ from .warp_pipeline import warp_pipeline_stage
 
 __all__ = [
     "AMDMFMALayout", "AMDWMMALayout", "cdna3", "cdna4", "cdna5", "rdna3", "rdna4", "gfx1250", "warp_pipeline_stage",
-    "slice", "get_scaled_upcast_fp4_scale_layout"
+    "slice"
 ]

--- a/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
@@ -5,14 +5,15 @@ from triton import knobs
 from triton.experimental.gluon.language import _core as ttgl
 from triton._C.libtriton import ir
 from ..._core import builtin, int8, uint8, _unwrap_if_constexpr
-from .._ops import _scaled_upcast
+from .._ops import _scaled_upcast, get_scaled_upcast_fp4_scale_layout
 
 if TYPE_CHECKING:
     from ..._semantic import GluonSemantic
 
 __all__ = [
     "buffer_atomic_add", "buffer_atomic_and", "buffer_atomic_min", "buffer_atomic_max", "buffer_atomic_or",
-    "buffer_atomic_xor", "buffer_atomic_xor", "buffer_load", "buffer_store", "mfma", "scaled_upcast"
+    "buffer_atomic_xor", "buffer_atomic_xor", "buffer_load", "buffer_store", "mfma", "scaled_upcast",
+    "get_scaled_upcast_fp4_scale_layout"
 ]
 
 _atomic_op_str_to_op = {

--- a/python/triton/experimental/gluon/language/amd/cdna5/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna5/__init__.py
@@ -2,7 +2,8 @@ from triton.runtime.jit import constexpr_function
 from triton._C.libtriton.gluon_ir import get_amd_wmma_scale_layout as _get_wmma_scale_layout
 
 from ..._core import builtin, int8, uint8, int32, float8e4nv, tensor, _unwrap_if_constexpr
-from .._ops import _load_shared_fp4_repacked, _wmma, _verify_wmma, _mma_scaled, _scaled_upcast, scaled_downcast
+from .._ops import (_load_shared_fp4_repacked, _wmma, _verify_wmma, _mma_scaled, _scaled_upcast, scaled_downcast,
+                    get_scaled_upcast_fp4_scale_layout)
 from .._layouts import AMDWMMALayout
 from ..cdna3 import buffer_load, buffer_store
 from ._layouts import PartitionedSharedLayout, make_partitioned_dot_layouts
@@ -14,7 +15,7 @@ from . import cluster
 __all__ = [
     "async_copy", "tdm", "mbarrier", "cluster", "wmma", "wmma_scaled", "scaled_upcast", "scaled_downcast",
     "buffer_load", "buffer_store", "get_wmma_scale_layout", "PartitionedSharedLayout", "make_partitioned_dot_layouts",
-    "load_shared_fp4_repacked"
+    "load_shared_fp4_repacked", "get_scaled_upcast_fp4_scale_layout"
 ]
 
 

--- a/third_party/amd/python/test/test_gluon_cdna5.py
+++ b/third_party/amd/python/test/test_gluon_cdna5.py
@@ -154,7 +154,7 @@ def test_runtime_scaled_upcast_fp4(compact_scale, BLOCK_K):
         x = ttgl.load(x_ptr + x_offsets)
 
         if COMPACT_SCALE:
-            scale_layout: ttgl.constexpr = ttgl.amd.get_scaled_upcast_fp4_scale_layout(
+            scale_layout: ttgl.constexpr = ttgl.amd.cdna5.get_scaled_upcast_fp4_scale_layout(
                 x, SCALE_FACTOR, ttgl.bfloat16, axis=1)
             scale_k: ttgl.constexpr = BLOCK_K // SCALE_FACTOR
         else:

--- a/third_party/amd/python/test/test_gluon_scaled_upcast.py
+++ b/third_party/amd/python/test/test_gluon_scaled_upcast.py
@@ -20,7 +20,12 @@ def _compact_scaled_upcast_fp4_kernel(x_ptr, scale_ptr, out_ptr, M: ttgl.constex
     x = ttgl.load(x_ptr + x_offsets)
 
     scale_factor: ttgl.constexpr = OUT_K // SCALE_K
-    scale_layout: ttgl.constexpr = ttgl.amd.get_scaled_upcast_fp4_scale_layout(x, scale_factor, ttgl.bfloat16, axis=1)
+    if USE_CDNA4:
+        scale_layout: ttgl.constexpr = ttgl.amd.cdna4.get_scaled_upcast_fp4_scale_layout(
+            x, scale_factor, ttgl.bfloat16, axis=1)
+    else:
+        scale_layout: ttgl.constexpr = ttgl.amd.cdna3.get_scaled_upcast_fp4_scale_layout(
+            x, scale_factor, ttgl.bfloat16, axis=1)
     offs_scale_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, scale_layout))
     offs_scale_k = ttgl.arange(0, SCALE_K, layout=ttgl.SliceLayout(0, scale_layout))
     scale_offsets = offs_scale_m[:, None] * SCALE_K + offs_scale_k[None, :]


### PR DESCRIPTION
Follow up on https://github.com/triton-lang/triton/pull/11470 which exposed the layout helper at the global amd module. This PR exports it from the supported architectures (CDNA3-5).

Note that CDNA4 exports everything from CDNA3 so it requires no changes. 