### PR TITLE
[interpreter] fix argument count mismatch in create_atomic_load/create_atomic_store

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1605,6 +1605,7 @@ def test_noinline_returns_tensor(device):
 # ---------------
 
 
+@pytest.mark.interpreter
 @pytest.mark.parametrize("dtype", [
     torch.bool, torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64, torch.float16, torch.float32,
     torch.float64

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -818,10 +818,10 @@ class InterpreterBuilder:
         return TensorHandle(_interpreter.atomic_cas(ptr.data, cmp.data, val.data, sem), cmp.dtype.scalar)
 
     def create_atomic_load(self, ptr, mask, sem, scope):
-        return self.create_masked_load(ptr, mask, None, None, None, True)
+        return self.create_masked_load(ptr, mask, None, None, True)
 
     def create_atomic_store(self, ptr, val, mask, sem, scope):
-        return self.create_masked_store(ptr, val, mask, None, None)
+        return self.create_masked_store(ptr, val, mask, None)
 
     def create_atomic_poll(self, ptr, expected, timeout_ns, sem, scope):
         matched = np.zeros(ptr.data.shape, dtype=np.bool_)


### PR DESCRIPTION
## Summary

`create_atomic_load` and `create_atomic_store` each pass one extra
positional argument to `create_masked_load`/`create_masked_store`,
so every interpreter-mode call to `tl.atomic_load`/`tl.atomic_store`
raises a `TypeError` before running. Likely a leftover from a prior
signature change (e.g. a `cache_policy` consolidation) where these two
call sites weren't updated to match.

Fixes #11675.

## Fix

Drop the extra `None` from each call so the argument count matches the
current 5-parameter `create_masked_load` and 4-parameter
`create_masked_store` signatures.

Also add `@pytest.mark.interpreter` to the existing
`test_atomic_load_store`, which already covers this exact path but was
never selected by `make test-interpret` (`pytest -m interpreter`) —
explaining why this argument-count bug survived undetected. The test's
only compiled-only assertions are already gated behind `is_cuda()`, so
no further changes are needed for it to pass under
`TRITON_INTERPRET=1`.

## Testing

- Repro kernel (`tl.atomic_load` + `tl.atomic_store`, int32) under
  `TRITON_INTERPRET=1`: `TypeError` before the fix, correct output
  (`[0..N-1]`) after.
- Same kernel in compiled (non-interpreter) mode: unaffected before
  and after — confirms this bug and fix are interpreter-only, and the
  fix introduces no regression on the compiled path.
- `test_atomic_load_store` (36 parametrizations, newly marked
  `@pytest.mark.interpreter`): unfixed → all 36 fail with the
  `TypeError`; fixed → all 36 pass under `TRITON_INTERPRET=1
  --device=cpu`; compiled mode (default GPU device) → all 36 pass
  before and after, confirming no regression.
- Verified on upstream/main build (A100, commit `4a15f415d8`).
- Local formatting checks against the pinned versions in
  `.pre-commit-config.yaml` (`yapf==0.43.0`, `ruff==0.9.1`): clean.

## Note

Compiled mode never hits this code — it goes through the nanobind C++
extension directly. Only `TRITON_INTERPRET=1` execution is affected.

## New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run the pinned formatters (`yapf==0.43.0`, `ruff==0.9.1`)
  against the changed files (pre-commit itself was not installed
  locally, so I ran the pinned tool versions directly in a scratch
  venv; both reported clean).
- [x] I have added tests.
  - `/python/test` for end-to-end tests
- [x] I have not added any `lit` tests.
