### PR TITLE
Revert "[TRITONGPU] Try reusing existing layout rematerialization before hoisting layout conversion "

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1317,14 +1317,14 @@ bool LayoutRematerialization::hoistConvertDotOperand(
     auto type = dyn_cast<RankedTensorType>(loadOp->getResult(0).getType());
     if (!type)
       continue;
-    // If there is nothing to remat between the leaf op and the convert, we are
-    // done.
-    if (innerSlice.empty())
-      return false;
     auto newType = type.cloneWithEncoding(layout[loadOp->getResult(0)]);
     auto newConvertOp = ConvertLayoutOp::create(builder, convertOp.getLoc(),
                                                 newType, loadOp->getResult(0));
     mapping.map(loadOp->getResult(0), newConvertOp.getResult());
+  }
+
+  if (innerSlice.empty()) {
+    return false;
   }
 
   LLVM_DEBUG({

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -4599,31 +4599,3 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
-
-// -----
-
-// hoistConvertDotOperand should try to reuse existing rematerializations even if nothing is hoisted
-
-// CHECK-LABEL: @hoist_dot_operand_reuse_existing_remat
-// CHECK: tt.load
-// CHECK: ttg.convert_layout {{.*}} -> tensor<16x16xf32, #ttg.dot_op
-// CHECK: cvt.rna.tf32.f32
-// CHECK-NOT: cvt.rna.tf32.f32
-// CHECK-NOT: ttg.convert_layout
-// CHECK: tt.return
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
-#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [1, 1], instrShape = [16, 8]}>
-#dot0 = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
-#dot1 = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:89", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @hoist_dot_operand_reuse_existing_remat(%xp: tensor<16x16x!tt.ptr<f32>, #blocked>, %w: tensor<16x16xf32, #dot1>, %acc: tensor<16x16xf32, #mma>) -> tensor<16x16xf32, #mma> {
-    %x = tt.load %xp : tensor<16x16x!tt.ptr<f32>, #blocked>
-    %hi = tt.elementwise_inline_asm "cvt.rna.tf32.f32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %x : tensor<16x16xf32, #blocked> -> tensor<16x16xf32, #blocked>
-    %lo = arith.subf %x, %hi : tensor<16x16xf32, #blocked>
-    %a0 = ttg.convert_layout %lo : tensor<16x16xf32, #blocked> -> tensor<16x16xf32, #dot0>
-    %d0 = tt.dot %a0, %w, %acc, inputPrecision = tf32 : tensor<16x16xf32, #dot0> * tensor<16x16xf32, #dot1> -> tensor<16x16xf32, #mma>
-    %a1 = ttg.convert_layout %hi : tensor<16x16xf32, #blocked> -> tensor<16x16xf32, #dot0>
-    %d1 = tt.dot %a1, %w, %d0, inputPrecision = tf32 : tensor<16x16xf32, #dot0> * tensor<16x16xf32, #dot1> -> tensor<16x16xf32, #mma>
-    tt.return %d1 : tensor<16x16xf32, #mma>
-  }
-}


### PR DESCRIPTION
Reverts triton-lang/triton#11538 which causes a compiler crash in internal workloads.

<details>
<summary>
Minified reproducer

</summary>

```mlir
// Run: triton-opt reduced.mlir --tritongpu-remove-layout-conversions -o /dev/null
#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
#blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
#blocked3 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
#blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
#blocked5 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:80", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = false} {
  tt.func public @repro(%arg0: i32, %arg1: !tt.ptr<i64>, %arg2: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
    %cst = arith.constant dense<1.000000e+30> : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
    %cst_0 = arith.constant dense<-1.000000e+30> : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked1}>>
    %cst_1 = arith.constant dense<-5.000000e-01> : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked1}>>
    %cst_2 = arith.constant dense<-32> : tensor<128x32xi32, #blocked>
    %cst_3 = arith.constant dense<16> : tensor<128x32xi32, #blocked>
    %cst_4 = arith.constant dense<31> : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
    %cst_5 = arith.constant dense<1.000000e+30> : tensor<128x32xf32, #blocked>
    %cst_6 = arith.constant dense<5.000000e-01> : tensor<128x1xf32, #blocked2>
    %cst_7 = arith.constant dense<32> : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
    %cst_8 = arith.constant dense<4294967295> : tensor<128xi64, #blocked3>
    %cst_9 = arith.constant dense<16> : tensor<128x1xi64, #blocked4>
    %cst_10 = arith.constant dense<0> : tensor<128xi64, #blocked3>
    %c1023_i32 = arith.constant 1023 : i32
    %c127_i32 = arith.constant 127 : i32
    %c8_i32 = arith.constant 8 : i32
    %cst_11 = arith.constant dense<0.000000e+00> : tensor<128x16xf16, #blocked2>
    %c512_i64 = arith.constant 512 : i64
    %c4_i64 = arith.constant 4 : i64
    %c1_i32 = arith.constant 1 : i32
    %c1024_i32 = arith.constant 1024 : i32
    %c128_i32 = arith.constant 128 : i32
    %cst_12 = arith.constant dense<16> : tensor<32x1xi32, #blocked5>
    %0 = tt.get_program_id y : i32
    %1 = arith.extsi %0 : i32 to i64
    %2 = tt.get_program_id x : i32
    %3 = tt.get_num_programs x : i32
    %4 = arith.muli %1, %c512_i64 : i64
    %5 = tt.addptr %arg4, %4 : !tt.ptr<f32>, i64
    %6 = arith.muli %1, %c4_i64 : i64
    %7 = tt.addptr %arg1, %6 : !tt.ptr<i64>, i64
    %8 = tt.load %7 : !tt.ptr<i64>
    %9 = arith.trunci %8 : i64 to i32
    %10 = tt.addptr %7, %c1_i32 : !tt.ptr<i64>, i32
    %11 = tt.load %10 : !tt.ptr<i64>
    %12 = arith.trunci %11 : i64 to i32
    %13 = tt.addptr %arg2, %9 : !tt.ptr<i64>, i32
    %14 = arith.addi %12, %c127_i32 : i32
    %15 = arith.divsi %14, %c128_i32 : i32
    %16 = arith.minsi %3, %15 : i32
    %17 = arith.cmpi slt, %12, %arg5 : i32
    cf.cond_br %17, ^bb1, ^bb2
  ^bb1:  // pred: ^bb0
    tt.return
  ^bb2:  // pred: ^bb0
    %18 = arith.cmpi sge, %2, %16 : i32
    cf.cond_br %18, ^bb3, ^bb4
  ^bb3:  // pred: ^bb2
    tt.return
  ^bb4:  // pred: ^bb2
    %19 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
    %20 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked5}>>
    %21 = tt.expand_dims %20 {axis = 1 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked5}>> -> tensor<32x1xi32, #blocked5>
    %22 = arith.muli %21, %cst_12 : tensor<32x1xi32, #blocked5>
    %23 = tt.splat %5 : !tt.ptr<f32> -> tensor<32x1x!tt.ptr<f32>, #blocked5>
    %24 = tt.addptr %23, %22 : tensor<32x1x!tt.ptr<f32>, #blocked5>, tensor<32x1xi32, #blocked5>
    %25 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked5}>>
    %26 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked2}>>
    %27 = tt.expand_dims %25 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked5}>> -> tensor<1x16xi32, #blocked5>
    %28 = tt.expand_dims %26 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked2}>> -> tensor<1x16xi32, #blocked2>
    %29 = tt.broadcast %24 : tensor<32x1x!tt.ptr<f32>, #blocked5> -> tensor<32x16x!tt.ptr<f32>, #blocked5>
    %30 = tt.broadcast %27 : tensor<1x16xi32, #blocked5> -> tensor<32x16xi32, #blocked5>
    %31 = tt.addptr %29, %30 : tensor<32x16x!tt.ptr<f32>, #blocked5>, tensor<32x16xi32, #blocked5>
    %32 = tt.load %31 : tensor<32x16x!tt.ptr<f32>, #blocked5>
    %33 = arith.addi %12, %c1023_i32 : i32
    %34 = arith.divsi %33, %c1024_i32 : i32
    %35 = arith.truncf %32 : tensor<32x16xf32, #blocked5> to tensor<32x16xf16, #blocked5>
    %36 = tt.trans %35 {order = array<i32: 1, 0>} : tensor<32x16xf16, #blocked5> -> tensor<16x32xf16, #blocked1>
    %37 = arith.extf %36 : tensor<16x32xf16, #blocked1> to tensor<16x32xf32, #blocked1>
    %38 = arith.mulf %37, %37 : tensor<16x32xf32, #blocked1>
    %39 = "tt.reduce"(%38) <{axis = 0 : i32}> ({
    ^bb0(%arg7: f32, %arg8: f32):
      %45 = arith.addf %arg7, %arg8 : f32
      tt.reduce.return %45 : f32
    }) : (tensor<16x32xf32, #blocked1>) -> tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked1}>>
    %40 = arith.mulf %39, %cst_1 : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked1}>>
    %41 = tt.splat %arg6 : i32 -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
    %42 = arith.cmpi slt, %19, %41 : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
    %43 = arith.select %42, %40, %cst_0 : tensor<32xi1, #ttg.slice<{dim = 0, parent = #blocked1}>>, tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked1}>>
    %44 = scf.for %arg7 = %2 to %34 step %16 iter_args(%arg8 = %cst) -> (tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>>)  : i32 {
      %45 = arith.muli %arg7, %c8_i32 : i32
      %46 = arith.addi %arg7, %c1_i32 : i32
      %47 = arith.muli %46, %c8_i32 : i32
      %48 = arith.minsi %15, %47 : i32
      %49 = scf.for %arg9 = %45 to %48 step %c1_i32 iter_args(%arg10 = %arg8) -> (tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>>)  : i32 {
        %50 = arith.muli %arg9, %c128_i32 : i32
        %51 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
        %52 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>>
        %53 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked3>
        %54 = tt.splat %50 : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
        %55 = tt.splat %50 : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>>
        %56 = tt.splat %50 : i32 -> tensor<128xi32, #blocked3>
        %57 = arith.addi %54, %51 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
        %58 = arith.addi %55, %52 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>>
        %59 = arith.addi %56, %53 : tensor<128xi32, #blocked3>
        %60 = tt.splat %12 : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
        %61 = tt.splat %12 : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>>
        %62 = tt.splat %12 : i32 -> tensor<128xi32, #blocked3>
        %63 = arith.cmpi slt, %57, %60 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
        %64 = arith.cmpi slt, %58, %61 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>>
        %65 = arith.cmpi slt, %59, %62 : tensor<128xi32, #blocked3>
        %66 = tt.splat %13 : !tt.ptr<i64> -> tensor<128x!tt.ptr<i64>, #blocked3>
        %67 = tt.addptr %66, %59 : tensor<128x!tt.ptr<i64>, #blocked3>, tensor<128xi32, #blocked3>
        %68 = tt.load %67, %65, %cst_10 : tensor<128x!tt.ptr<i64>, #blocked3>
        %69 = arith.andi %68, %cst_8 : tensor<128xi64, #blocked3>
        %70 = tt.expand_dims %64 {axis = 1 : i32} : tensor<128xi1, #ttg.slice<{dim = 1, parent = #blocked2}>> -> tensor<128x1xi1, #blocked2>
        %71 = ttg.convert_layout %69 : tensor<128xi64, #blocked3> -> tensor<128xi64, #ttg.slice<{dim = 1, parent = #blocked4}>>
        %72 = tt.expand_dims %71 {axis = 1 : i32} : tensor<128xi64, #ttg.slice<{dim = 1, parent = #blocked4}>> -> tensor<128x1xi64, #blocked4>
        %73 = arith.muli %72, %cst_9 : tensor<128x1xi64, #blocked4>
        %74 = tt.splat %arg3 : !tt.ptr<f16> -> tensor<128x1x!tt.ptr<f16>, #blocked4>
        %75 = tt.addptr %74, %73 : tensor<128x1x!tt.ptr<f16>, #blocked4>, tensor<128x1xi64, #blocked4>
        %76 = ttg.convert_layout %75 : tensor<128x1x!tt.ptr<f16>, #blocked4> -> tensor<128x1x!tt.ptr<f16>, #blocked2>
        %77 = tt.broadcast %76 : tensor<128x1x!tt.ptr<f16>, #blocked2> -> tensor<128x16x!tt.ptr<f16>, #blocked2>
        %78 = tt.broadcast %28 : tensor<1x16xi32, #blocked2> -> tensor<128x16xi32, #blocked2>
        %79 = tt.addptr %77, %78 : tensor<128x16x!tt.ptr<f16>, #blocked2>, tensor<128x16xi32, #blocked2>
        %80 = tt.broadcast %70 : tensor<128x1xi1, #blocked2> -> tensor<128x16xi1, #blocked2>
        %81 = tt.load %79, %80, %cst_11 : tensor<128x16x!tt.ptr<f16>, #blocked2>
        %82 = tt.expand_dims %43 {axis = 0 : i32} : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x32xf32, #blocked1>
        %83 = ttg.convert_layout %82 : tensor<1x32xf32, #blocked1> -> tensor<1x32xf32, #blocked>
        %84 = tt.broadcast %83 : tensor<1x32xf32, #blocked> -> tensor<128x32xf32, #blocked>
        %85 = ttg.convert_layout %84 : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #mma>
        %86 = ttg.convert_layout %81 : tensor<128x16xf16, #blocked2> -> tensor<128x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
        %87 = ttg.convert_layout %36 : tensor<16x32xf16, #blocked1> -> tensor<16x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
        %88 = tt.dot %86, %87, %85, inputPrecision = tf32x3 : tensor<128x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<16x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x32xf32, #mma>
        %89 = ttg.convert_layout %88 : tensor<128x32xf32, #mma> -> tensor<128x32xf32, #blocked>
        %90 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
        %91 = tt.expand_dims %90 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
        %92 = tt.bitcast %89 : tensor<128x32xf32, #blocked> -> tensor<128x32xi32, #blocked>
        %93 = arith.addi %92, %cst_3 : tensor<128x32xi32, #blocked>
        %94 = arith.andi %93, %cst_2 : tensor<128x32xi32, #blocked>
        %95 = tt.broadcast %91 : tensor<1x32xi32, #blocked> -> tensor<128x32xi32, #blocked>
        %96 = arith.ori %94, %95 : tensor<128x32xi32, #blocked>
        %97 = tt.bitcast %96 : tensor<128x32xi32, #blocked> -> tensor<128x32xf32, #blocked>
        %98 = "tt.reduce"(%97) <{axis = 1 : i32}> ({
        ^bb0(%arg11: f32, %arg12: f32):
          %122 = arith.maxnumf %arg11, %arg12 : f32
          tt.reduce.return %122 : f32
        }) : (tensor<128x32xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
        %99 = tt.bitcast %98 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
        %100 = arith.andi %99, %cst_4 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
        %101 = arith.select %63, %100, %cst_7 : tensor<128xi1, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
        %102 = ttg.convert_layout %101 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128xi32, #blocked3>
        %103 = arith.extsi %102 : tensor<128xi32, #blocked3> to tensor<128xi64, #blocked3>
        %104 = arith.extsi %arg0 : i32 to i64
        %105 = tt.splat %104 : i64 -> tensor<128xi64, #blocked3>
        %106 = arith.shli %103, %105 : tensor<128xi64, #blocked3>
        %107 = arith.ori %68, %106 : tensor<128xi64, #blocked3>
        tt.store %67, %107, %65 : tensor<128x!tt.ptr<i64>, #blocked3>
        %108 = arith.extf %81 : tensor<128x16xf16, #blocked2> to tensor<128x16xf32, #blocked2>
        %109 = arith.mulf %108, %108 : tensor<128x16xf32, #blocked2>
        %110 = "tt.reduce"(%109) <{axis = 1 : i32}> ({
        ^bb0(%arg11: f32, %arg12: f32):
          %122 = arith.addf %arg11, %arg12 : f32
          tt.reduce.return %122 : f32
        }) : (tensor<128x16xf32, #blocked2>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked2}>>
        %111 = tt.expand_dims %110 {axis = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked2}>> -> tensor<128x1xf32, #blocked2>
        %112 = arith.mulf %111, %cst_6 : tensor<128x1xf32, #blocked2>
        %113 = ttg.convert_layout %112 : tensor<128x1xf32, #blocked2> -> tensor<128x1xf32, #blocked>
        %114 = tt.broadcast %113 : tensor<128x1xf32, #blocked> -> tensor<128x32xf32, #blocked>
        %115 = arith.subf %89, %114 : tensor<128x32xf32, #blocked>
        %116 = tt.expand_dims %101 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
        %117 = tt.broadcast %116 : tensor<128x1xi32, #blocked> -> tensor<128x32xi32, #blocked>
        %118 = arith.cmpi eq, %117, %95 : tensor<128x32xi32, #blocked>
        %119 = arith.select %118, %115, %cst_5 : tensor<128x32xi1, #blocked>, tensor<128x32xf32, #blocked>
        %120 = "tt.reduce"(%119) <{axis = 0 : i32}> ({
        ^bb0(%arg11: f32, %arg12: f32):
          %122 = arith.minnumf %arg11, %arg12 : f32
          tt.reduce.return %122 : f32
        }) : (tensor<128x32xf32, #blocked>) -> tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
        %121 = arith.minnumf %120, %arg10 : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
        scf.yield %121 : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
      }
      scf.yield %49 : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
    }
    tt.return
  }
}

```
</details>