### PR TITLE
[TRITONGPU] Treat a negative inner-loop trip count as empty when speculating

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -1162,11 +1162,15 @@ static LogicalResult speculateInnerLoopLength(scf::ForOp outerLoop,
   // Mark the inner loop.
   innerLoop->setAttr(kMustExecuteAttrName, b.getUnitAttr());
 
-  // Speculate on whether the length of the inner loop is zero.
+  // Speculate on whether the inner loop is empty. The `else` branch keeps the
+  // must-execute marking above, which drops the predicate around the inner
+  // body, so this has to prove the trip count is positive. `computeNumIters`
+  // returns ceildivsi(ub - lb, step), which is negative rather than zero when
+  // the bounds are reversed, so test for a non-positive length.
   Value lenInner = computeNumIters(b, innerLoop);
   auto zeroAttr = IntegerAttr::get(lenInner.getType(), 0);
   Value innerLoopEmpty =
-      arith::CmpIOp::create(b, arith::CmpIPredicate::eq, lenInner,
+      arith::CmpIOp::create(b, arith::CmpIPredicate::sle, lenInner,
                             arith::ConstantOp::create(b, zeroAttr));
   auto ifOp = scf::IfOp::create(b, outerLoop.getResultTypes(), innerLoopEmpty);
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6999,6 +6999,26 @@ def test_tl_range_fuse_dependent(device):
     torch.testing.assert_close(out_j, ref_j, atol=0, rtol=0)
 
 
+@pytest.mark.parametrize("inner_ub", [3, 6])
+def test_tl_range_fuse_empty_inner(inner_ub, device):
+    # The inner loop is empty when its upper bound is below its lower bound. Its
+    # trip count is then negative rather than zero, which loop fusion must still
+    # speculate as empty: the fused loop does not predicate the inner body.
+
+    @triton.jit
+    def kernel(inner_ub, out_ptr):
+        acc = tl.full((), 0, tl.int32)
+        for _ in tl.range(0, 4, flatten=True):
+            for _ in tl.range(5, inner_ub):
+                acc += 1
+        tl.store(out_ptr, acc)
+
+    out = torch.empty((), dtype=torch.int32, device=device)
+    compiled_kernel = kernel[(1, )](inner_ub, out, num_warps=1)
+    assert "tt.flatten" in compiled_kernel.asm["ttir"]
+    assert out.item() == 4 * len(range(5, inner_ub))
+
+
 def test_tl_range_option_none():
 
     @triton.jit

--- a/test/TritonGPU/fuse-nested-loops.mlir
+++ b/test/TritonGPU/fuse-nested-loops.mlir
@@ -493,7 +493,7 @@ tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
   %c1_i32 = arith.constant 1 : i32
 
   // CHECK: [[LEN:%.*]] = arith.subi [[UB]], [[LB]]
-  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[LEN]], %c0_i32
+  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi sle, [[LEN]], %c0_i32
 
   // CHECK: scf.if [[IS_ZERO]]
   // CHECK-NEXT: scf.for %{{.*}} = [[LB]] to [[UB]] step %c1_i32
@@ -525,7 +525,7 @@ tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
 tt.func @speculate_hoist(%lb: i32, %ub: i32) {
   %c1_i32 = arith.constant 1 : i32
 
-  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[UB]], %c0_i32
+  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi sle, [[UB]], %c0_i32
 
   // CHECK: scf.if [[IS_ZERO]]
   scf.for %i = %lb to %ub step %c1_i32 : i32 {
@@ -613,7 +613,7 @@ tt.func @assume_not_dominating_loop(%lb: i32, %ub: i32, %flag: i1) {
   // it must still be emitted (the assume on the other branch is not in force
   // here). The buggy pass instead replaced this guard with `arith.constant
   // true` because it matched the assume without a dominance check.
-  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[UB]], %c0_i32
+  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi sle, [[UB]], %c0_i32
   // CHECK: scf.if [[IS_ZERO]]
   // CHECK-NEXT: scf.for %{{.*}} = %c0_i32 to [[UB]] step %c1_i32
   // CHECK-NEXT:   "prologue"
@@ -634,5 +634,29 @@ tt.func @assume_not_dominating_loop(%lb: i32, %ub: i32, %flag: i1) {
     } {tt.flatten}
     scf.yield
   }
+  tt.return
+}
+
+// -----
+
+// The inner loop runs from 5 to 3, so its trip count is negative, not zero.
+// Speculation must still take the empty branch: the inner body is unpredicated
+// in the non-empty branch, so it would otherwise run once per outer iteration.
+// CHECK-LABEL: @speculate_empty_inner
+// CHECK: "prologue"
+// CHECK-NOT: "body"
+tt.func @speculate_empty_inner() {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c3_i32 = arith.constant 3 : i32
+  %c4_i32 = arith.constant 4 : i32
+  %c5_i32 = arith.constant 5 : i32
+  scf.for %i = %c0_i32 to %c4_i32 step %c1_i32 : i32 {
+    "prologue"(%i) : (i32) -> ()
+    scf.for %j = %c5_i32 to %c3_i32 step %c1_i32 : i32 {
+      "body"(%i, %j) : (i32, i32) -> ()
+      scf.yield
+    }
+  } {tt.flatten}
   tt.return
 }


### PR DESCRIPTION
Fixes #11656

## Problem

`tritongpu-fuse-nested-loops` miscompiles a `flatten=True` nest whose inner loop has an upper bound below its lower bound: the inner body runs once per outer iteration instead of zero times. With `for _ in tl.range(5, ub)` nested inside `tl.range(0, 4, flatten=True)`, `ub=3` yields 4 where the unflattened nest yields 0.

`speculateInnerLoopLength` version-splits the nest into `if (inner loop is empty) { nest with the inner loop deleted } else { nest with the inner loop marked ttg.must-execute }`. That marking is what lets `flattenLoopNest` replace the inner body's `T >= start && T < start + len` predicate with `arith.constant true`, so the `else` branch is only sound when the inner loop really does run at least once.

The emptiness test was `arith.cmpi eq, len, 0`, but `computeNumIters` returns `ceildivsi(ub - lb, step)`, which is *negative* rather than zero for reversed bounds. The generated TTGIR shows the whole failure in a few lines:

```mlir
%acc   = arith.subi %ub, %c5_i32                   // len = ub - 5
%acc_0 = arith.cmpi eq, %acc, %c0_i32              // "is the inner loop empty?"
%acc_1 = scf.if %acc_0 -> (i32) {
  scf.yield %c0_i32                                // empty: 0
} else {
  %acc_2 = arith.maxsi %acc, %c1_i32               // max(1, len) clamps -2 to 1
  %acc_3 = arith.muli %acc_2, %c4_i32              // total_iters = 4
  %acc_4 = scf.for ... to %acc_3 ... { acc += 1 }  // body is unpredicated here
```

At `ub=3` the length is `-2`, `-2 == 0` is false, so the nest takes the `else` branch, `maxsi` clamps the negative length to one T-slot per outer iteration, and the unpredicated body increments four times.

## Fix

Use `sle` for the emptiness test. The speculation has to prove the trip count is *positive*, and `!= 0` does not prove that while `> 0` does. Nothing else in the pass needs to change: the general fusion path already accumulates `max(1, len)` for slot accounting and keeps the raw `len` in the body predicate, so a non-positive `len` there already means "the body does not run".

## Priors

`speculateInnerLoopLength` and its `arith.cmpi eq, len, 0` test both arrive in #5726 (`0cb01405`), so the predicate has been `eq` since the speculation was first written. This is not a regression.

#8132 (`2ad519c2`) added the dependent-inner-bound path, which accumulates `max(1, numIters)` and leaves the raw `numIters` in the body predicate. The general path therefore already treats a non-positive trip count as "the body does not run", which leaves the speculation predicate as the one place that does not.

#11521 (`8f80860f`, fixing #11519) is the same defect class in the same function: `ttg.must-execute` ends up on a loop that can run zero times, and the resulting unpredicated body produces silent wrong results. There the cause was trusting an `llvm.assume` that does not dominate the loop; here it is a trip count that is negative rather than zero. That change tightened *which assumptions* license the fast path; this one tightens *the arithmetic test* that licenses it.

## Verification

Reproducer from #11656 on an RTX 4080 (sm_89). Before, against triton 3.6.0:

```
FAIL ub=3: flattened=4 ordinary=0 expected=0
OK   ub=6: flattened=4 ordinary=4 expected=4
```

After, with this change built from source:

```
OK   ub=3: flattened=0 ordinary=0 expected=0
OK   ub=6: flattened=4 ordinary=4 expected=4
```

The new lit case `@speculate_empty_inner` fails without the code change (its `CHECK-NOT: "body"` matches inside the fused loop) and passes with it. Full `lit test/` is 299 passed, 2 unsupported, 0 failed. `pytest python/test/unit/language/test_core.py -k tl_range` is 6 passed.

Three existing CHECK lines pinned the `eq` predicate and are updated to `sle`: `@fuse_attr_speculate`, `@speculate_hoist`, and `@assume_not_dominating_loop` from #11521.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.
