### PR TITLE
[NVIDIA] Support native N=8 K-packed FP4 matmul

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -324,35 +324,25 @@ static Value createTmemScaleOperand(Value tensor, Attribute tmemEncoding,
                                     Attribute tensorMemorySpace, int numWarps,
                                     Location loc, PatternRewriter &rewriter) {
   auto tensorType = cast<RankedTensorType>(tensor.getType());
-  auto shape = llvm::to_vector(tensorType.getShape());
-  // TMEM stores need at least 16 rows, even when an N=8 MMA only reads eight.
-  shape[0] = std::max<int64_t>(shape[0], 16);
-  auto tmemType = MemDescType::get(shape, tensorType.getElementType(),
-                                   tmemEncoding, tensorMemorySpace,
-                                   /*mutableMemory=*/false);
-  auto tmemLayout = nvidia_gpu::getDefaultLayoutForTmemLdSt(tmemType, numWarps);
-  auto stagedType =
-      RankedTensorType::get(shape, tensorType.getElementType(), tmemLayout);
-  Value converted;
-  if (shape[0] != tensorType.getShape()[0]) {
-    // Repeat the scale rows into padding without reading beyond the input.
-    SmallVector<int64_t> expandedShape = {shape[0] / tensorType.getShape()[0],
-                                          tensorType.getShape()[0], shape[1]};
-    auto *ctx = tensorType.getContext();
-    auto expandedLayout = LinearEncodingAttr::get(
-        ctx, reshapeLayout(ctx, toLinearLayout(stagedType), expandedShape));
-    auto sliceLayout = SliceEncodingAttr::get(ctx, 0, expandedLayout);
-    auto sliceType = tensorType.cloneWithEncoding(sliceLayout);
-    Value slice = ConvertLayoutOp::create(rewriter, loc, sliceType, tensor);
-    Value expanded = ExpandDimsOp::create(rewriter, loc, slice, 0);
-    auto expandedType = RankedTensorType::get(
-        expandedShape, tensorType.getElementType(), expandedLayout);
-    Value broadcast =
-        BroadcastOp::create(rewriter, loc, expandedType, expanded);
-    converted = ReshapeOp::create(rewriter, loc, stagedType, broadcast);
-  } else {
-    converted = ConvertLayoutOp::create(rewriter, loc, stagedType, tensor);
+  if (tensorType.getShape()[0] == 8) {
+    // Repeat N=8 scale rows to fill the minimum 16-row TMEM store.
+    int64_t k = tensorType.getShape()[1];
+    auto expanded =
+        ReshapeOp::create(rewriter, loc, ArrayRef<int64_t>{1, 8, k}, tensor);
+    auto broadcast = BroadcastOp::create(
+        rewriter, loc, expanded.getType().clone({2, 8, k}), expanded);
+    auto padded =
+        ReshapeOp::create(rewriter, loc, ArrayRef<int64_t>{16, k}, broadcast);
+    tensor = padded;
+    tensorType = padded.getType();
   }
+  auto tmemType =
+      MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
+                       tmemEncoding, tensorMemorySpace,
+                       /*mutableMemory=*/false);
+  auto tmemLayout = nvidia_gpu::getDefaultLayoutForTmemLdSt(tmemType, numWarps);
+  auto stagedType = tensorType.cloneWithEncoding(tmemLayout);
+  Value converted = ConvertLayoutOp::create(rewriter, loc, stagedType, tensor);
   return triton::nvidia_gpu::TMEMAllocOp::create(rewriter, loc, tmemType,
                                                  /*token=*/Type(), converted);
 }

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -324,13 +324,35 @@ static Value createTmemScaleOperand(Value tensor, Attribute tmemEncoding,
                                     Attribute tensorMemorySpace, int numWarps,
                                     Location loc, PatternRewriter &rewriter) {
   auto tensorType = cast<RankedTensorType>(tensor.getType());
-  auto tmemType =
-      MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
-                       tmemEncoding, tensorMemorySpace,
-                       /*mutableMemory=*/false);
+  auto shape = llvm::to_vector(tensorType.getShape());
+  // TMEM stores need at least 16 rows, even when an N=8 MMA only reads eight.
+  shape[0] = std::max<int64_t>(shape[0], 16);
+  auto tmemType = MemDescType::get(shape, tensorType.getElementType(),
+                                   tmemEncoding, tensorMemorySpace,
+                                   /*mutableMemory=*/false);
   auto tmemLayout = nvidia_gpu::getDefaultLayoutForTmemLdSt(tmemType, numWarps);
-  auto stagedType = tensorType.cloneWithEncoding(tmemLayout);
-  Value converted = ConvertLayoutOp::create(rewriter, loc, stagedType, tensor);
+  auto stagedType =
+      RankedTensorType::get(shape, tensorType.getElementType(), tmemLayout);
+  Value converted;
+  if (shape[0] != tensorType.getShape()[0]) {
+    // Repeat the scale rows into padding without reading beyond the input.
+    SmallVector<int64_t> expandedShape = {shape[0] / tensorType.getShape()[0],
+                                          tensorType.getShape()[0], shape[1]};
+    auto *ctx = tensorType.getContext();
+    auto expandedLayout = LinearEncodingAttr::get(
+        ctx, reshapeLayout(ctx, toLinearLayout(stagedType), expandedShape));
+    auto sliceLayout = SliceEncodingAttr::get(ctx, 0, expandedLayout);
+    auto sliceType = tensorType.cloneWithEncoding(sliceLayout);
+    Value slice = ConvertLayoutOp::create(rewriter, loc, sliceType, tensor);
+    Value expanded = ExpandDimsOp::create(rewriter, loc, slice, 0);
+    auto expandedType = RankedTensorType::get(
+        expandedShape, tensorType.getElementType(), expandedLayout);
+    Value broadcast =
+        BroadcastOp::create(rewriter, loc, expandedType, expanded);
+    converted = ReshapeOp::create(rewriter, loc, stagedType, broadcast);
+  } else {
+    converted = ConvertLayoutOp::create(rewriter, loc, stagedType, tensor);
+  }
   return triton::nvidia_gpu::TMEMAllocOp::create(rewriter, loc, tmemType,
                                                  /*token=*/Type(), converted);
 }
@@ -842,8 +864,6 @@ public:
       return failure();
     if (numWarps != 4 && numWarps != 8)
       return failure();
-    if (retShapePerCTA[0] < 128 || retShapePerCTA[1] < 16)
-      return failure();
     Location loc = dotOp.getLoc();
     // operands
     Value a = dotOp.getA();
@@ -862,6 +882,13 @@ public:
     }
 
     bool isFp4MMA = isAFP4 && isBFP4;
+    // K-packed FP4 supports 128x8 MMA; keep its scale padding within one CTA.
+    int minN = isFp4MMA && dotOp.getLhsKPack() && dotOp.getRhsKPack() &&
+                       lookupNumCTAs(dotOp) == 1
+                   ? 8
+                   : 16;
+    if (retShapePerCTA[0] < 128 || retShapePerCTA[1] < minN)
+      return failure();
     bool requiresFp4Padding =
         nvidia_gpu::TargetFeatures(computeCapability).requiresFp4Padding();
 

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -324,18 +324,6 @@ static Value createTmemScaleOperand(Value tensor, Attribute tmemEncoding,
                                     Attribute tensorMemorySpace, int numWarps,
                                     Location loc, PatternRewriter &rewriter) {
   auto tensorType = cast<RankedTensorType>(tensor.getType());
-  if (tensorType.getShape()[0] == 8) {
-    // Repeat N=8 scale rows to fill the minimum 16-row TMEM store.
-    int64_t k = tensorType.getShape()[1];
-    auto expanded =
-        ReshapeOp::create(rewriter, loc, ArrayRef<int64_t>{1, 8, k}, tensor);
-    auto broadcast = BroadcastOp::create(
-        rewriter, loc, expanded.getType().clone({2, 8, k}), expanded);
-    auto padded =
-        ReshapeOp::create(rewriter, loc, ArrayRef<int64_t>{16, k}, broadcast);
-    tensor = padded;
-    tensorType = padded.getType();
-  }
   auto tmemType =
       MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
                        tmemEncoding, tensorMemorySpace,
@@ -872,7 +860,7 @@ public:
     }
 
     bool isFp4MMA = isAFP4 && isBFP4;
-    // K-packed FP4 supports 128x8 MMA; keep its scale padding within one CTA.
+    // K-packed FP4 supports 128x8 MMA with a single CTA.
     int minN = isFp4MMA && dotOp.getLhsKPack() && dotOp.getRhsKPack() &&
                        lookupNumCTAs(dotOp) == 1
                    ? 8

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -385,6 +385,25 @@ getDistributedLayoutForTmemLdSt(gpu::MemDescType memType, TMemAccessAtom atom,
          "This layout is inferred sometimes for the 32x32b atom");
   auto ll = toLinearLayout(memType);
   auto bitwidth = memType.getElementTypeBitWidth();
+  if (atom == TMemAccessAtom::I32x32b &&
+      isa<TensorMemoryScalesEncodingAttr>(memType.getEncoding()) &&
+      memType.getShape().front() == 8 &&
+      memType.getAllocShape().take_back(2).front() == 8 &&
+      ll.getInDimSize(StringAttr::get(memType.getContext(), "block")) == 1) {
+    // The allocation reserves 16 rows per warp. Infer the physical access,
+    // then broadcast the unused rows in the register layout.
+    auto bases = ll.getBases();
+    bases[StringAttr::get(memType.getContext(), "row")][3] = {8, 0};
+    auto dims = ll.getOutDims();
+    dims[0].second = 16;
+    auto physicalLayout =
+        LinearLayout(std::move(bases), dims, /*requireSurjective=*/true);
+    auto layout = getDistributedLayoutForTmemLdSt(physicalLayout, atom,
+                                                  numWarps, bitwidth);
+    if (layout)
+      return layout->resizeOutDim(dims[0].first, 8);
+    return std::nullopt;
+  }
   return getDistributedLayoutForTmemLdSt(ll, atom, numWarps, bitwidth);
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
@@ -259,6 +259,7 @@ computeTMemLdStEncodingInfo(RankedTensorType regTy, MemDescType memTy,
   auto kBlock = S("block");
   auto kWarp = S("warp");
   auto kRow = S("row");
+  auto kLane = S("lane");
   auto cvt = regLayout.invertAndCompose(memLayout);
   auto maybeSublayout = cvt.quotient({kBlock});
   if (!maybeSublayout) {
@@ -287,6 +288,16 @@ computeTMemLdStEncodingInfo(RankedTensorType regTy, MemDescType memTy,
   auto bases = cvt.getBases();
   bases[kWarp][0] = {32, 0};
   bases[kWarp][1] = {64, 0};
+  if (isa<TensorMemoryScalesEncodingAttr>(memTy.getEncoding()) &&
+      memTy.getShape().front() == 8 &&
+      memTy.getAllocShape().take_back(2).front() == 8 &&
+      memLayout.getInDimSize(kBlock) == 1 &&
+      cvt.getBasis(kLane, 3) == ArrayRef{0, 0}) {
+    // A scale allocation owns at least 16 rows per warp. Use its unused rows
+    // for the upper eight lanes of each store. Scale descriptors are
+    // store-only.
+    bases[kLane][3] = {8, 0};
+  }
   cvt = LinearLayout(std::move(bases), cvt.getOutDims(),
                      /*isSurjective=*/cvt.isSurjective());
 

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -2381,6 +2381,40 @@ def test_tmem_copy_2d():
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("K", [2, 4, 8, 16])
+@pytest.mark.parametrize("num_warps", [4, 8])
+def test_tmem_scales_narrow_rows(K, num_warps):
+
+    @gluon.jit
+    def kernel(inp, out, guard_out, K: ttgl.constexpr):
+        COLS: ttgl.constexpr = 1 if K <= 4 else K // 2
+        word_layout: ttgl.constexpr = TensorMemoryLayout([64, COLS], col_stride=1)
+        guard = allocate_tensor_memory(ttgl.int32, [64, COLS], word_layout)
+        guard.store(ttgl.full([64, COLS], -7, ttgl.int32, guard.get_reg_layout()))
+        scales = allocate_tensor_memory(ttgl.uint8, [8, K], TensorMemoryScalesLayout())
+        layout: ttgl.constexpr = scales.get_reg_layout()
+        rows = ttgl.arange(0, 8, layout=ttgl.SliceLayout(1, layout))[:, None]
+        cols = ttgl.arange(0, K, layout=ttgl.SliceLayout(0, layout))[None, :]
+        scales.store(ttgl.load(inp + rows * K + cols))
+
+        # Read the physical words to check the scale rows in every warp's block.
+        words = scales.reinterpret(ttgl.int32, [64, COLS], word_layout)
+        result_layout: ttgl.constexpr = words.get_reg_layout()
+        rows = ttgl.arange(0, 64, layout=ttgl.SliceLayout(1, result_layout))[:, None]
+        cols = ttgl.arange(0, COLS, layout=ttgl.SliceLayout(0, result_layout))[None, :]
+        ttgl.store(out + rows * COLS + cols, words.load())
+        ttgl.store(guard_out + rows * COLS + cols, guard.load())
+
+    inp = torch.arange(8 * K, device="cuda").reshape(8, K).to(torch.uint8)
+    out = torch.empty((64, 1 if K <= 4 else K // 2), dtype=torch.int32, device="cuda")
+    guard = torch.empty_like(out)
+    kernel[(1, )](inp, out, guard, K, num_warps=num_warps)
+    scale_bytes = out[:, ::2].contiguous().flatten().view(torch.uint8).reshape(4, 16, -1)[:, :8, :K]
+    torch.testing.assert_close(scale_bytes, inp.expand(4, -1, -1), atol=0, rtol=0)
+    torch.testing.assert_close(guard, torch.full_like(guard, -7), atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_tmem_pipeline_stage_subslice_index_reinterpret():
 
     @gluon.jit

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -1136,6 +1136,45 @@ def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, with_a_sc
             assert "kind::mxf8f6f4" in ptx
 
 
+@pytest.mark.parametrize("BLOCK_M", [128, 256])
+@pytest.mark.parametrize("BLOCK_K", [64, 128, 256])
+@pytest.mark.parametrize("num_warps", [4, 8])
+@pytest.mark.parametrize("num_stages", [1, 3])
+@pytest.mark.parametrize("scale_type, VEC_SIZE", [("float8_e8m0fnu", 32), ("float8_e4m3fn", 16)])
+def test_block_scale_fp4_narrow_n(BLOCK_M, BLOCK_K, num_warps, num_stages, scale_type, VEC_SIZE, device):
+    if not is_cuda() or torch.cuda.get_device_capability()[0] != 10:
+        pytest.skip("Requires fifth-generation NVIDIA tensor cores")
+
+    torch.manual_seed(42)
+    M, N, K = 2 * BLOCK_M, 8, 4 * BLOCK_K
+    a_fp4 = MXFP4Tensor(size=(M, K), device=device).random()
+    b_fp4 = MXFP4Tensor(size=(N, K), device=device).random()
+    a = a_fp4.to_packed_tensor(dim=1)
+    b = b_fp4.to_packed_tensor(dim=1).T
+    a_scale = torch.rand((M, K // VEC_SIZE), device=device)
+    b_scale = torch.rand((N, K // VEC_SIZE), device=device)
+    if scale_type == "float8_e8m0fnu":
+        a_scale_ref = MXScaleTensor(a_scale)
+        b_scale_ref = MXScaleTensor(b_scale)
+        a_scale = a_scale_ref.data
+        b_scale = b_scale_ref.data
+    else:
+        a_scale = a_scale_ref = a_scale.to(torch.float8_e4m3fn)
+        b_scale = b_scale_ref = b_scale.to(torch.float8_e4m3fn)
+    a_ref = a_fp4.to(torch.float32) * a_scale_ref.to(torch.float32).repeat_interleave(VEC_SIZE, dim=1)
+    b_ref = b_fp4.to(torch.float32) * b_scale_ref.to(torch.float32).repeat_interleave(VEC_SIZE, dim=1)
+    output = torch.empty((M, N), dtype=torch.float32, device=device)
+    kernel = block_scale_fp4_matmul[(M // BLOCK_M, )](a, b, output, a_scale, b_scale, M, N, K, a_scale.stride(0),
+                                                      *a.stride(), *b.stride(), *output.stride(), VEC_SIZE, BLOCK_M, N,
+                                                      BLOCK_K, NUM_STAGES=num_stages, PACK_ALONG_K=True,
+                                                      num_warps=num_warps)
+    if is_compile_warmup():
+        return
+    torch.testing.assert_close(output, a_ref @ b_ref.T, atol=1e-3, rtol=1e-3)
+    kind = "mxf4nvf4" if scale_type == "float8_e4m3fn" else "mxf4"
+    assert f"tcgen05.mma.cta_group::1.kind::{kind}.block_scale" in kernel.asm["ptx"]
+
+
 @triton.jit
 def rhs_scaled_n_packed_fp4_matmul(A, B, BS, C):
     a = tl.load(A + tl.arange(0, 128)[:, None] * 32 + tl.arange(0, 32)[None, :])

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -1219,6 +1219,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+// N=8 scale stores use the allocation's 16 physical rows.
+#linear = #ttg.linear<{register = [[0, 1]], lane = [[1, 0], [2, 0], [4, 0], [0, 0], [0, 0]], warp = [[0, 0], [0, 0]], block = []}>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+// CHECK-LABEL: @store_8x2_scales
+tt.func private @store_8x2_scales(%arg0: !ttg.memdesc<8x2xi8, #tmem_scales, #ttng.tensor_memory, mutable>, %arg1: tensor<8x2xi8, #linear>) {
+  %true = arith.constant true
+  // CHECK: @$0 tcgen05.st.sync.aligned.16x32bx2.x1.b32 [$1 + 0], 0, {$2}
+  ttng.tmem_store %arg1, %arg0, %true : tensor<8x2xi8, #linear> -> !ttg.memdesc<8x2xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+  tt.return
+}
+}
+
+// -----
+
 // Test basic reduction with min
 // The reduction output has 1 value per thread per message
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -1030,6 +1030,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: sm100_dot_scaled_nvfp4_n8
+  // CHECK-NOT: ttg.fp4_to_fp
+  // CHECK: ttng.tc_gen5_mma_scaled
+  // CHECK-NOT: tt.dot_scaled
+  // CHECK: tt.return
+  tt.func public @sm100_dot_scaled_nvfp4_n8(%a: tensor<128x32xi8, #blocked>, %scale_a: tensor<128x4xf8E4M3FN, #blocked>, %b: tensor<32x8xi8, #blocked_k>, %scale_b: tensor<8x4xf8E4M3FN, #blocked>) -> tensor<128x8xf32, #blocked> {
+    %cst = arith.constant dense<0.0> : tensor<128x8xf32, #blocked>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e2m1 rhs = e2m1 {fastMath = false, lhs_k_pack = true, rhs_k_pack = true}
+      : tensor<128x32xi8, #blocked>, tensor<128x4xf8E4M3FN, #blocked> * tensor<32x8xi8, #blocked_k>, tensor<8x4xf8E4M3FN, #blocked> -> tensor<128x8xf32, #blocked>
+    tt.return %d : tensor<128x8xf32, #blocked>
+  }
+
+  // CHECK-LABEL: sm100_dot_scaled_nvfp4_n4_fallback
+  // CHECK: ttg.fp4_to_fp
+  // CHECK-NOT: ttng.tc_gen5_mma_scaled
+  // CHECK-NOT: tt.dot_scaled
+  // CHECK: tt.return
+  tt.func public @sm100_dot_scaled_nvfp4_n4_fallback(%a: tensor<128x32xi8, #blocked>, %scale_a: tensor<128x4xf8E4M3FN, #blocked>, %b: tensor<32x4xi8, #blocked_k>, %scale_b: tensor<4x4xf8E4M3FN, #blocked>) -> tensor<128x4xf32, #blocked> {
+    %cst = arith.constant dense<0.0> : tensor<128x4xf32, #blocked>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e2m1 rhs = e2m1 {fastMath = false, lhs_k_pack = true, rhs_k_pack = true}
+      : tensor<128x32xi8, #blocked>, tensor<128x4xf8E4M3FN, #blocked> * tensor<32x4xi8, #blocked_k>, tensor<4x4xf8E4M3FN, #blocked> -> tensor<128x4xf32, #blocked>
+    tt.return %d : tensor<128x4xf32, #blocked>
+  }
+}
+
+// -----
+
 // We previously asserted that a tmem allocation must fit in the available tmem.
 // This would cause an assertion failure if the result matrix was too large.
 // Check that we allow the large result in AccelerateMatmul, and leave it to

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -1036,6 +1036,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: sm100_dot_scaled_nvfp4_n8
   // CHECK-NOT: ttg.fp4_to_fp
+  // CHECK-NOT: tt.reshape
+  // CHECK-NOT: tt.broadcast
+  // CHECK: ttng.tmem_alloc {{.*}} : (tensor<8x4xf8E4M3FN, {{.*}}>) -> !ttg.memdesc<8x4xf8E4M3FN,
   // CHECK: ttng.tc_gen5_mma_scaled
   // CHECK-NOT: tt.dot_scaled
   // CHECK: tt.return


### PR DESCRIPTION
## Summary

Enable native `128 x 8` matrix multiply-accumulate (MMA) instructions for K-packed NVIDIA FP4 (NVFP4) and microscaling FP4 (MXFP4) when `num_ctas=1`. These tiles currently take the bfloat16 (BF16) decomposition path despite being supported by the [Parallel Thread Execution (PTX) instruction set](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-matrix-shape).

The width guard was introduced while fixing small-N scale handling in #8172. Relaxing it requires completing the scale-staging support: tensor-memory (TMEM) stores need at least 16 rows. Keep the B-scale tensor and its descriptor at eight logical rows. TMEM layout inference and store lowering use the 16 physical rows already reserved by the allocator.

The relaxed guard applies only to K-packed FP4 operands in one cooperative thread array (CTA). Other operand layouts and multi-CTA launches retain their existing width limits.

## Validation

Rebuilt the native compiler with `make` and validated on one NVIDIA GB300 (SM103):

- `python -m pytest -s --tb=short python/test/unit/language/test_matmul.py::test_block_scale_fp4_narrow_n`: 48 cases passed. Covers NVFP4/MXFP4, M tiles of 128/256, K tiles of 64/128/256, 4/8 warps, and 1/3 pipeline stages. Checks results against a 32-bit floating-point reference and native FP4 instructions.
- `python -m pytest -s --tb=short python/test/gluon/test_core.py::test_tmem_scales_narrow_rows`: 8 cases passed. Checks the physical scale rows and an adjacent allocation across scale widths 2/4/8/16 and 4/8 warps.
- Both lit files passed: `test/TritonGPU/accelerate-matmul.mlir` and `test/Conversion/tritongpu_to_llvm_blackwell.mlir`. Coverage checks native N=8, retained N=4 fallback, unchanged logical scale shape, and physical store lowering.

Synthetic NVFP4 kernel runtime against base `4a15f415d8ac` (microseconds; lower is better). Both builds use identical inputs and a `128 x N x 128` tile, four warps, and one pipeline stage. Each result is the median of five `do_bench_cudagraph(..., rep=100)` measurements, with correctness checked before timing.

| Matrix M x N x K | Base | This PR | Speedup |
|---|---:|---:|---:|
| 128 x 8 x 256 | 5.736 | 2.865 | 2.00x |
| 2048 x 8 x 512 | 9.571 | 4.088 | 2.34x |
| 4096 x 8 x 4096 | 66.364 | 22.222 | 2.99x |
| 2048 x 16 x 512 (control) | 4.316 | 4.313 | 1.00x |

For the N=8 cases, register usage falls from 167 to 44 and shared memory from 32 KiB to 9.5 KiB. The N=16 control emits identical instructions; its PTX differs only in a debug source path. These are kernel execution timings on generated inputs.

<details>
<summary>Benchmark reproducer</summary>

Run from the repository root against each built version:

```bash
PYTHONPATH=python/test/unit/language python - <<'PY'
import statistics
import torch
import triton
import triton.testing
from test_matmul import block_scale_fp4_matmul, MXFP4Tensor

for M, N, K in [(128, 8, 256), (2048, 8, 512), (4096, 8, 4096), (2048, 16, 512)]:
    torch.manual_seed(42)
    a_fp4 = MXFP4Tensor(size=(M, K), device="cuda").random()
    b_fp4 = MXFP4Tensor(size=(N, K), device="cuda").random()
    a = a_fp4.to_packed_tensor(dim=1)
    b = b_fp4.to_packed_tensor(dim=1).T
    sa = torch.rand((M, K // 16), device="cuda").to(torch.float8_e4m3fn)
    sb = torch.rand((N, K // 16), device="cuda").to(torch.float8_e4m3fn)
    out = torch.empty((M, N), dtype=torch.float32, device="cuda")
    ar = a_fp4.to(torch.float32) * sa.float().repeat_interleave(16, dim=1)
    br = b_fp4.to(torch.float32) * sb.float().repeat_interleave(16, dim=1)
    ref = ar @ br.T

    def run():
        return block_scale_fp4_matmul[(M // 128,)](
            a, b, out, sa, sb, M, N, K, sa.stride(0),
            *a.stride(), *b.stride(), *out.stride(), 16, 128, N, 128,
            NUM_STAGES=1, PACK_ALONG_K=True, num_warps=4,
        )

    kernel = run()
    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
    samples = [triton.testing.do_bench_cudagraph(run, rep=100) * 1000 for _ in range(5)]
    native = "kind::mxf4nvf4" in kernel.asm["ptx"]
    print((M, N, K), statistics.median(samples), "us", "native:", native)
PY
```

</details>

## Lines Changed

| Type | Added | Removed | Net |
|---|---:|---:|---:|
| Tests | 123 | 0 | +123 |
| Core Logic | 37 | 2 | +35 |
| AutoGenerated | 0 | 0 | 0 |
| Total | 160 | 2 | +158 |

## Reviewers Guide

- `lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp`: conditional N=8 eligibility.
- `lib/Dialect/TritonNvidiaGPU/IR/{Dialect,TensorMemoryUtils}.cpp`: infer and lower the physical store while preserving eight logical rows.
- The Python and lit tests cover numerical correctness, padding isolation, instruction selection, and the fallback boundary. No file moves or generated changes.
