### PR TITLE
[OptimizeThreadLocality] Handle multi-use thread locality results

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -333,15 +333,13 @@ class TritonGPUOptimizeThreadLocalityPass
       auto blockArg = dyn_cast<BlockArgument>(accumOperand);
       auto blockArgNum = blockArg.getArgNumber();
       auto forOp = dyn_cast<scf::ForOp>(blockArg.getOwner()->getParentOp());
+      auto *initOperand = forOp.getTiedLoopInit(blockArg);
+      if (!initOperand)
+        continue;
+      auto loopResult = forOp.getTiedLoopResult(initOperand);
+      auto resultIndex = loopResult.getResultNumber();
       // get oldAccum
-      auto oldAccum =
-          forOp.getInitArgs()[blockArgNum - forOp.getNumInductionVars()];
-      // get old loop user
-      Value loopResult =
-          forOp.getResult(blockArgNum - forOp.getNumInductionVars());
-      assert(loopResult.hasOneUse());
-      OpOperand &loopUse = *(loopResult.getUses().begin());
-      Operation *loopUser = loopUse.getOwner();
+      auto oldAccum = initOperand->get();
       // get old loop yield
       auto oldYield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
       // create newAccum initialization
@@ -368,8 +366,8 @@ class TritonGPUOptimizeThreadLocalityPass
       // incorporate the original accumulator value into the final result
       auto finalOp = incorporateOriginalAccumulatorValue(builder, oldUpdate,
                                                          cvtLayout, oldAccum);
-      // Replace the old loop user with the final result
-      loopUser->setOperand(loopUse.getOperandNumber(), finalOp->getResult(0));
+      // Replace all uses of the old loop result with the final result.
+      newLoop.getResult(resultIndex).replaceAllUsesWith(finalOp->getResult(0));
 
       // cleanup
       oldYield.erase();

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -884,3 +884,35 @@ tt.func @skip_optimize_on_1d_tensor(%arg0: tensor<256xf32, #blocked>, %arg1: ten
 }
 
 }
+
+// -----
+
+// CHECK-LABEL: tt.func @loop_result_multiple_uses(
+// CHECK: %[[FINAL_RESULT:.+]] = arith.addf {{.*}} : tensor<1xf32,
+// CHECK: arith.addf %[[FINAL_RESULT]], %[[FINAL_RESULT]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#slice = #ttg.slice<{dim = 1, parent = #blocked}>
+module attributes {"ttg.num-warps" = 1 : i32} {
+  tt.func @loop_result_multiple_uses(
+      %input: tensor<1x64x!tt.ptr<f32>, #blocked>,
+      %output: tensor<1x!tt.ptr<f32>, #slice>, %count: i32) {
+    %zero = arith.constant dense<0.0> : tensor<1xf32, #slice>
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %result = scf.for %i = %c0 to %count step %c1
+        iter_args(%acc = %zero) -> (tensor<1xf32, #slice>) : i32 {
+      %values = tt.load %input : tensor<1x64x!tt.ptr<f32>, #blocked>
+      %sum = "tt.reduce"(%values) <{axis = 1 : i32}> ({
+      ^bb0(%lhs: f32, %rhs: f32):
+        %add = arith.addf %lhs, %rhs : f32
+        tt.reduce.return %add : f32
+      }) : (tensor<1x64xf32, #blocked>) -> tensor<1xf32, #slice>
+      %next = arith.addf %acc, %sum : tensor<1xf32, #slice>
+      scf.yield %next : tensor<1xf32, #slice>
+    }
+    %twice = arith.addf %result, %result : tensor<1xf32, #slice>
+    tt.store %output, %twice : tensor<1x!tt.ptr<f32>, #slice>
+    tt.return
+  }
+}


### PR DESCRIPTION
The thread-local reduction rewrite assumed the corresponding scf.for result had one use. This will crash valid kernels that reused it in a build with assert, and will lead to a miscompile without asserts:
```
lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp:342: virtual void
  mlir::triton::gpu::(anonymous namespace)::TritonGPUOptimizeThreadLocalityPass::runOnOperation(): 
  Assertion `loopResult.hasOneUse()' failed.
```

For example, we trigger this when `scf`.for produces `result` that is used as both operands in and add operation like so:

```
    %result = scf.for ... iter_args(%acc = %zero)
    ..
    %twice = arith.addf %result, %result
```

This can very easily be triggered from source code with an almost identical pattern.

The rewrite is checking that different values inside the loop have one use, but it forget to check that loopResult.hasOneUse() and thus misses that it can have multiple SSA uses, which all need to be replaced.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
