### PR TITLE
[FRONTEND] Materialize FP8 constants directly

### DIFF
--- a/python/src/fp8.h
+++ b/python/src/fp8.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "llvm/ADT/APFloat.h"
+
+// Match FP8 casts: saturate overflow, but preserve FNUZ infinity-to-NaN
+// behavior.
+inline llvm::APFloat convertFp8(float value,
+                                const llvm::fltSemantics &semantics) {
+  llvm::APFloat result(value);
+  bool isFnuz = &semantics == &llvm::APFloat::Float8E4M3FNUZ() ||
+                &semantics == &llvm::APFloat::Float8E5M2FNUZ();
+  bool saturate = result.isFinite() || (result.isInfinity() && !isFnuz);
+  bool negative = result.isNegative();
+  bool losesInfo;
+  result.convert(semantics, llvm::APFloat::rmNearestTiesToEven, &losesInfo);
+  if (saturate && !result.isFinite())
+    return llvm::APFloat::getLargest(semantics, negative);
+  return result;
+}

--- a/python/src/interpreter.cc
+++ b/python/src/interpreter.cc
@@ -1,4 +1,4 @@
-#include "llvm/ADT/APFloat.h"
+#include "fp8.h"
 
 #include <atomic>
 #include <cmath>
@@ -752,18 +752,24 @@ void init_triton_interpreter(py::module_ &m) {
   m.def("fma_fp32", &fma_array<float>);
   m.def("fma_fp64", &fma_array<double>);
 
-  m.def("get_fp8", [](float value, const std::string &dtype) {
+  m.def("convert_fp8", [](const AnyArray &input, const std::string &dtype) {
+    require_dtype<float>(input, "input");
     static const std::map<std::string, const llvm::fltSemantics *> semantics = {
         {"fp8e4nv", &llvm::APFloat::Float8E4M3FN()},
         {"fp8e5", &llvm::APFloat::Float8E5M2()},
         {"fp8e4b8", &llvm::APFloat::Float8E4M3FNUZ()},
         {"fp8e5b16", &llvm::APFloat::Float8E5M2FNUZ()},
     };
-    llvm::APFloat result(value);
-    bool losesInfo;
-    result.convert(*semantics.at(dtype), llvm::APFloat::rmNearestTiesToEven,
-                   &losesInfo);
-    return result.bitcastToAPInt().getZExtValue();
+    const auto &dstSemantics = *semantics.at(dtype);
+    py::object ret = numpy_empty(input.size(), py::str("uint8"));
+    auto ret_array = py::cast<MutableArray>(ret);
+    auto *out = static_cast<uint8_t *>(ret_array.data());
+    for (size_t i = 0; i < input.size(); ++i) {
+      float value;
+      memcpy(&value, const_element_data(input, i), sizeof(value));
+      out[i] = convertFp8(value, dstSemantics).bitcastToAPInt().getZExtValue();
+    }
+    return ret.attr("reshape")(shape_list(input));
   });
 
   m.def("load",

--- a/python/src/interpreter.cc
+++ b/python/src/interpreter.cc
@@ -1,3 +1,5 @@
+#include "llvm/ADT/APFloat.h"
+
 #include <atomic>
 #include <cmath>
 #include <cstddef>
@@ -749,6 +751,20 @@ void init_triton_interpreter(py::module_ &m) {
 
   m.def("fma_fp32", &fma_array<float>);
   m.def("fma_fp64", &fma_array<double>);
+
+  m.def("get_fp8", [](float value, const std::string &dtype) {
+    static const std::map<std::string, const llvm::fltSemantics *> semantics = {
+        {"fp8e4nv", &llvm::APFloat::Float8E4M3FN()},
+        {"fp8e5", &llvm::APFloat::Float8E5M2()},
+        {"fp8e4b8", &llvm::APFloat::Float8E4M3FNUZ()},
+        {"fp8e5b16", &llvm::APFloat::Float8E5M2FNUZ()},
+    };
+    llvm::APFloat result(value);
+    bool losesInfo;
+    result.convert(*semantics.at(dtype), llvm::APFloat::rmNearestTiesToEven,
+                   &losesInfo);
+    return result.bitcastToAPInt().getZExtValue();
+  });
 
   m.def("load",
         [](py::object ptr_obj, py::object mask_obj, py::object other_obj,

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -995,6 +995,11 @@ void init_triton_ir(py::module_ &m) {
              return self.create<arith::ConstantFloatOp>(
                  type, APFloat(type.getFloatSemantics(), std::to_string(v)));
            })
+      .def("get_fp8",
+           [](TritonOpBuilder &self, float v, Type type) -> Value {
+             return self.create<arith::ConstantOp>(
+                 self.getBuilder().getFloatAttr(type, v));
+           })
       .def("get_fp16",
            [](TritonOpBuilder &self, float v) -> Value {
              return self.create<arith::ConstantOp>(

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1,4 +1,5 @@
 #include "ir.h"
+#include "fp8.h"
 
 #include <cstring>
 #include <nanobind/nanobind.h>
@@ -997,8 +998,9 @@ void init_triton_ir(py::module_ &m) {
            })
       .def("get_fp8",
            [](TritonOpBuilder &self, float v, Type type) -> Value {
-             return self.create<arith::ConstantOp>(
-                 self.getBuilder().getFloatAttr(type, v));
+             auto floatType = cast<FloatType>(type);
+             return self.create<arith::ConstantFloatOp>(
+                 floatType, convertFp8(v, floatType.getFloatSemantics()));
            })
       .def("get_fp16",
            [](TritonOpBuilder &self, float v) -> Value {

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1015,16 +1015,6 @@ void init_triton_ir(py::module_ &m) {
              return self.create<arith::ConstantOp>(
                  self.getBuilder().getF64FloatAttr(v));
            })
-      .def("get_null_value",
-           [](TritonOpBuilder &self, Type type) -> Value {
-             if (auto floatTy = dyn_cast<FloatType>(type))
-               return self.create<arith::ConstantFloatOp>(
-                   floatTy, APFloat(floatTy.getFloatSemantics(), 0));
-             else if (auto intTy = dyn_cast<IntegerType>(type))
-               return self.create<arith::ConstantIntOp>(intTy, 0);
-             else
-               throw std::runtime_error("Not implemented");
-           })
       .def("get_all_ones_value",
            [](TritonOpBuilder &self, Type type) -> Value {
              uint64_t val = 0xFFFFFFFFFFFFFFFF;

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -4179,12 +4179,11 @@ def test_amd_scaled_upcast_fp8_cdna(target):
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @kernel() attributes {noinline = false} {
-    %cst = arith.constant 1.000000e+00 : f32
-    %0 = arith.truncf %cst : f32 to f8E4M3FN
-    %1 = tt.splat %0 : f8E4M3FN -> tensor<16x64xf8E4M3FN, #blocked>
+    %cst = arith.constant 1.000000e+00 : f8E4M3FN
+    %cst_0 = arith.constant dense<1.000000e+00> : tensor<16x64xf8E4M3FN, #blocked>
     %c2_i8 = arith.constant 2 : i8
-    %cst_0 = arith.constant dense<2> : tensor<16x64xi8, #blocked>
-    %2 = amdg.scaled_upcast_fp8 %1 scale %cst_0 : tensor<16x64xf8E4M3FN, #blocked>, tensor<16x64xi8, #blocked> -> tensor<16x64xbf16, #blocked>
+    %cst_1 = arith.constant dense<2> : tensor<16x64xi8, #blocked>
+    %0 = amdg.scaled_upcast_fp8 %cst_0 scale %cst_1 : tensor<16x64xf8E4M3FN, #blocked>, tensor<16x64xi8, #blocked> -> tensor<16x64xbf16, #blocked>
     tt.return
   }
 }

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -391,13 +391,7 @@ def test_fp8_compiles_for_multiple_architectures_hip():
 
 
 def test_fp8_compiles_for_multiple_architectures_cuda():
-    """
-    Validate FP8 compilation succeeds for architectures with different
-    hardware support.
-
-    SM90 has native FP8 instructions; SM80 does not and requires software
-    conversion. Compiling for both in sequence must succeed for each target.
-    """
+    """Compile native and software FP8 conversion paths in the same process."""
 
     @triton.jit
     def fp8_convert(src, dst):
@@ -407,3 +401,5 @@ def test_fp8_compiles_for_multiple_architectures_cuda():
     src = ASTSource(fn=fp8_convert, signature={"src": "*fp32", "dst": "*fp8e5"}, constexprs={})
     triton.compile(src, target=GPUTarget("cuda", 90, 32))
     triton.compile(src, target=GPUTarget("cuda", 80, 32))
+    triton.compile(src, target=GPUTarget("cuda", 75, 32))
+    triton.compile(src, target=GPUTarget("cuda", 89, 32), options=dict(ptx_version=81))

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -7,7 +7,7 @@ import pytest
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna3, is_hip_rdna4, is_hip_gfx1250
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna3
 
 FP8_DTYPES = ('float8e5', 'float8e4b15', 'float8e4nv', 'float8e4b8', 'float8e5b16')
 
@@ -338,11 +338,8 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
 def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
 
     if is_cuda():
-        if src_dtype != 'float32' and torch.cuda.get_device_capability(0) < (9, 0):
-            pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
-
-        if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
-            pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
+        if dst_dtype == 'float8e4nv' and torch.cuda.get_device_capability(0) < (8, 9):
+            pytest.skip("float8e4nv requires compute capability 8.9+")
 
         if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne':
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU CDNA3")
@@ -374,17 +371,11 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
 @pytest.mark.parametrize("src_dtype", ["float32", "float16", "bfloat16"])
 def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, rounding="rtne"):
     if is_cuda():
-        if src_dtype != 'float32' and torch.cuda.get_device_capability(0) < (9, 0):
-            pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
-
-        if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
-            pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
+        if dst_dtype == 'float8e4nv' and torch.cuda.get_device_capability(0) < (8, 9):
+            pytest.skip("float8e4nv requires compute capability 8.9+")
 
     if dst_dtype in FP8_DTYPES and is_hip_rdna3():
         pytest.skip(f"{dst_dtype} is not supported on AMDGPU RDNA3")
-
-    if mode in ('inf', '-inf') and (is_hip_rdna4() or is_hip_gfx1250()):
-        pytest.skip(f"clamping from `{mode}` is not supported on AMDGPU GFX12")
 
     converter = {
         tl.float8e4nv: torch.float8_e4m3fn,
@@ -433,6 +424,44 @@ def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, round
         assert(torch.all(torch.isnan(dst)))
     else:
         torch.testing.assert_close(dst, torch.full_like(dst, expected_result))
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("src_dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("dst_dtype", [
+    torch.float8_e4m3fn, torch.float8_e5m2, torch.float8_e4m3fnuz, torch.float8_e5m2fnuz,
+])
+def test_typeconvert_downcast_special_values(src_dtype, dst_dtype, device):
+    fnuz = dst_dtype in (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz)
+    if is_cuda():
+        if fnuz:
+            pytest.skip("FNUZ formats are not supported on CUDA")
+        if dst_dtype == torch.float8_e4m3fn and torch.cuda.get_device_capability(0) < (8, 9):
+            pytest.skip("float8e4m3fn requires compute capability 8.9+")
+    if is_hip_rdna3():
+        pytest.skip("FP8 is not supported on AMDGPU RDNA3")
+
+    values = [
+        0.0, -0.0, 1.0625 + 2**-23, -1.0625 - 2**-23,
+        1.0625, -1.0625, 1.125 + 2**-23, -1.125 - 2**-23,
+        1.1875, -1.1875, 1.875, 1.9375, 2**-16, -2**-16, 2**-17, -2**-17,
+        2**-18, -2**-18, 240.0, -240.0, 248.0, -248.0, 448.0, -448.0,
+        465.0, -465.0, 61440.0, -61440.0, 1e10, float("inf"), float("-inf"), float("nan"),
+    ]
+    src = torch.tensor(values, dtype=src_dtype, device=device)
+    dst = torch.empty(src.shape, dtype=dst_dtype, device=device)
+    type_convert_triton[(1,)](src, dst, "rtne", len(values))
+
+    actual = dst.cpu()
+    src = src.cpu().float()
+    max_value = torch.finfo(dst_dtype).max
+    expected = src.clamp(-max_value, max_value)
+    if fnuz:
+        expected[src.isinf()] = float("nan")
+    expected = expected.to(dst_dtype)
+    is_nan = expected.float().isnan()
+    torch.testing.assert_close(actual.float().isnan(), is_nan)
+    torch.testing.assert_close(actual.view(torch.uint8)[~is_nan], expected.view(torch.uint8)[~is_nan])
 
 
 @pytest.mark.parametrize("src_dtype", ['float8e4b8', 'float8e5b16'])

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4806,7 +4806,8 @@ def test_full(dtype_str, shape, device):
 @pytest.mark.parametrize("shape", [(), (1, ), (128, )])
 @pytest.mark.parametrize("value", [
     0.0, -0.0, 1.0, 0.1, -0.1, 1.1, 1.0625, 1.1875, 1.125, 1.375, 1.0625 + 2**-30, 1.125 + 2**-30, 2**-9,
-    2**-10 + 2**-20, 2**-16, 2**-17, 2**-18, -2**-18, 240.0, 248.0, 448.0, 464.0, 465.0, 57344.0, 61440.0,
+    2**-10 + 2**-20, 2**-16, 2**-17, 2**-18, -2**-18, 240.0, 248.0, 448.0, 464.0, -464.0, 464.0 + 2**-20, 465.0, -465.0,
+    57344.0, 61440.0,
     float("inf"),
     float("-inf"),
     float("nan")
@@ -4827,7 +4828,9 @@ def test_full_fp8(dtype, shape, value, device):
     kernel[(1, )](out, value, shape)
     actual = out.cpu()
     expected = torch.full((128, ), value, dtype=torch.float32, device="cpu").to(dtype)
-    if torch.isnan(expected.float()).all():
+    # E4M3 constants overflow to NaN; newer PyTorch versions saturate to +/-448.
+    overflows_e4m3 = dtype == torch.float8_e4m3fn and abs(np.float32(value)) > 464
+    if overflows_e4m3 or torch.isnan(expected.float()).all():
         assert torch.isnan(actual.float()).all()
     else:
         torch.testing.assert_close(actual.view(torch.uint8), expected.view(torch.uint8))

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4805,9 +4805,10 @@ def test_full(dtype_str, shape, device):
                          [torch.float8_e4m3fn, torch.float8_e5m2, torch.float8_e4m3fnuz, torch.float8_e5m2fnuz])
 @pytest.mark.parametrize("shape", [(), (1, ), (128, )])
 @pytest.mark.parametrize("value", [
-    0.0, -0.0, 1.0, 0.1, -0.1, 1.1, 1.0625, 1.1875, 1.125, 1.375, 1.0625 + 2**-30, 1.125 + 2**-30, 2**-9,
-    2**-10 + 2**-20, 2**-16, 2**-17, 2**-18, -2**-18, 240.0, 248.0, 448.0, 464.0, -464.0, 464.0 + 2**-20, 465.0, -465.0,
-    57344.0, 61440.0,
+    0.0, -0.0, 1.0, 0.1, -0.1, 1.1, 1.0625, 1.1875, 1.125, 1.375, 1.875, 1.9375, 1.0625 + 2**-30, 1.125 + 2**-30,
+    1.0625 + 2**-23, 1.125 + 2**-23, 2**-9, 2**-10 + 2**-20, 2**-16, 2**-17, 2**-18, -2**-18, 2**-18 + 2**-30, 240.0,
+    248.0, 448.0, 464.0, -464.0, 464.0 + 2**-20, 465.0, -465.0, 57344.0, -57344.0, 61440.0, -61440.0, 65504.0, 1e10,
+    -1e10,
     float("inf"),
     float("-inf"),
     float("nan")
@@ -4819,18 +4820,25 @@ def test_full_fp8(dtype, shape, value, device):
         pytest.skip("FNUZ formats are not supported on CUDA")
 
     @triton.jit
-    def kernel(out, value: tl.constexpr, shape: tl.constexpr):
+    def kernel(src, out, value: tl.constexpr, shape: tl.constexpr):
         a = tl.full(shape, value, out.dtype.element_ty)
+        b = tl.full(shape, tl.load(src), out.dtype.element_ty)
         tl.static_assert(a.shape == shape)
+        tl.static_assert(b.shape == shape)
         tl.store(out + tl.arange(0, 128), a)
+        tl.store(out + 128 + tl.arange(0, 128), b)
 
-    out = torch.empty((128, ), dtype=dtype, device=device)
-    kernel[(1, )](out, value, shape)
+    src = torch.tensor([value], dtype=torch.float32)
+    out = torch.empty((2, 128), dtype=dtype, device=device)
+    kernel[(1, )](src.to(device), out, value, shape)
     actual = out.cpu()
-    expected = torch.full((128, ), value, dtype=torch.float32, device="cpu").to(dtype)
-    # E4M3 constants overflow to NaN; newer PyTorch versions saturate to +/-448.
-    overflows_e4m3 = dtype == torch.float8_e4m3fn and abs(np.float32(value)) > 464
-    if overflows_e4m3 or torch.isnan(expected.float()).all():
+    # FP8 casts saturate, except that FNUZ formats map infinities to NaN.
+    max_value = torch.finfo(dtype).max
+    expected = src.clamp(-max_value, max_value)
+    if triton_dtype in (tl.float8e4b8, tl.float8e5b16) and torch.isinf(src).all():
+        expected.fill_(float("nan"))
+    expected = expected.to(dtype).expand_as(actual)
+    if torch.isnan(expected.float()).all():
         assert torch.isnan(actual.float()).all()
     else:
         torch.testing.assert_close(actual.view(torch.uint8), expected.view(torch.uint8))

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4800,6 +4800,39 @@ def test_full(dtype_str, shape, device):
     assert torch.all(out_dynamic == 2)
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("dtype",
+                         [torch.float8_e4m3fn, torch.float8_e5m2, torch.float8_e4m3fnuz, torch.float8_e5m2fnuz])
+@pytest.mark.parametrize("shape", [(), (1, ), (128, )])
+@pytest.mark.parametrize("value", [
+    0.0, -0.0, 1.0, 0.1, -0.1, 1.1, 1.0625, 1.1875, 1.125, 1.375, 1.0625 + 2**-30, 1.125 + 2**-30, 2**-9,
+    2**-10 + 2**-20, 2**-16, 2**-17, 2**-18, -2**-18, 240.0, 248.0, 448.0, 464.0, 465.0, 57344.0, 61440.0,
+    float("inf"),
+    float("-inf"),
+    float("nan")
+])
+def test_full_fp8(dtype, shape, value, device):
+    triton_dtype = str_to_triton_dtype(torch_dtype_name(dtype))
+    check_type_supported(triton_dtype, device)
+    if is_cuda() and triton_dtype in (tl.float8e4b8, tl.float8e5b16):
+        pytest.skip("FNUZ formats are not supported on CUDA")
+
+    @triton.jit
+    def kernel(out, value: tl.constexpr, shape: tl.constexpr):
+        a = tl.full(shape, value, out.dtype.element_ty)
+        tl.static_assert(a.shape == shape)
+        tl.store(out + tl.arange(0, 128), a)
+
+    out = torch.empty((128, ), dtype=dtype, device=device)
+    kernel[(1, )](out, value, shape)
+    actual = out.cpu()
+    expected = torch.full((128, ), value, dtype=torch.float32, device="cpu").to(dtype)
+    if torch.isnan(expected.float()).all():
+        assert torch.isnan(actual.float()).all()
+    else:
+        torch.testing.assert_close(actual.view(torch.uint8), expected.view(torch.uint8))
+
+
 @pytest.mark.parametrize("literal, dtype_str", [(1e+50, "f64"), (1e+10, "f32"), (1.0, "f32"), ('float("inf")', "f32"),
                                                 ('float("-inf")', "f32"), ('float("nan")', "f32"),
                                                 ('float("-nan")', "f32"), (0., "f32"), (5, "i32"), (2**40, "i64")])

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -1086,9 +1086,9 @@ def test_fp8_div_mod_promotion():
 
     @triton.jit
     def kernel():
-        x = tl.full((8, ), 0, tl.float16).to(tl.float8e5)
-        y = tl.full((8, ), 0, tl.float16).to(tl.float8e5)
-        z = tl.full((8, ), 0, tl.float16).to(tl.float8e4nv)
+        x = tl.full((8, ), 0, tl.float8e5)
+        y = tl.full((8, ), 0, tl.float8e5)
+        z = tl.full((8, ), 0, tl.float8e4nv)
         h = tl.full((8, ), 0, tl.float16)
         b = tl.full((8, ), 0, tl.bfloat16)
         d = tl.full((8, ), 0, tl.float64)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -607,8 +607,7 @@ class TritonSemantic(Generic[TensorTy]):
             value = self.tensor(self.builder.get_fp32(value), tl.float32)
             return self.cast(value, dtype)
         elif dtype.is_fp8():
-            value = self.builder.get_fp32(value)
-            value = self.builder.create_fp_trunc(value, dtype.to_ir(self.builder))
+            value = self.builder.get_fp8(value, dtype.to_ir(self.builder))
         else:
             get_value_fn = getattr(self.builder, f"get_{dtype.name}")
             value = get_value_fn(value)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -476,8 +476,7 @@ class TritonSemantic(Generic[TensorTy]):
             raise ValueError("wrong type argument to unary minus (" + input_sca_ty.__repr__() + ")")
         if input_sca_ty.is_floating():
             return self.tensor(self.builder.create_fneg(input.handle), input.type)
-        _0 = self.tensor(self.builder.get_null_value(input_sca_ty.to_ir(self.builder)), input_sca_ty)
-        return self.sub(_0, input, True)
+        return self.sub(self.scalar_constant(0, input_sca_ty), input, True)
 
     def invert(self, input: TensorTy) -> TensorTy:
         input_sca_ty = input.type.scalar
@@ -867,9 +866,7 @@ class TritonSemantic(Generic[TensorTy]):
            (src_sca_ty.int_bitwidth != dst_sca_ty.int_bitwidth or src_sca_ty.int_signedness != dst_sca_ty.int_signedness):
             sign_extend = src_sca_ty.is_int_signed() and not src_sca_ty.is_bool()
             if dst_sca_ty.is_bool():
-                ty = input.dtype.to_ir(self.builder)
-                _0 = self.tensor(self.builder.get_null_value(ty), input.dtype)
-                return self.not_equal(input, _0)
+                return self.not_equal(input, self.scalar_constant(0, input.dtype))
             else:
                 return self.tensor(self.builder.create_int_cast(input.handle, dst_ty.to_ir(self.builder), sign_extend),
                                    dst_ty)
@@ -877,9 +874,7 @@ class TritonSemantic(Generic[TensorTy]):
         # Casting standard floating types to integer types
         if src_sca_ty.is_standard_floating() and dst_sca_ty.is_int():
             if dst_sca_ty.is_bool():
-                ty = input.dtype.to_ir(self.builder)
-                _0 = self.tensor(self.builder.get_null_value(ty), input.dtype)
-                return self.not_equal(input, _0)
+                return self.not_equal(input, self.scalar_constant(0, input.dtype))
             elif dst_sca_ty.is_int_signed():
                 return self.tensor(self.builder.create_fp_to_si(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
             else:

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -505,9 +505,6 @@ class InterpreterBuilder:
     def get_fp64(self, value):
         return TensorHandle(np.array([value], dtype=np.float64), tl.float64)
 
-    def get_null_value(self, type):
-        return TensorHandle(np.array([0], dtype=_get_np_dtype(type)), type)
-
     # programming model
     def create_get_program_id(self, axis):
         if self.grid_idx is None:

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -496,6 +496,9 @@ class InterpreterBuilder:
     def get_bf16(self, value):
         return self.create_fp_trunc(self.get_fp32(value), tl.bfloat16)
 
+    def get_fp8(self, value, dtype):
+        return TensorHandle(np.array([_interpreter.get_fp8(value, dtype.name)], dtype=np.uint8), dtype)
+
     def get_fp32(self, value):
         return TensorHandle(np.array([value], dtype=np.float32), tl.float32)
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -176,6 +176,14 @@ def _get_np_dtype(tt_dtype):
 
 
 def _convert_float(input, input_dtype, output_dtype, rounding_mode):
+    if input_dtype in (tl.float16, tl.bfloat16,
+                       tl.float32) and output_dtype in (tl.float8e4nv, tl.float8e5, tl.float8e4b8,
+                                                        tl.float8e5b16) and rounding_mode == _ir.ROUNDING_MODE.RTNE:
+        if input_dtype == tl.bfloat16:
+            input = (input.astype(np.uint32) << 16).view(np.float32)
+        else:
+            input = input.astype(np.float32, copy=False)
+        return _interpreter.convert_fp8(input, output_dtype.name)
     input_uint_dtype = getattr(np, f"uint{input_dtype.primitive_bitwidth}")
     output_unint_dtype = getattr(np, f"uint{output_dtype.primitive_bitwidth}")
     input_bin = np.frombuffer(input.tobytes(), dtype=input_uint_dtype)
@@ -497,7 +505,7 @@ class InterpreterBuilder:
         return self.create_fp_trunc(self.get_fp32(value), tl.bfloat16)
 
     def get_fp8(self, value, dtype):
-        return TensorHandle(np.array([_interpreter.get_fp8(value, dtype.name)], dtype=np.uint8), dtype)
+        return self.create_fp_to_fp(self.get_fp32(value), dtype, _ir.ROUNDING_MODE.RTNE)
 
     def get_fp32(self, value):
         return TensorHandle(np.array([value], dtype=np.float32), tl.float32)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
@@ -24,6 +24,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/FloatingPointMode.h"
 #include <type_traits>
 
 using namespace mlir;
@@ -561,9 +562,9 @@ SmallVector<Value> scalePk4DowncastToFp8(Location loc,
 }
 
 template <typename ConvertOp>
-SmallVector<Value> scalePk8DowncastToFp8(Location loc,
-                                         ConversionPatternRewriter &rewriter,
-                                         const SmallVector<Value> &v) {
+SmallVector<Value>
+scalePk8DowncastToFp8(Location loc, ConversionPatternRewriter &rewriter,
+                      const SmallVector<Value> &v, Type dstTy) {
   const size_t inSize = 8;
   assert(v.size() == inSize);
 
@@ -601,9 +602,22 @@ SmallVector<Value> scalePk8DowncastToFp8(Location loc,
   assert(vFPInTy && vFPResTy && vFPOutTy);
 
   // convert SmallVector to llvm vector
+  auto srcTy = cast<FloatType>(v[0].getType());
+  auto max =
+      llvm::APFloat::getLargest(cast<FloatType>(dstTy).getFloatSemantics());
+  bool losesInfo;
+  max.convert(srcTy.getFloatSemantics(), llvm::APFloat::rmNearestTiesToEven,
+              &losesInfo);
+  Value maxValue = LLVM::ConstantOp::create(rewriter, loc, srcTy,
+                                            rewriter.getFloatAttr(srcTy, max));
   Value inVec = b.undef(vFPInTy);
   for (size_t i = 0; i < inSize; ++i) {
-    inVec = b.insert_element(vFPInTy, inVec, v[i], b.i32_val(i));
+    // GFX1250 clamps finite overflow but does not saturate infinite inputs.
+    Value isInf = LLVM::IsFPClass::create(
+        rewriter, loc, i1_ty, v[i], rewriter.getI32IntegerAttr(llvm::fcInf));
+    Value signedMax = LLVM::CopySignOp::create(rewriter, loc, maxValue, v[i]);
+    Value value = b.select(isInf, signedMax, v[i]);
+    inVec = b.insert_element(vFPInTy, inVec, value, b.i32_val(i));
   }
 
   auto resVec = ConvertOp::create(rewriter, loc, vFPResTy, inVec, b.f32_val(1));
@@ -1492,7 +1506,7 @@ public:
     if (isa<Float8E4M3FNType>(dstTy)) {
       if (isaFamily == ISAFamily::GFX1250) {
         return scalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Fp8F16Op>(
-            loc, rewriter, v);
+            loc, rewriter, v, dstTy);
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkFp8F16Op>(loc,
                                                                    rewriter, v);
@@ -1583,7 +1597,7 @@ public:
       } else if (isa<Float8E5M2Type>(dstTy)) {
         if (isaFamily == ISAFamily::GFX1250) {
           return scalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Bf8F16Op>(
-              loc, rewriter, v);
+              loc, rewriter, v, dstTy);
         } else if (isaFamily == ISAFamily::CDNA4) {
           return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkBf8F16Op>(
               loc, rewriter, v);
@@ -1727,7 +1741,7 @@ public:
     if (isa<Float8E4M3FNType>(dstTy)) {
       if (isaFamily == ISAFamily::GFX1250) {
         return scalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Fp8Bf16Op>(
-            loc, rewriter, v);
+            loc, rewriter, v, dstTy);
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkFp8Bf16Op>(
             loc, rewriter, v);
@@ -1809,7 +1823,7 @@ public:
     if (isa<Float8E5M2Type>(dstTy)) {
       if (isaFamily == ISAFamily::GFX1250) {
         return scalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Bf8Bf16Op>(
-            loc, rewriter, v);
+            loc, rewriter, v, dstTy);
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkBf8Bf16Op>(
             loc, rewriter, v);
@@ -2093,7 +2107,7 @@ public:
     } else if (isa<Float8E4M3FNType>(dstTy)) {
       if (isaFamily == ISAFamily::GFX1250) {
         return scalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Fp8F32Op>(
-            loc, rewriter, inVals);
+            loc, rewriter, inVals, dstTy);
       } else if (isaFamily == ISAFamily::CDNA4) {
         return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkFp8F32Op>(
             loc, rewriter, inVals);
@@ -2175,7 +2189,7 @@ public:
       } else if (isa<Float8E5M2Type>(dstTy)) {
         if (isaFamily == ISAFamily::GFX1250) {
           return scalePk8DowncastToFp8<ROCDL::CvtScaleF32Pk8Bf8F32Op>(
-              loc, rewriter, inVals);
+              loc, rewriter, inVals, dstTy);
         } else if (isaFamily == ISAFamily::CDNA4) {
           return scalePk4DowncastToFp8<ROCDL::CvtScaleF32PkBf8F32Op>(
               loc, rewriter, inVals);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -27,22 +27,51 @@ struct Fp8ConversionDesc {
   size_t numElements;
 };
 
-static const Fp8ConversionDesc Fp16_to_Fp8E5M2_RTNE(bool hasNativeFP) {
-  Fp8ConversionDesc ret;
-  if (!hasNativeFP) {
-    ret = {"{                            \n"
-           ".reg .b32 a<2>;              \n"
-           "and.b32 a0, $1, 0xfffefffe;  \n"   // a0 &= 0xfffefffe
-           "and.b32 a1, $2, 0xfffefffe;  \n"   // (strip lowest bit)
-           "add.u32 a0, a0, 0x00800080;  \n"   // a0 += 0x00800080
-           "add.u32 a1, a1, 0x00800080;  \n"   // (round to nearest)
-           "prmt.b32 $0, a0, a1, 0x7531; \n\t" // output = a1a0
-           "}",
-           32, 32, 4};
+static Fp8ConversionDesc Fp16_to_Fp8E5M2_RTNE(int computeCapability) {
+  if (computeCapability >= 89)
+    return {"cvt.rn.satfinite.e5m2x2.f16x2 $0, $1; \n\t", 32, 16, 2};
+  std::string ptx = "{\n"
+                    ".reg .b32 a<2>, r<2>, n<2>, fp8max;\n"
+                    "mov.b32 fp8max, 0x7b007b00;\n"
+                    "and.b32 a0, $1, 0x7fff7fff;\n"
+                    "and.b32 a1, $2, 0x7fff7fff;\n";
+  // Clamp each magnitude to 57344 while retaining NaNs.
+  if (computeCapability >= 80) {
+    ptx += "min.NaN.f16x2 a0, a0, fp8max;\n"
+           "min.NaN.f16x2 a1, a1, fp8max;\n";
   } else {
-    ret = {"cvt.rn.satfinite.e5m2x2.f16x2 $0, $1; \n\t", 32, 16, 2};
+    ptx += ".reg .b32 fp8inf;\n"
+           "mov.b32 fp8inf, 0x7c007c00;\n"
+           "vset2.u32.u32.gt n0, a0, fp8inf, a0;\n"
+           "vset2.u32.u32.gt n1, a1, fp8inf, a1;\n"
+           "vmin2.u32.u32.u32 a0, a0, fp8max, a0;\n"
+           "vmin2.u32.u32.u32 a1, a1, fp8max, a1;\n"
+           "shl.b32 n0, n0, 10;\n"
+           "shl.b32 n1, n1, 10;\n"
+           "add.u32 a0, a0, n0;\n"
+           "add.u32 a1, a1, n1;\n";
   }
-  return ret;
+  // Add 0x7f + the retained low bit for ties-to-even in each halfword.
+  // Only canonical NaNs can carry into bit 15; map them back to FP8 NaNs.
+  ptx += "shr.b32 r0, a0, 8;\n"
+         "shr.b32 r1, a1, 8;\n"
+         "and.b32 r0, r0, 0x00010001;\n"
+         "and.b32 r1, r1, 0x00010001;\n"
+         "add.u32 r0, r0, 0x007f007f;\n"
+         "add.u32 r1, r1, 0x007f007f;\n"
+         "add.u32 r0, r0, a0;\n"
+         "add.u32 r1, r1, a1;\n"
+         "shr.b32 n0, r0, 7;\n"
+         "shr.b32 n1, r1, 7;\n"
+         "and.b32 n0, n0, 0x01000100;\n"
+         "and.b32 n1, n1, 0x01000100;\n"
+         "sub.u32 r0, r0, n0;\n"
+         "sub.u32 r1, r1, n1;\n"
+         "lop3.b32 r0, r0, $1, 0x80008000, 0xf8;\n"
+         "lop3.b32 r1, r1, $2, 0x80008000, 0xf8;\n"
+         "prmt.b32 $0, r0, r1, 0x7531;\n"
+         "}";
+  return {std::move(ptx), 32, 32, 4};
 }
 
 const Fp8ConversionDesc Fp16_to_Fp8E5M2_RTZ = {
@@ -120,64 +149,16 @@ static const Fp8ConversionDesc Fp8E5M2_to_Bf16(bool hasNativeFP) {
   return ret;
 }
 
-static const Fp8ConversionDesc Bf16_to_Fp8E5M2(bool hasNativeFP) {
-  Fp8ConversionDesc ret;
-  if (!hasNativeFP) {
-    ret = {
-        "{                                           \n" // bf16=fp8>>3 + 112<<7
-        ".reg .u32 sign, sign<2>, nosign, nosign<2>; \n" // fp8_min = 0b00000000
-        ".reg .u32 fp8_min, fp8_max, rn_;            \n" // fp8_max = 0b11111111
-        "mov.u32 fp8_min, 0x38003800;                \n" // so bf16_min = 0x3800
-        "mov.u32 fp8_max, 0x57e057e0;                \n" // so bf16_max = 0x57e0
-        "mov.u32 rn_, 0x00100010;                    \n" // round to nearest
-        "and.b32 sign0, $1, 0x80008000;              \n" // sign0=in0&0x80008000
-        "and.b32 sign1, $2, 0x80008000;              \n" // (store sign)
-        "prmt.b32 sign, sign0, sign1, 0x7531;        \n"
-        "and.b32 nosign0, $1, 0x7fff7fff;            \n" // nosign0=in0&0x7fff7fff
-        "and.b32 nosign1, $2, 0x7fff7fff;            \n" // (strip sign)
-
-        // nosign = clamp(nosign, min, max)
-        ".reg .u32 nosign_0_<2>, nosign_1_<2>;       \n"
-        "and.b32 nosign_0_0, nosign0, 0xffff0000;    \n"
-        "max.u32 nosign_0_0, nosign_0_0, 0x38000000; \n"
-        "min.u32 nosign_0_0, nosign_0_0, 0x57e00000; \n"
-        "and.b32 nosign_0_1, nosign0, 0x0000ffff;    \n"
-        "max.u32 nosign_0_1, nosign_0_1, 0x3800;     \n"
-        "min.u32 nosign_0_1, nosign_0_1, 0x57e0;     \n"
-        "or.b32 nosign0, nosign_0_0, nosign_0_1;     \n"
-        "and.b32 nosign_1_0, nosign1, 0xffff0000;    \n"
-        "max.u32 nosign_1_0, nosign_1_0, 0x38000000; \n"
-        "min.u32 nosign_1_0, nosign_1_0, 0x57e00000; \n"
-        "and.b32 nosign_1_1, nosign1, 0x0000ffff;    \n"
-        "max.u32 nosign_1_1, nosign_1_1, 0x3800;     \n"
-        "min.u32 nosign_1_1, nosign_1_1, 0x57e0;     \n"
-        "or.b32 nosign1, nosign_1_0, nosign_1_1;     \n"
-
-        "add.u32 nosign0, nosign0, rn_;              \n" // nosign0 += rn_
-        "add.u32 nosign1, nosign1, rn_;              \n" // (round to nearest)
-        "sub.u32 nosign0, nosign0, 0x38003800;       \n" // nosign0-=0x38003800
-        "sub.u32 nosign1, nosign1, 0x38003800;       \n" // (compensate offset)
-        "shl.b32 nosign0, nosign0, 3;                \n" // nosign0 <<= 3
-        "shl.b32 nosign1, nosign1, 3;                \n" // shift into to fp8e4
-        "prmt.b32 nosign, nosign0, nosign1, 0x7531;  \n" // nosign0 = 0xf100f200
-                                                         // nosign1 = 0xf300f400
-                                                         // nosign = 0xf3f4f1f2
-        "or.b32 $0, nosign, sign;                    \n" // restore sign
-        "}",
-        32, 32, 4};
-  } else {
-    ret = {"{                                       \n"
-           ".reg .b16 a<2>;                         \n"
-           ".reg .f32 b<2>;                         \n"
-           "mov.b32 {a0, a1}, $1;                   \n"
-           "cvt.f32.bf16 b0, a0;                    \n"
-           "cvt.f32.bf16 b1, a1;                    \n"
-           "cvt.rn.satfinite.e5m2x2.f32 $0, b1, b0; \n"
-           "}",
-           32, 16, 2};
-  }
-  return ret;
-}
+static const Fp8ConversionDesc Bf16_to_Fp8E5M2 = {
+    "{                                       \n"
+    ".reg .b16 a<2>;                         \n"
+    ".reg .f32 b<2>;                         \n"
+    "mov.b32 {a0, a1}, $1;                   \n"
+    "cvt.f32.bf16 b0, a0;                    \n"
+    "cvt.f32.bf16 b1, a1;                    \n"
+    "cvt.rn.satfinite.e5m2x2.f32 $0, b1, b0; \n"
+    "}",
+    32, 16, 2};
 
 // Fp8E4M3 (x2) -> Fp16 (x2) (packed)
 static const Fp8ConversionDesc Fp8E4M3Nv_to_Fp16 = {
@@ -430,7 +411,7 @@ struct FpToFpOpConversion
              Fp8E5M2_to_Fp16(computeCapability >= 89)},
             {{F16TyID, F8E4M3TyID, RoundingMode::RTNE}, Fp16_to_Fp8E4M3Nv},
             {{F16TyID, F8E5M2TyID, RoundingMode::RTNE},
-             Fp16_to_Fp8E5M2_RTNE(computeCapability >= 89)},
+             Fp16_to_Fp8E5M2_RTNE(computeCapability)},
             {{F16TyID, F8E5M2TyID, RoundingMode::RTZ}, Fp16_to_Fp8E5M2_RTZ},
             // F8 -> BF16
             // mul{.rnd}.bf16 and mul{.rnd}.bf16x2 requires sm_90 or higher.
@@ -446,7 +427,7 @@ struct FpToFpOpConversion
              hasPackedBf16
                  ? Fp8ConversionDesc{"cvt.rn.satfinite.e5m2x2.bf16x2 $0, $1;",
                                      32, 16, 2}
-                 : Bf16_to_Fp8E5M2(computeCapability >= 89)},
+                 : Bf16_to_Fp8E5M2},
             {{BF16TyID, F8E4M3TyID, RoundingMode::RTNE},
              hasPackedBf16
                  ? Fp8ConversionDesc{"cvt.rn.satfinite.e4m3x2.bf16x2 $0, $1;",
@@ -531,11 +512,17 @@ struct FpToFpOpConversion
       return outVals;
     }
 
+    bool useSoftwareFp8 = computeCapability < 89 &&
+                          isa<Float8E5M2Type>(dstElementType) &&
+                          roundingMode == RoundingMode::RTNE;
+    bool hasNativeFp32ToFp8 = computeCapability >= 90 ||
+                              (computeCapability == 89 && ptxVersion >= 81);
     bool useFP16IntermediateSrc =
-        srcElementType.isF32() &&
-        (!(computeCapability >= 90 &&
-           (llvm::isa<Float8E4M3FNType, Float8E5M2Type>(dstElementType))) ||
-         roundingMode.value() == RoundingMode::RTZ);
+        (srcElementType.isF32() &&
+         (!(hasNativeFp32ToFp8 &&
+            (llvm::isa<Float8E4M3FNType, Float8E5M2Type>(dstElementType))) ||
+          roundingMode.value() == RoundingMode::RTZ)) ||
+        (useSoftwareFp8 && srcElementType.isBF16());
     bool isDstFP32 = dstElementType.isF32();
     Type srcType = useFP16IntermediateSrc ? f16_ty : srcElementType;
     Type dstType = isDstFP32 ? f16_ty : dstElementType;
@@ -545,9 +532,25 @@ struct FpToFpOpConversion
     for (unsigned i = 0; i < std::min(numElements, operands.size()); i++) {
       inVals.push_back(operands[i][0]);
     }
-    if (useFP16IntermediateSrc)
-      for (Value &v : inVals)
+    if (useFP16IntermediateSrc) {
+      for (Value &v : inVals) {
+        if (srcElementType.isBF16())
+          v = b.fpext(f32_ty, v);
+        Value original = v;
         v = convertFp32ToFp16(loc, rewriter, v, RoundingMode::RTZ);
+        if (srcElementType.isF32() && roundingMode == RoundingMode::RTNE &&
+            isa<Float8E4M3FNType, Float8E5M2Type>(dstElementType)) {
+          // At FP8 rounding boundaries, half truncation discards at most 16
+          // FP32 bits, and exact midpoints have all 16 clear. Jamming the half
+          // low bit preserves which side of a midpoint the input occupies.
+          Value discarded =
+              b.and_(b.bitcast(original, i32_ty), b.i32_val(0xffff));
+          Value sticky = b.icmp_ne(discarded, b.i32_val(0));
+          Value bits = b.or_(b.bitcast(v, i16_ty), b.zext(i16_ty, sticky));
+          v = b.bitcast(bits, f16_ty);
+        }
+      }
+    }
     inVals.resize(numElements, b.undef(typeConverter->convertType(srcType)));
     SmallVector<Value> outVals = cvtFunc(loc, rewriter, inVals);
     assert(outVals.size() == inVals.size());


### PR DESCRIPTION
Materialize FP8 literals in their target format instead of emitting `arith.truncf`. Inexact literals currently reach an invalid LLVM FP32-to-i8 truncation.

This now compiles and stores `1.125`:

```python
@triton.jit
def fill(out):
    x = tl.full((128,), 1.1, tl.float8e4nv)
    tl.store(out + tl.arange(0, 128), x)
```

For the four formats below, constants and interpreted or compiled FP16/BF16/FP32 nearest-even downcasts now share the same overflow policy. For example, both `tl.full((), 465.0, tl.float8e4nv)` and the corresponding runtime cast produce `448`.

| Format | Finite overflow | ±Infinity |
| --- | --- | --- |
| E4M3FN | ±448 | ±448 |
| E5M2 | ±57344 | ±57344 |
| E4M3FNUZ | ±240 | NaN |
| E5M2FNUZ | ±57344 | NaN |

NaNs remain NaNs; FNUZ formats retain unsigned zero. FP16/BF16 constants, legacy `fp8e4b15`, and explicit round-toward-zero casts are unchanged.

Share the FP8 encoder with the interpreter, fix older NVIDIA software rounding and GFX1250 infinity handling, and reuse scalar constant construction for zero operands.

### Benchmark

GB300, CUDA 13.0, warm buffers, median of seven shuffled CUDA graph rounds. Compare direct `1.1` fills with the working FP32-then-cast workaround:

| Output | E4M3FN: workaround → constant (µs) | E5M2: workaround → constant (µs) |
| --- | ---: | ---: |
| 128 B | 0.689 → 0.689 | 0.689 → 0.689 |
| 1 MiB | 1.251 → 1.233 | 1.251 → 1.233 |
| 16 MiB | 8.855 → 8.835 | 8.855 → 8.836 |

Direct constants remove one FP8 conversion; the 128-byte kernel uses six registers instead of eight. Exact `1.0` fills already fold and are unchanged.

Correct rounding has a cost on A100's software E5M2 conversion path. For 1,048,576 runtime values:

| Source → E5M2 | Before (µs) | After (µs) | Change |
| --- | ---: | ---: | ---: |
| FP16 | 2.264 | 2.409 | +6.4% |
| BF16 | 2.620 | 2.507 | -4.3% |
| FP32 | 2.699 | 3.133 | +16.1% |

### Validation

Tests compare stored bytes for direct literals and runtime conversions, including ties, adjacent values, subnormals, signed zero, overflow, infinities, and NaNs. The final run passes 319 GPU tests and 504 interpreter tests; both frontend suites also pass.

Exhaustive FP16/BF16 inputs and one million FP32 inputs pass on A100. An MI300X instruction probe confirms the FNUZ infinity exception. GFX1250 is validated through generated IR and assembly; execution and performance on that architecture remain untested.

| Files | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | +97 | -29 | +68 |
| Non-tests | +170 | -113 | +57 |
| All | +267 | -142 | +125 |

### Reviewer's guide

- `python/src/`: share saturating FP8 encoding between constant construction and the interpreter.
- `python/triton/`: route literals and interpreted casts through that encoder; reuse scalar zero construction.
- `third_party/nvidia/`: fix software nearest-even conversion and preserve rounding through FP16 intermediates.
- `third_party/amd/`: saturate infinite inputs before GFX1250 packed conversions.
- `python/test/`: cover constant/cast agreement, older target paths, and direct-constant frontend output.

<!-- codex-thread: 01a08832-399d-7051-91ea-feff50c4abd4 -->

