### PR TITLE
[GPU] Preserve warp context in noinline helpers

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -49,6 +49,7 @@ namespace mlir::triton::gpu {
 
 constexpr static char AttrMaxRegistersName[] = "ttg.maxnreg";
 constexpr static char AttrNumWarpsName[] = "ttg.num-warps";
+constexpr static char AttrWarpIdOffsetName[] = "ttg.warp-id-offset";
 constexpr static char AttrNumCTAsName[] = "ttg.num-ctas";
 constexpr static char AttrTargetName[] = "ttg.target";
 constexpr static char AttrNumThreadsPerWarp[] = "ttg.threads-per-warp";

--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -1,6 +1,9 @@
 #include "mlir/IR/BuiltinOps.h"
+#include "triton/Analysis/CallGraph.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir::triton::gpu {
@@ -82,6 +85,38 @@ static void padToMaxWarpGroups(WarpSpecializeOp op, int numExtraWarpGroups) {
   partitions.erase();
 }
 
+static LogicalResult annotateWarpIdOffsets(ModuleOp mod) {
+  triton::CallGraph<int> callGraph(mod);
+  DenseMap<FunctionOpInterface, int> offsets;
+  for (auto root : callGraph.getRoots())
+    offsets[root] = 0;
+
+  LogicalResult result = success();
+  callGraph.walk(
+      [&](CallOpInterface call, FunctionOpInterface callee) {
+        auto caller = call->getParentOfType<FunctionOpInterface>();
+        int start = getWarpGroupStartWarpId(call->getBlock())
+                        .value_or(offsets.lookup(caller));
+        // Equal-sized partitions can share a helper when their starts have
+        // the same remainder modulo the helper's warp count.
+        int offset = start % lookupNumWarps(callee);
+        auto [it, inserted] = offsets.try_emplace(callee, offset);
+        if (!inserted && it->second != offset) {
+          call.emitError("callee is used with incompatible warp ID offsets");
+          result = failure();
+        }
+      },
+      [](FunctionOpInterface) {});
+  if (failed(result))
+    return failure();
+
+  Builder b(mod.getContext());
+  for (auto [func, offset] : offsets)
+    if (!isKernel(func))
+      func->setAttr(AttrWarpIdOffsetName, b.getI32IntegerAttr(offset));
+  return success();
+}
+
 namespace {
 struct AllocateWarpGroups
     : public mlir::triton::gpu::impl::TritonGPUAllocateWarpGroupsBase<
@@ -128,6 +163,9 @@ struct AllocateWarpGroups
       }
       op.setWarpGroupStartIds(startIds);
     });
+
+    if (failed(annotateWarpIdOffsets(mod)))
+      return signalPassFailure();
 
     Builder b(&getContext());
     mod->setAttr("ttg.total-num-warps",

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -132,8 +132,9 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
       newFuncOp.setPassthroughAttr(
           ArrayAttr::get(ctx, rewriter.getStringAttr("noinline")));
       newFuncOp.setLinkage(LLVM::Linkage::Internal);
-      if (Attribute numWarps = funcOp->getAttr(triton::gpu::AttrNumWarpsName))
-        newFuncOp->setAttr("ws_num_warps", numWarps);
+      newFuncOp->setAttr(
+          "ws_num_warps",
+          rewriter.getI32IntegerAttr(triton::gpu::lookupNumWarps(funcOp)));
     }
 
     rewriter.eraseOp(funcOp);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -416,10 +416,18 @@ Value getThreadId(OpBuilder &rewriter, Location loc) {
 
   TritonLLVMOpBuilder b(loc, rewriter);
 
-  // If this is being created inside a warp specialize op, compute the relative
-  // thread ID within the warp group.
-  if (std::optional<int> startId =
-          getWarpGroupStartThreadId(rewriter.getInsertionBlock())) {
+  std::optional<int> startId =
+      getWarpGroupStartThreadId(rewriter.getInsertionBlock());
+  auto func = lookupPt->getParentOfType<FunctionOpInterface>();
+  if (!startId && func->hasAttr("ws_num_warps")) {
+    // Outlined helpers use relative IDs. Descending worker sizes place each
+    // W-warp partition at moduleWarps mod W; default helpers have
+    // W=moduleWarps.
+    int moduleWarps =
+        triton::gpu::lookupNumWarps(func->getParentOfType<ModuleOp>());
+    startId = (moduleWarps % numWarps) * threadsPerWarp;
+  }
+  if (startId) {
     tid = arith::SubIOp::create(rewriter, loc, tid, b.i32_val(*startId));
   }
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -419,14 +419,10 @@ Value getThreadId(OpBuilder &rewriter, Location loc) {
   std::optional<int> startId =
       getWarpGroupStartThreadId(rewriter.getInsertionBlock());
   auto func = lookupPt->getParentOfType<FunctionOpInterface>();
-  if (!startId && func->hasAttr("ws_num_warps")) {
-    // Outlined helpers use relative IDs. Descending worker sizes place each
-    // W-warp partition at moduleWarps mod W; default helpers have
-    // W=moduleWarps.
-    int moduleWarps =
-        triton::gpu::lookupNumWarps(func->getParentOfType<ModuleOp>());
-    startId = (moduleWarps % numWarps) * threadsPerWarp;
-  }
+  auto offset =
+      func->getAttrOfType<IntegerAttr>(triton::gpu::AttrWarpIdOffsetName);
+  if (!startId && offset)
+    startId = offset.getInt() * threadsPerWarp;
   if (startId) {
     tid = arith::SubIOp::create(rewriter, loc, tid, b.i32_val(*startId));
   }

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -4460,6 +4460,10 @@ std::optional<int> triton::gpu::maybeLookupNumWarps(Operation *op) {
     unsigned idx = op->getParentRegion()->getRegionNumber();
     return partitions.getParentOp().getPartitionNumWarps()[idx];
   }
+  // Function conversion preserves an outlined helper's warp count here.
+  if (isa<FunctionOpInterface>(op))
+    if (auto attr = op->getAttrOfType<IntegerAttr>("ws_num_warps"))
+      return attr.getInt();
   if (Operation *parent = op->getParentOp())
     return maybeLookupNumWarps(parent);
   return {};

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1125,6 +1125,52 @@ def test_async_copy_mbarrier():
     torch.testing.assert_close(out[20:], torch.zeros((12, 32), **tensor_opts))
 
 
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
+@pytest.mark.parametrize("worker_warps,nested", [(2, False), (4, False), (8, False), (8, True)])
+def test_warp_specialize_noinline_ids(worker_warps, nested):
+
+    @gluon.jit
+    def add(lhs, rhs):
+        return lhs + rhs
+
+    @gluon.jit(noinline=True)
+    def indices_and_scan(N: ttgl.constexpr, LAYOUT: ttgl.constexpr):
+        indices = ttgl.arange(0, N, layout=LAYOUT)
+        ones = ttgl.full((N, ), 1, ttgl.int32, layout=LAYOUT)
+        prefix = ttgl.associative_scan(ones, 0, add)
+        return indices, prefix
+
+    @gluon.jit(noinline=True)
+    def forward(N: ttgl.constexpr, LAYOUT: ttgl.constexpr):
+        return indices_and_scan(N, LAYOUT)
+
+    @gluon.jit
+    def worker(index_out, scan_out, W: ttgl.constexpr, NESTED: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [W], [0])
+        indices = ttgl.arange(0, 32 * W, layout=layout)
+        if NESTED:
+            helper_indices, prefix = forward(32 * W, layout)
+        else:
+            helper_indices, prefix = indices_and_scan(32 * W, layout)
+        ttgl.store(index_out + indices, indices + helper_indices)
+        ttgl.store(scan_out + indices, prefix)
+
+    @gluon.jit
+    def idle():
+        pass
+
+    @gluon.jit
+    def kernel(index_out, scan_out, W: ttgl.constexpr, NESTED: ttgl.constexpr):
+        ttgl.warp_specialize([(idle, ()), (worker, (index_out, scan_out, W, NESTED))], [W])
+
+    expected = torch.arange(32 * worker_warps, dtype=torch.int32, device="cuda")
+    index_out = torch.empty_like(expected)
+    scan_out = torch.empty_like(expected)
+    kernel[(1, )](index_out, scan_out, worker_warps, nested, num_warps=4)
+    torch.testing.assert_close(index_out, 2 * expected, rtol=0, atol=0)
+    torch.testing.assert_close(scan_out, expected + 1, rtol=0, atol=0)
+
+
 # Equivalence-class multicast: multicast_cta selects which CTA-ID bits to multicast
 # along.  Two CTAs share a class when (id_a & ~mask) == (id_b & ~mask).
 #

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1126,8 +1126,7 @@ def test_async_copy_mbarrier():
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
-@pytest.mark.parametrize("worker_warps,nested", [(2, False), (4, False), (8, False), (8, True)])
-def test_warp_specialize_noinline_ids(worker_warps, nested):
+def test_warp_specialize_noinline_ids():
 
     @gluon.jit
     def add(lhs, rhs):
@@ -1145,13 +1144,10 @@ def test_warp_specialize_noinline_ids(worker_warps, nested):
         return indices_and_scan(N, LAYOUT)
 
     @gluon.jit
-    def worker(index_out, scan_out, W: ttgl.constexpr, NESTED: ttgl.constexpr):
-        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [W], [0])
-        indices = ttgl.arange(0, 32 * W, layout=layout)
-        if NESTED:
-            helper_indices, prefix = forward(32 * W, layout)
-        else:
-            helper_indices, prefix = indices_and_scan(32 * W, layout)
+    def worker(index_out, scan_out):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [8], [0])
+        indices = ttgl.arange(0, 256, layout=layout)
+        helper_indices, prefix = forward(256, layout)
         ttgl.store(index_out + indices, indices + helper_indices)
         ttgl.store(scan_out + indices, prefix)
 
@@ -1160,13 +1156,18 @@ def test_warp_specialize_noinline_ids(worker_warps, nested):
         pass
 
     @gluon.jit
-    def kernel(index_out, scan_out, W: ttgl.constexpr, NESTED: ttgl.constexpr):
-        ttgl.warp_specialize([(idle, ()), (worker, (index_out, scan_out, W, NESTED))], [W])
+    def kernel(index_out, scan_out):
+        # Both workers share the helpers, starting at physical warps 4 and 12.
+        ttgl.warp_specialize([
+            (idle, ()),
+            (worker, (index_out, scan_out)),
+            (worker, (index_out + 256, scan_out + 256)),
+        ], [8, 8])
 
-    expected = torch.arange(32 * worker_warps, dtype=torch.int32, device="cuda")
+    expected = torch.arange(256, dtype=torch.int32, device="cuda").repeat(2, 1)
     index_out = torch.empty_like(expected)
     scan_out = torch.empty_like(expected)
-    kernel[(1, )](index_out, scan_out, worker_warps, nested, num_warps=4)
+    kernel[(1, )](index_out, scan_out, num_warps=4)
     torch.testing.assert_close(index_out, 2 * expected, rtol=0, atol=0)
     torch.testing.assert_close(scan_out, expected + 1, rtol=0, atol=0)
 

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -1040,6 +1040,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK: llvm.call @callee_zero_scratch
   // CHECK: llvm.func internal @callee_zero_scratch
   // CHECK-SAME: passthrough = ["noinline", "convergent"]
+  // CHECK-SAME: ws_num_warps = 4 : i32
   tt.func public @test_call_zero_scratch_no_grid_ops() attributes {noinline = false} {
     tt.call @callee_zero_scratch() : () -> ()
     tt.return

--- a/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
@@ -142,3 +142,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     tt.return %0 : tensor<64xbf16, #blocked>
   }
 }
+
+// -----
+
+#blocked8 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 12 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // The eight-warp worker starts at physical wave 4. Its outlined range must
+  // use the same relative wave IDs as its caller's range.
+  // GFX1250-LABEL: llvm.func internal @outlined_indices_8
+  // GFX1250: [[WAVE:%.*]] = rocdl.wave.id : i32
+  // GFX1250: [[OFFSET:%.*]] = llvm.mlir.constant(4 : i32) : i32
+  // GFX1250: [[REL:%.*]] = llvm.sub [[WAVE]], [[OFFSET]] : i32
+  // GFX1250: [[MASK:%.*]] = llvm.mlir.constant(7 : i32) : i32
+  // GFX1250: llvm.and [[REL]], [[MASK]] : i32
+  tt.func private @outlined_indices_8() -> tensor<256xi32, #blocked8> attributes {noinline = true, "ttg.num-warps" = 8 : i32} {
+    %range = tt.make_range {start = 0 : i32, end = 256 : i32} : tensor<256xi32, #blocked8>
+    tt.return %range : tensor<256xi32, #blocked8>
+  }
+
+  tt.func @call_outlined_indices_8(%out: !tt.ptr<i32>) {
+    ttg.warp_specialize(%out) attributes {warpGroupStartIds = array<i32: 4>}
+    default {
+      ttg.warp_yield
+    }
+    partition0(%arg0: !tt.ptr<i32>) num_warps(8) {
+      %values = tt.call @outlined_indices_8() : () -> tensor<256xi32, #blocked8>
+      %range = tt.make_range {start = 0 : i32, end = 256 : i32} : tensor<256xi32, #blocked8>
+      %base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>, #blocked8>
+      %ptrs = tt.addptr %base, %range : tensor<256x!tt.ptr<i32>, #blocked8>, tensor<256xi32, #blocked8>
+      tt.store %ptrs, %values : tensor<256x!tt.ptr<i32>, #blocked8>
+      ttg.warp_return
+    } : (!tt.ptr<i32>) -> ()
+    tt.return
+  }
+}

--- a/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
@@ -147,32 +147,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 #blocked8 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 12 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // The eight-warp worker starts at physical wave 4. Its outlined range must
-  // use the same relative wave IDs as its caller's range.
+  // The eight-warp helper uses the caller's precomputed offset.
   // GFX1250-LABEL: llvm.func internal @outlined_indices_8
   // GFX1250: [[WAVE:%.*]] = rocdl.wave.id : i32
   // GFX1250: [[OFFSET:%.*]] = llvm.mlir.constant(4 : i32) : i32
   // GFX1250: [[REL:%.*]] = llvm.sub [[WAVE]], [[OFFSET]] : i32
   // GFX1250: [[MASK:%.*]] = llvm.mlir.constant(7 : i32) : i32
   // GFX1250: llvm.and [[REL]], [[MASK]] : i32
-  tt.func private @outlined_indices_8() -> tensor<256xi32, #blocked8> attributes {noinline = true, "ttg.num-warps" = 8 : i32} {
+  tt.func private @outlined_indices_8() -> tensor<256xi32, #blocked8> attributes {noinline = true, "ttg.num-warps" = 8 : i32, "ttg.warp-id-offset" = 4 : i32} {
     %range = tt.make_range {start = 0 : i32, end = 256 : i32} : tensor<256xi32, #blocked8>
     tt.return %range : tensor<256xi32, #blocked8>
-  }
-
-  tt.func @call_outlined_indices_8(%out: !tt.ptr<i32>) {
-    ttg.warp_specialize(%out) attributes {warpGroupStartIds = array<i32: 4>}
-    default {
-      ttg.warp_yield
-    }
-    partition0(%arg0: !tt.ptr<i32>) num_warps(8) {
-      %values = tt.call @outlined_indices_8() : () -> tensor<256xi32, #blocked8>
-      %range = tt.make_range {start = 0 : i32, end = 256 : i32} : tensor<256xi32, #blocked8>
-      %base = tt.splat %arg0 : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>, #blocked8>
-      %ptrs = tt.addptr %base, %range : tensor<256x!tt.ptr<i32>, #blocked8>, tensor<256xi32, #blocked8>
-      tt.store %ptrs, %values : tensor<256x!tt.ptr<i32>, #blocked8>
-      ttg.warp_return
-    } : (!tt.ptr<i32>) -> ()
-    tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -3333,7 +3333,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
   // CHECK-LABEL: llvm.func internal @call_smem_nested(
   // CHECK-SAME: %[[NESTED_PARENT_SMEM:.*]]: !llvm.ptr<3>
-  // CHECK-SAME: ws_num_warps = 4 : i32
   tt.func private @call_smem_nested() attributes {noinline = true} {
     %inner = ttg.local_alloc : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
     // CHECK: %[[NESTED_CALL_OFFSET:.*]] = llvm.mlir.constant(128 : i32)

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -3324,6 +3324,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: llvm.func internal @call_smem_leaf(
+  // CHECK-SAME: ws_num_warps = 4 : i32
   tt.func private @call_smem_leaf() attributes {noinline = true} {
     %inner = ttg.local_alloc : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
     ttg.local_dealloc %inner : !ttg.memdesc<16xi32, #shared, #smem, mutable>
@@ -3332,6 +3333,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
   // CHECK-LABEL: llvm.func internal @call_smem_nested(
   // CHECK-SAME: %[[NESTED_PARENT_SMEM:.*]]: !llvm.ptr<3>
+  // CHECK-SAME: ws_num_warps = 4 : i32
   tt.func private @call_smem_nested() attributes {noinline = true} {
     %inner = ttg.local_alloc : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
     // CHECK: %[[NESTED_CALL_OFFSET:.*]] = llvm.mlir.constant(128 : i32)
@@ -3527,6 +3529,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttg.inline_asm "bar.sync 0;" {constraints = "", pure = false} : () -> ()
     // CHECK-NOT: llvm.inline_asm
     // CHECK: llvm.return
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  // A one-warp caller must issue both 16x64 messages from its outlined helper.
+  // CHECK-LABEL: llvm.func internal @outlined_single_warp_tma
+  // CHECK-SAME: ws_num_warps = 1 : i32
+  // CHECK-COUNT-2: cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK-NOT: cp.async.bulk.tensor
+  // CHECK: llvm.return
+  tt.func private @outlined_single_warp_tma(%desc: !tt.tensordesc<16x128xf16, #shared>, %dst: !ttg.memdesc<16x128xf16, #shared, #smem, mutable>, %bar: !ttg.memdesc<1xi64, #barrier, #smem, mutable>, %x: i32, %pred: i1) attributes {noinline = true, "ttg.num-warps" = 1 : i32} {
+    ttng.async_tma_copy_global_to_local %desc[%x, %x] %dst, %bar, %pred : !tt.tensordesc<16x128xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x128xf16, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
@@ -35,8 +35,9 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
           rewriter.getStringAttr("convergent")};
       newFuncOp.setPassthroughAttr(ArrayAttr::get(ctx, passthroughAttrs));
       newFuncOp.setLinkage(LLVM::Linkage::Internal);
-      if (Attribute numWarps = funcOp->getAttr(triton::gpu::AttrNumWarpsName))
-        newFuncOp->setAttr("ws_num_warps", numWarps);
+      newFuncOp->setAttr(
+          "ws_num_warps",
+          rewriter.getI32IntegerAttr(triton::gpu::lookupNumWarps(funcOp)));
     }
 
     rewriter.eraseOp(funcOp);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/WarpIdOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/WarpIdOpToLLVM.cpp
@@ -43,13 +43,10 @@ public:
     if (targetInfo.supportsWaveId()) {
       warpId = ROCDL::WaveId::create(rewriter, loc, i32_ty);
       auto func = op->getParentOfType<FunctionOpInterface>();
-      if (func->hasAttr("ws_num_warps")) {
-        // Outlined helpers use relative IDs. Worker starts are congruent to
-        // moduleWarps modulo their width; default helpers have zero offset.
+      if (auto offset =
+              func->getAttrOfType<IntegerAttr>(AttrWarpIdOffsetName)) {
         int numWarps = triton::gpu::lookupNumWarps(op);
-        int moduleWarps =
-            triton::gpu::lookupNumWarps(func->getParentOfType<ModuleOp>());
-        warpId = b.sub(warpId, b.i32_val(moduleWarps % numWarps));
+        warpId = b.sub(warpId, b.i32_val(offset.getInt()));
         warpId = b.and_(warpId, b.i32_val(numWarps - 1));
       }
     } else {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/WarpIdOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/WarpIdOpToLLVM.cpp
@@ -42,6 +42,16 @@ public:
 
     if (targetInfo.supportsWaveId()) {
       warpId = ROCDL::WaveId::create(rewriter, loc, i32_ty);
+      auto func = op->getParentOfType<FunctionOpInterface>();
+      if (func->hasAttr("ws_num_warps")) {
+        // Outlined helpers use relative IDs. Worker starts are congruent to
+        // moduleWarps modulo their width; default helpers have zero offset.
+        int numWarps = triton::gpu::lookupNumWarps(op);
+        int moduleWarps =
+            triton::gpu::lookupNumWarps(func->getParentOfType<ModuleOp>());
+        warpId = b.sub(warpId, b.i32_val(moduleWarps % numWarps));
+        warpId = b.and_(warpId, b.i32_val(numWarps - 1));
+      }
     } else {
       int threadsPerWarp = triton::gpu::lookupThreadsPerWarp(rewriter);
       Value warpSizeVal = b.i32_val(threadsPerWarp);

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -206,7 +206,8 @@ public:
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    if (triton::gpu::lookupNumWarps(op) == 1) {
+    int numWarps = triton::gpu::lookupNumWarps(op);
+    if (numWarps == 1) {
       // If there is only one warp, the warp ID is always 0.
       rewriter.replaceOp(op, b.i32_val(0));
       return success();
@@ -214,6 +215,15 @@ public:
 
     Value tid = NVVM::ThreadIdXOp::create(rewriter, loc, i32_ty);
     Value warpId = b.udiv(tid, b.i32_val(32));
+    auto func = op->getParentOfType<FunctionOpInterface>();
+    if (func->hasAttr("ws_num_warps")) {
+      // Outlined helpers use relative IDs. Worker starts are congruent to
+      // moduleWarps modulo their width; default helpers have zero offset.
+      int moduleWarps =
+          triton::gpu::lookupNumWarps(func->getParentOfType<ModuleOp>());
+      warpId = b.sub(warpId, b.i32_val(moduleWarps % numWarps));
+      warpId = b.and_(warpId, b.i32_val(numWarps - 1));
+    }
     if (!op.getOmitUniformHint()) {
       // This indicates to PTXAS that the result and its derived values are
       // uniform across the warp. For example, if a branch condition derives

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -216,12 +216,9 @@ public:
     Value tid = NVVM::ThreadIdXOp::create(rewriter, loc, i32_ty);
     Value warpId = b.udiv(tid, b.i32_val(32));
     auto func = op->getParentOfType<FunctionOpInterface>();
-    if (func->hasAttr("ws_num_warps")) {
-      // Outlined helpers use relative IDs. Worker starts are congruent to
-      // moduleWarps modulo their width; default helpers have zero offset.
-      int moduleWarps =
-          triton::gpu::lookupNumWarps(func->getParentOfType<ModuleOp>());
-      warpId = b.sub(warpId, b.i32_val(moduleWarps % numWarps));
+    if (auto offset = func->getAttrOfType<IntegerAttr>(
+            triton::gpu::AttrWarpIdOffsetName)) {
+      warpId = b.sub(warpId, b.i32_val(offset.getInt()));
       warpId = b.and_(warpId, b.i32_val(numWarps - 1));
     }
     if (!op.getOmitUniformHint()) {


### PR DESCRIPTION
Preserve each outlined helper's effective warp count through LLVM conversion and make thread and warp IDs relative to the calling partition. This fixes incorrect indices and incomplete TMA copies from warp-specialized Gluon code.