### PR TITLE
[Analysis] Preserve shared-memory aliases through calls

### DIFF
--- a/include/triton/Analysis/Alias.h
+++ b/include/triton/Analysis/Alias.h
@@ -34,9 +34,9 @@ public:
   }
 
 private:
-  /// The set of allocated values that are aliased by this lattice.
-  /// For now, we only consider aliased value produced by the following
-  /// situations:
+  /// The set of allocated values and shared-memory function arguments
+  /// aliased by this lattice. Aliases propagate through views, calls, and
+  /// control flow, including:
   /// 1. values returned by scf.yield
   /// 2. block arguments in scf.for
   /// Example:
@@ -56,6 +56,12 @@ private:
   ///
   /// Therefore, v1's liveness range is the union of v3, v4, and v6
   /// v2's liveness range is the union of v4 and v5.
+  ///
+  /// Shared-memory function arguments remain in the set even when incoming
+  /// allocations are known. If argument p receives caller allocation a, a
+  /// view q of p retains both a and p. Keeping a preserves allocation
+  /// liveness; keeping p lets function summaries bind the view's effects to
+  /// each caller.
   DenseSet<Value> allocs;
 };
 
@@ -89,6 +95,11 @@ public:
   visitOperation(Operation *op,
                  ArrayRef<const dataflow::Lattice<AliasInfo> *> operands,
                  ArrayRef<dataflow::Lattice<AliasInfo> *> results) override;
+
+protected:
+  void visitCallableOperation(
+      CallableOpInterface callable,
+      ArrayRef<dataflow::AbstractSparseLattice *> arguments) override;
 };
 
 } // namespace mlir

--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -145,6 +145,13 @@ public:
     return bufferIds;
   }
 
+  /// Returns the current function's entry arguments aliased by a value.
+  ArrayRef<unsigned> getAliasedArgumentIndices(Value value) const {
+    auto it = argumentAliases.find(value);
+    return it == argumentAliases.end() ? ArrayRef<unsigned>{}
+                                       : it->second.getArrayRef();
+  }
+
   /// Returns the scratch buffer id of the given value.
   BufferId getBufferId(Operation *operation) const {
     if (opScratch.count(operation)) {
@@ -251,6 +258,7 @@ private:
   OpScratchMapT opVirtual;
   ValueBufferMapT valueBuffer;
   AliasBufferMapT aliasBuffer;
+  DenseMap<Value, llvm::SmallSetVector<unsigned, 2>> argumentAliases;
   BufferSetT bufferSet;
   size_t sharedMemorySize = 0;
 

--- a/lib/Analysis/Alias.cpp
+++ b/lib/Analysis/Alias.cpp
@@ -2,6 +2,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
@@ -18,6 +19,23 @@ AliasInfo AliasInfo::join(const AliasInfo &lhs, const AliasInfo &rhs) {
     ret.insert(value);
   }
   return ret;
+}
+
+void SharedMemoryAliasAnalysis::visitCallableOperation(
+    CallableOpInterface callable,
+    ArrayRef<dataflow::AbstractSparseLattice *> arguments) {
+  dataflow::SparseForwardDataFlowAnalysis<
+      dataflow::Lattice<AliasInfo>>::visitCallableOperation(callable,
+                                                            arguments);
+  // Keep the incoming allocation roots and this callee's formal identity.
+  for (auto *argument : arguments) {
+    auto *lattice = static_cast<dataflow::Lattice<AliasInfo> *>(argument);
+    Value value = lattice->getAnchor();
+    auto memory = dyn_cast<triton::gpu::MemDescType>(value.getType());
+    if (memory &&
+        isa<triton::gpu::SharedMemorySpaceAttr>(memory.getMemorySpace()))
+      propagateIfChanged(lattice, lattice->join(AliasInfo(value)));
+  }
 }
 
 LogicalResult SharedMemoryAliasAnalysis::visitOperation(

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -324,6 +324,9 @@ private:
         for (auto alloc : info.getAllocs()) {
           if (allocation->valueBuffer.count(alloc))
             allocation->addAlias(value, alloc);
+          else if (auto argument = dyn_cast<BlockArgument>(alloc);
+                   argument && argument.getOwner()->getParentOp() == operation)
+            allocation->argumentAliases[value].insert(argument.getArgNumber());
         }
       }
     }

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -305,13 +305,12 @@ SmallVector<AllocationSlice> MembarAnalysis::getAllocationSlices(Value value) {
   };
   Allocation::BufferIdSetT bufferIds;
   if (accessMode == AccessMode::AllocatorAliasesOnly) {
-    // Allocation identity survives unknown geometry. Direct argument effects
+    // Allocation identity survives unknown geometry. Argument effects
     // have no local IDs; retain them until a caller binds their allocation.
     bufferIds = allocation.getAllBufferIdsWithAliases(value);
-    auto argument = dyn_cast<BlockArgument>(value);
-    if (argument && argument.getOwner() == &function.getBlocks().front()) {
+    for (unsigned argument : allocation.getAliasedArgumentIndices(value)) {
       AllocationSlice slice(Interval<size_t>{});
-      slice.argumentIndex = argument.getArgNumber();
+      slice.argumentIndex = argument;
       slices.push_back(std::move(slice));
     }
   } else if (footprint) {
@@ -355,11 +354,6 @@ void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
                   slice.translateToCallsite(call, callee, regions)};
             Value actual = call.getArgOperands()[*slice.argumentIndex];
             auto slices = getAllocationSlices(actual);
-            if (!actual.getDefiningOp<triton::gpu::LocalAllocOp>() &&
-                llvm::none_of(slices, [](const AllocationSlice &bound) {
-                  return bound.argumentIndex.has_value();
-                }))
-              return SmallVector<AllocationSlice>{};
             // A callee can reinterpret the argument's view. Retain the caller's
             // allocation IDs, but cover each whole allocation without shifting.
             for (AllocationSlice &bound : slices) {

--- a/test/Analysis/test-alias.mlir
+++ b/test/Analysis/test-alias.mlir
@@ -64,6 +64,8 @@ tt.func @subview(%A : !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory>) 
   %a = ttg.local_alloc : () -> !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
   // expected-remark @below {{%1 -> %0}}
   %cst1 = ttg.memdesc_index %a[%index] : !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // expected-remark @below {{%2 -> %arg0}}
+  %arg_view = ttg.memdesc_index %A[%index] : !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory>
   tt.return
 }
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -115,6 +115,52 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %result = ttg.local_load %dst : !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable> -> tensor<256x128xf16, #blockedCallDst>
     tt.return %cvt, %result : tensor<256x128xf16, #blockedCallDst>, tensor<256x128xf16, #blockedCallDst>
   }
+
+  // An indexed call argument retains the allocation's reuse dependency.
+  // CHECK-LABEL: @cluster_call_indexed_argument_reuses_scratch
+  // CHECK: ttg.convert_layout{{.*}}allocation.offset = [[INDEXED_OFFSET:[0-9]+]]
+  // CHECK-DAG: ttg.local_alloc {allocation.offset = [[INDEXED_OFFSET]]
+  // CHECK-DAG: ttg.memdesc_index
+  // CHECK-DAG: ttng.cluster_barrier{{$}}
+  // CHECK: tt.call @forward_store_argument
+  tt.func @cluster_call_indexed_argument_reuses_scratch(%slot: i32) -> (tensor<256x128xf16, #blockedCallDst>, tensor<256x128xf16, #blockedCallDst>) {
+    %c1 = arith.constant 1 : i32
+    %index = arith.andi %slot, %c1 : i32
+    %value = arith.constant dense<0.0> : tensor<256x128xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %value : tensor<256x128xf16, #blockedCallSrc> -> tensor<256x128xf16, #blockedCallDst>
+    %stages = ttg.local_alloc : () -> !ttg.memdesc<2x256x128xf16, #sharedCall, #ttg.shared_memory, mutable>
+    %dst = ttg.memdesc_index %stages[%index] : !ttg.memdesc<2x256x128xf16, #sharedCall, #ttg.shared_memory, mutable> -> !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>
+    tt.call @forward_store_argument(%dst) : (!ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>) -> ()
+    %result = ttg.local_load %dst : !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable> -> tensor<256x128xf16, #blockedCallDst>
+    tt.return %cvt, %result : tensor<256x128xf16, #blockedCallDst>, tensor<256x128xf16, #blockedCallDst>
+  }
+
+  tt.func private @store_indexed_argument(%stages: !ttg.memdesc<2x256x128xf16, #sharedCall, #ttg.shared_memory, mutable>, %slot: i32) attributes {noinline = true} {
+    %c1 = arith.constant 1 : i32
+    %index = arith.andi %slot, %c1 : i32
+    %dst = ttg.memdesc_index %stages[%index] : !ttg.memdesc<2x256x128xf16, #sharedCall, #ttg.shared_memory, mutable> -> !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>
+    %value = arith.constant dense<3.0> : tensor<256x128xf16, #blockedCallDst>
+    ttg.local_store %value, %dst : tensor<256x128xf16, #blockedCallDst> -> !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>
+    tt.return
+  }
+
+  // Indexing inside the callee must retain the caller allocation's effects.
+  // CHECK-LABEL: @cluster_callee_indexed_argument_reuses_scratch
+  // CHECK: ttg.convert_layout{{.*}}allocation.offset = [[CALLEE_INDEXED_OFFSET:[0-9]+]]
+  // CHECK-DAG: ttg.local_alloc {allocation.offset = [[CALLEE_INDEXED_OFFSET]]
+  // CHECK-DAG: ttng.cluster_barrier{{$}}
+  // CHECK: tt.call @store_indexed_argument
+  tt.func @cluster_callee_indexed_argument_reuses_scratch(%slot: i32) -> (tensor<256x128xf16, #blockedCallDst>, tensor<256x128xf16, #blockedCallDst>) {
+    %value = arith.constant dense<0.0> : tensor<256x128xf16, #blockedCallSrc>
+    %cvt = ttg.convert_layout %value : tensor<256x128xf16, #blockedCallSrc> -> tensor<256x128xf16, #blockedCallDst>
+    %stages = ttg.local_alloc : () -> !ttg.memdesc<2x256x128xf16, #sharedCall, #ttg.shared_memory, mutable>
+    tt.call @store_indexed_argument(%stages, %slot) : (!ttg.memdesc<2x256x128xf16, #sharedCall, #ttg.shared_memory, mutable>, i32) -> ()
+    %c1 = arith.constant 1 : i32
+    %index = arith.andi %slot, %c1 : i32
+    %dst = ttg.memdesc_index %stages[%index] : !ttg.memdesc<2x256x128xf16, #sharedCall, #ttg.shared_memory, mutable> -> !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable>
+    %result = ttg.local_load %dst : !ttg.memdesc<256x128xf16, #sharedCall, #ttg.shared_memory, mutable> -> tensor<256x128xf16, #blockedCallDst>
+    tt.return %cvt, %result : tensor<256x128xf16, #blockedCallDst>, tensor<256x128xf16, #blockedCallDst>
+  }
 }
 
 // -----

--- a/test/lib/Analysis/TestAlias.cpp
+++ b/test/lib/Analysis/TestAlias.cpp
@@ -57,8 +57,7 @@ struct TestAliasPass
       if (latticeElement) {
         auto &info = latticeElement->getValue();
         for (auto &alias : info.getAllocs()) {
-          auto opName =
-              getValueOperandName(alias.getDefiningOp()->getResult(0), state);
+          auto opName = getValueOperandName(alias, state);
           opNames.push_back(std::move(opName));
         }
       }


### PR DESCRIPTION
Keep shared-memory function arguments alongside incoming allocations in `AliasInfo`, and use their aliases to bind callee effects to caller buffers. This preserves the cluster barriers required before shared scratch is reused when calls use indexed descriptor views.