### PR TITLE
Assert the async-copy branch in test_compile_tensor_copy

### DIFF
--- a/third_party/amd/python/test/test_gluon_cdna5.py
+++ b/third_party/amd/python/test/test_gluon_cdna5.py
@@ -1782,7 +1782,7 @@ def test_compile_tensor_copy(BLOCK_M, BLOCK_N, NUM_BUFFERS, ASYNC_LOAD_TYPE, NUM
     if ASYNC_LOAD_TYPE in {"DEVICE_TDM", "HOST_TDM"}:
         pattern = {"tensor_load_to_lds", "s_wait_tensorcnt 0x0"}
     else:
-        ASYNC_LOAD_TYPE == "ASYNC_COPY"
+        assert ASYNC_LOAD_TYPE == "ASYNC_COPY"
         pattern = {"global_load_async_to_lds", "s_wait_asynccnt 0x0"}
     for p in pattern:
         assert re.search(p, amdgcn), f"Can't find {p} in amdgcn"


### PR DESCRIPTION
# Description

The `else` branch of `test_compile_tensor_copy` opens with a bare comparison:

```python
if ASYNC_LOAD_TYPE in {"DEVICE_TDM", "HOST_TDM"}:
    pattern = {"tensor_load_to_lds", "s_wait_tensorcnt 0x0"}
else:
    ASYNC_LOAD_TYPE == "ASYNC_COPY"      # evaluated, discarded
    pattern = {"global_load_async_to_lds", "s_wait_asynccnt 0x0"}
```

Python evaluates the comparison and throws the result away, so the line documents an expectation it never enforces. `ruff --select B015` flags it: *"Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it."*

This prepends the `assert`.

It cannot fail today: the test parametrizes `ASYNC_LOAD_TYPE` as `["ASYNC_COPY", "DEVICE_TDM", "HOST_TDM"]` and the `if` above catches the two TDM cases, so the `else` is exactly `ASYNC_COPY` for every parametrization. Its value is for later — if a fourth load type is added without updating the pattern set below, the test will now say so instead of silently checking async-copy instructions against it.

Happy to delete the line instead if you'd rather not have the assertion; either resolves the lint, but asserting seemed closer to the original intent.
