### PR TITLE
[AMD] Enable amdgpu-use-amdgpu-trackers only when waves_per_eu > 1

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -48,7 +48,7 @@ def is_expert_scheduling_enabled(arch):
     return arch in ["gfx1250"]
 
 
-def get_llvm_flags(arch):
+def get_llvm_flags(options):
     """LLVM command line flags for every LLVM pipeline run of a compilation.
 
     These are process-wide LLVM options: compilations sharing a process can only
@@ -57,8 +57,9 @@ def get_llvm_flags(arch):
     """
     flags = []
     # LLVM has no per-function attribute for the AMDGPU register pressure
-    # trackers yet.
-    if arch in ["gfx942", "gfx950"]:
+    # trackers yet. They help kernels that request waves_per_eu > 1 and would
+    # otherwise spill, but regress single-wave MFMA kernels that already fit.
+    if options.arch in ["gfx942", "gfx950"] and options.waves_per_eu > 1:
         flags.append("amdgpu-use-amdgpu-trackers")
     return flags
 
@@ -447,7 +448,7 @@ class HIPBackend(BaseBackend):
         target_features = ''
         if knobs.compilation.enable_asan:
             target_features = '+xnack'
-        llvm.attach_datalayout(llvm_mod, target_triple, options.arch, target_features, get_llvm_flags(options.arch))
+        llvm.attach_datalayout(llvm_mod, target_triple, options.arch, target_features, get_llvm_flags(options))
 
         # Set various control constants on the LLVM module so that device
         # libraries can resolve references to them.
@@ -526,7 +527,7 @@ class HIPBackend(BaseBackend):
                 if not fn.is_declaration():
                     fn.add_fn_attr("amdgpu-expert-scheduling-mode", "true")
 
-        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, '', get_llvm_flags(options.arch),
+        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, '', get_llvm_flags(options),
                              options.enable_fp_fusion, disable_vector_combine=True)
 
         # Architectures with architected SGPRs store the workgroup id in ttmp9 (X) and ttmp7 (Y[15:0], Z[31:16]).
@@ -567,7 +568,7 @@ class HIPBackend(BaseBackend):
         assert len(names) == 1
         metadata["name"] = names[0]
         # llvm -> hsaco
-        flags = get_llvm_flags(options.arch)
+        flags = get_llvm_flags(options)
         features = ''
         target_triple = amd.get_target_triple(options.arch)
         ir_hash = hashlib.sha256(src.encode("utf-8")).hexdigest()


### PR DESCRIPTION
#11285 started passing LLVM's `amdgpu-use-amdgpu-trackers` for every gfx942/gfx950 compilation. That helps kernels that request a multi-wave occupancy target and would otherwise spill, but it regresses single-wave kernels that already fit, badly so for MFMA-heavy ones. This PR keys the flag on the kernel's `waves_per_eu` request and only passes it when `waves_per_eu > 1`.

## Why

The trackers make the machine scheduler chase register pressure harder. Under a tight budget that is the right trade. For a kernel at occupancy 1 with no spills, lower pressure buys nothing, and the tracker-driven schedule ends up bouncing MFMA accumulators between AGPRs and VGPRs until both register files overflow.

Measured on gfx950 by feeding fixed LLVM IR to `llc` with and without the flag (same LLVM; main loop instructions / AGPR-VGPR copies / spilled VGPRs):

| kernel (AITER) | waves_per_eu | flag off | flag on |
|---|---|---|---|
| gemm_afp4wfp4 4096x4096x4096 | 1 | 236 / 27 / 0 | 897 / 605 / 64 |
| gemm_a16w16 1x2880x4096 | 8 | 83 / 0 / 17 | 86 / 0 / 0 |
| gemm_a16w16 1x1280x8192 | 8 | 313 / 2 / 140 | 233 / 6 / 24 |

The afp4wfp4 kernel loses roughly half its throughput with the flag on (1315 vs 2639 TFLOPS in AITER's benchmark); the a16w16 kernels are the cases the flag was introduced for. The pattern is identical on every LLVM from the February 2026 pin through current main, so this is a question of which kernels should opt in rather than an LLVM regression. Two July LLVM changes to the tracker's pressure estimates (llvm/llvm-project#208574, #211139) made the afp4wfp4 case somewhat worse but did not create it.

## What changes

* `get_llvm_flags` takes the `HIPOptions` and adds the trackers flag only for gfx942/gfx950 kernels with `waves_per_eu > 1`. `waves_per_eu` is the same request that becomes the `amdgpu-waves-per-eu` function attribute, so the flag now follows the kernel's own occupancy target.
* Because the flag is a process-wide LLVM option, kernels with and without it can no longer overlap inside one process; `ScopedLLVMOptions` serializes them. That is a small parallelism cost, not a correctness issue.
* LLVM has no per-function attribute for the trackers yet. Once one exists this should become an attribute set in `make_llir`, which would also remove the serialization. That switch will be needed anyway: llvm/llvm-project#210547 turns the trackers on inside the max-occupancy strategy, and once Triton picks that up the absence of the flag no longer means off, so the opt-out for single-wave kernels has to become explicit.

## Testing

* Compiled both kernels for gfx950 with `triton.compile` on this branch (no GPU needed), main loop instructions / AGPR-VGPR copies / spilled VGPRs:
  * AITER `_gemm_afp4wfp4_kernel`, 4096^3 config, `waves_per_eu=1`: 334 / 122 / 0. Forcing the flag back on for the same build with `DISABLE_LLVM_OPT=amdgpu-use-amdgpu-trackers` gives 910 / 550 / 256, i.e. the regression this PR removes.
  * AITER `_gemm_a16w16_kernel`, 1x2880x4096 config, `waves_per_eu=8`: 54 VGPRs, 0 spills, unchanged from before this PR, so kernels that asked for occupancy keep the trackers.
* `pre-commit run --from-ref upstream/main --to-ref HEAD` passes.
