### PR TITLE
Update Blackwell ptxas to 13.4.59

### DIFF
--- a/cmake/nvidia-toolchain-version.json
+++ b/cmake/nvidia-toolchain-version.json
@@ -1,5 +1,5 @@
 {
-  "ptxas-blackwell": "13.3.33",
+  "ptxas-blackwell": "13.4.59",
   "ptxas": "12.9.86",
   "cuobjdump": "13.1.80",
   "nvdisasm": "13.1.80",


### PR DESCRIPTION
Update `ptxas-blackwell` from 13.3.33 to 13.4.59, shipped in the [CUDA 13.4.1 release dated September 9, 2026](https://developer.download.nvidia.com/compute/cuda/redist/redistrib_13.4.1.json).

