### PR TITLE
[Gluon] Fix layout inference state propagation

### DIFF
--- a/lib/Dialect/Gluon/Transforms/InferLayoutUtils.cpp
+++ b/lib/Dialect/Gluon/Transforms/InferLayoutUtils.cpp
@@ -31,6 +31,10 @@ struct LayoutInfo {
   bool mayVary = false;
 
   operator bool() { return bool(encoding); }
+
+  bool operator==(const LayoutInfo &other) const {
+    return encoding == other.encoding && mayVary == other.mayVary;
+  }
 };
 
 uint64_t hashWithMemo(Attribute attr,
@@ -78,6 +82,22 @@ LayoutInfo combineInfo(LayoutInfo lhs, LayoutInfo rhs, Operation *op,
 bool encodingsMayVary(Operation *op) {
   return isa<triton::JoinOp, triton::SplitOp, triton::ReshapeOp,
              triton::TransOp>(op);
+}
+
+Attribute inferDstEncodingWithHint(
+    Operation *op, Attribute srcEncoding,
+    const llvm::MapVector<Value, LayoutInfo> &valueToEncoding) {
+  if (encodingsMayVary(op) && op->getNumResults() == 1) {
+    auto it = valueToEncoding.find(op->getResult(0));
+    if (it != valueToEncoding.end()) {
+      // Keep an existing result when inverse inference accepts this input.
+      // A default join can otherwise choose a different valid register order.
+      Attribute hint = it->second.encoding;
+      if (inferSrcEncoding(op, hint) == srcEncoding)
+        return hint;
+    }
+  }
+  return inferDstEncoding(op, srcEncoding);
 }
 
 LogicalResult
@@ -155,7 +175,8 @@ LogicalResult inferLayout(
                                   worklist, hashMemo)))
           return failure();
       } else {
-        auto dstEnc = inferDstEncoding(op, info.encoding);
+        auto dstEnc =
+            inferDstEncodingWithHint(op, info.encoding, valueToEncoding);
         if (dstEnc) {
           bool mayVary = info.mayVary || encodingsMayVary(op);
           LayoutInfo dstInfo{dstEnc, mayVary};

--- a/test/Gluon/auto_encoding.mlir
+++ b/test/Gluon/auto_encoding.mlir
@@ -199,3 +199,99 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     tt.return %2 : i32
   }
 }
+
+// -----
+
+// The reshape can provisionally infer a linear encoding for the cast result.
+// The explicit slice seed must refine it so both sides of the cast agree.
+// CHECK-LABEL: @refine_reshape_layout
+// CHECK: %[[POSITIONS:.*]] = tt.make_range {{.*}} : tensor<8xi32, #ttg.slice<{dim = 1, parent = [[BLOCKED:#.*]]}>>
+// CHECK: %[[CAST:.*]] = arith.sitofp %[[POSITIONS]] : tensor<8xi32, #ttg.slice<{dim = 1, parent = [[BLOCKED]]}>> to tensor<8xf32, #ttg.slice<{dim = 1, parent = [[BLOCKED]]}>>
+// CHECK: tt.reshape %[[CAST]]
+// CHECK-NOT: auto_encoding
+// CHECK: tt.return
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @refine_reshape_layout() -> (tensor<8xi32, #slice>, tensor<8x1xf32, #blocked>) {
+    %positions = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32, #gluon.auto_encoding>
+    %cast = arith.sitofp %positions : tensor<8xi32, #gluon.auto_encoding> to tensor<8xf32, #gluon.auto_encoding>
+    %expanded = tt.reshape %cast : tensor<8xf32, #gluon.auto_encoding> -> tensor<8x1xf32, #gluon.auto_encoding>
+    %fixed_positions = gluon.set_auto_layout %positions : tensor<8xi32, #gluon.auto_encoding> -> tensor<8xi32, #slice>
+    %fixed_expanded = gluon.set_auto_layout %expanded : tensor<8x1xf32, #gluon.auto_encoding> -> tensor<8x1xf32, #blocked>
+    tt.return %fixed_positions, %fixed_expanded : tensor<8xi32, #slice>, tensor<8x1xf32, #blocked>
+  }
+}
+
+// -----
+
+// Join permits several result register orders. Keep the order inferred
+// backwards from the dot operand instead of replacing it with the default.
+// CHECK-LABEL: @preserve_join_layout
+// CHECK-NOT: auto_encoding
+// CHECK: %[[LHS:.*]] = tt.trans {{.*}} -> tensor<4x128x16xbf16, #ttg.dot_op<
+// CHECK-NEXT: tt.return %[[LHS]]
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1, 1], instrShape = [1, 16, 8]}>
+#dot = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
+#auto = #gluon.auto_encoding
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @preserve_join_layout(%arg: bf16) -> tensor<4x128x16xbf16, #dot> {
+    %input = tt.splat %arg : bf16 -> tensor<4x8x128xbf16, #auto>
+    %padding = arith.constant dense<0.0> : tensor<4x8x128xbf16, #auto>
+    %joined = tt.join %input, %padding : tensor<4x8x128xbf16, #auto> -> tensor<4x8x128x2xbf16, #auto>
+    %transposed = tt.trans %joined {order = array<i32: 0, 3, 1, 2>} : tensor<4x8x128x2xbf16, #auto> -> tensor<4x2x8x128xbf16, #auto>
+    %reshaped = tt.reshape %transposed : tensor<4x2x8x128xbf16, #auto> -> tensor<4x16x128xbf16, #auto>
+    %lhs = tt.trans %reshaped {order = array<i32: 0, 2, 1>} : tensor<4x16x128xbf16, #auto> -> tensor<4x128x16xbf16, #auto>
+    %result = gluon.set_auto_layout %lhs : tensor<4x128x16xbf16, #auto> -> tensor<4x128x16xbf16, #dot>
+    tt.return %result : tensor<4x128x16xbf16, #dot>
+  }
+}
+
+// -----
+
+// Join operands must reconcile to identical types, even for equivalent layouts.
+// CHECK-LABEL: @equivalent_join_operands
+// CHECK-NOT: auto_encoding
+// CHECK: tt.return
+#q = #ttg.blocked<{sizePerThread = [1, 1, 1, 1], threadsPerWarp = [1, 1, 1, 32], warpsPerCTA = [1, 1, 1, 4], order = [0, 1, 2, 3]}>
+#j = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 2], threadsPerWarp = [1, 1, 1, 32, 1], warpsPerCTA = [1, 1, 1, 4, 1], order = [4, 0, 2, 1, 3]}>
+#auto = #gluon.auto_encoding
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @equivalent_join_operands(%ptr: !tt.ptr<f32>) -> (tensor<1x1x1x128xf32, #q>, tensor<1x1x1x128x2xf32, #j>) {
+    %p = tt.splat %ptr : !tt.ptr<f32> -> tensor<1x1x1x128x!tt.ptr<f32>, #auto>
+    %x = tt.load %p : tensor<1x1x1x128x!tt.ptr<f32>, #auto>
+    %a = tt.trans %x {order = array<i32: 1, 0, 2, 3>} : tensor<1x1x1x128xf32, #auto> -> tensor<1x1x1x128xf32, #auto>
+    %b = tt.trans %x {order = array<i32: 0, 2, 1, 3>} : tensor<1x1x1x128xf32, #auto> -> tensor<1x1x1x128xf32, #auto>
+    %joined = tt.join %a, %b : tensor<1x1x1x128xf32, #auto> -> tensor<1x1x1x128x2xf32, #auto>
+    %anchor = gluon.set_auto_layout %x : tensor<1x1x1x128xf32, #auto> -> tensor<1x1x1x128xf32, #q>
+    %out = ttg.convert_layout %joined : tensor<1x1x1x128x2xf32, #auto> -> tensor<1x1x1x128x2xf32, #j>
+    tt.return %anchor, %out : tensor<1x1x1x128xf32, #q>, tensor<1x1x1x128x2xf32, #j>
+  }
+}
+
+// -----
+
+// A split result hint must not prevent its two result types from reconciling.
+// CHECK-LABEL: @split_result_reconciliation
+// CHECK-NOT: auto_encoding
+// CHECK: tt.return
+#parent = #ttg.blocked<{sizePerThread = [1, 2, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#slice = #ttg.slice<{dim = 2, parent = #parent}>
+#seed = #ttg.slice<{dim = 1, parent = #slice}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#auto = #gluon.auto_encoding
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @split_result_reconciliation(%xptr: !tt.ptr<f32>, %yptr: !tt.ptr<f32>) -> (tensor<128x2xf32, #blocked>, tensor<128xf32, #seed>, tensor<128x2xf32, #blocked>) {
+    %xp = tt.splat %xptr : !tt.ptr<f32> -> tensor<128x2x2x!tt.ptr<f32>, #auto>
+    %x = tt.load %xp : tensor<128x2x2x!tt.ptr<f32>, #auto>
+    %parts:2 = tt.split %x : tensor<128x2x2xf32, #auto> -> tensor<128x2xf32, #auto>
+    %yp = tt.splat %yptr : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #auto>
+    %y = tt.load %yp : tensor<128x!tt.ptr<f32>, #auto>
+    %joined = tt.join %y, %y : tensor<128xf32, #auto> -> tensor<128x2xf32, #auto>
+    %sum = arith.addf %joined, %parts#0 : tensor<128x2xf32, #auto>
+    %part_anchor = gluon.set_auto_layout %parts#1 : tensor<128x2xf32, #auto> -> tensor<128x2xf32, #blocked>
+    %seed_anchor = gluon.set_auto_layout %y : tensor<128xf32, #auto> -> tensor<128xf32, #seed>
+    %out = ttg.convert_layout %sum : tensor<128x2xf32, #auto> -> tensor<128x2xf32, #blocked>
+    tt.return %part_anchor, %seed_anchor, %out : tensor<128x2xf32, #blocked>, tensor<128xf32, #seed>, tensor<128x2xf32, #blocked>
+  }
+}


### PR DESCRIPTION
Fix two issues in Gluon layout inference:

- Define `LayoutInfo::operator==` to compare `encoding` and `mayVary`. The previous comparison used the implicit `bool` conversion, so initialized layouts compared equal and refinements were not propagated.
- Preserve an existing result encoding when inverse inference returns the same input encoding. This keeps compatible layout choices through joins, reshapes, and transposes. Exclude split from hint reuse so ordinary forward inference can reconcile its results.