### PR TITLE
[NFC] Remove dead synchronization-analysis paths

### DIFF
--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -681,18 +681,6 @@ LogicalResult BufferRegionAnalysis::visitOperation(
       propagateIfChanged(result, result->join(info));
     return success();
   };
-  if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
-    for (Region *region : wsOp.getPartitionRegions()) {
-      if (region->empty())
-        continue;
-
-      Block &entry = region->front();
-      auto *exec =
-          getOrCreate<dataflow::Executable>(getProgramPointBefore(&entry));
-      propagateIfChanged(exec, exec->setToLive());
-    }
-    return success();
-  }
   if (auto localAllocOp = dyn_cast<ttg::LocalAllocOp>(op)) {
     // Descriptor views preserve memory space, so shared origins cannot
     // contribute to a tensor-memory footprint.

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -84,20 +84,6 @@ bool isPreAllocAliasSliceFilter(const AllocationSlice &lhsSlice,
          allocation->isExplicitBuffer(bufferId);
 }
 
-bool hasUnresolvedCrossClusterDependency(const BlockInfo &blockInfo) {
-  auto hasDistributedDependency = [](const BlockInfo::SliceMapT &slices,
-                                     bool isRead) {
-    for (const auto &sliceAndOps : slices)
-      for (Operation *depOp : sliceAndOps.second)
-        if (isDistributedMultiCTAOp(depOp, isRead))
-          return true;
-    return false;
-  };
-
-  return hasDistributedDependency(blockInfo.syncReadSlices, /*isRead=*/true) ||
-         hasDistributedDependency(blockInfo.syncWriteSlices, /*isRead=*/false);
-}
-
 bool valueAliasesTrackedBuffers(Value value,
                                 const Allocation::BufferIdSetT &tracked,
                                 Allocation *allocation) {


### PR DESCRIPTION
Remove the unreachable `WarpSpecializeOp` transfer arm from buffer-region analysis and the unused cluster-dependency helper. Warp-specialized regions are already marked live during initialization.