### PR TITLE
[Triton] Don't fold a multi-result reduce in CombineBroadcastMulReducePattern

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -143,11 +143,7 @@ public:
     if (reduceOp.getAxis() != 1)
       return failure();
     // only support reduce with simple addition
-    Region &combineOp = reduceOp.getCombineOp();
-    bool isReduceAdd = combineOp.hasOneBlock() &&
-                       combineOp.front().getOperations().size() == 2 &&
-                       isAddF32(&*combineOp.front().getOperations().begin());
-    if (!isReduceAdd)
+    if (!isAddF32(reduceOp.getSingleCombiner()))
       return failure();
     // operand of reduce has to be mul
     auto mulOp = reduceOp.getOperand(0).getDefiningOp<arith::MulFOp>();

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -568,3 +568,20 @@ tt.func @test_combine_broadcast_mul_reduce_higher_rank(%arg0: tensor<32x16x4xf32
     }) : (tensor<32x16x32x4xf32>) -> tensor<32x32x4xf32>
     tt.return %5 : tensor<32x32x4xf32>
 }
+
+// CHECK-LABEL: @test_combine_broadcast_mul_reduce_multiple_results
+tt.func @test_combine_broadcast_mul_reduce_multiple_results(%arg0: tensor<32x16xf32>, %arg1: tensor<16x32xf32>) -> tensor<32x32xf32> {
+    // CHECK-NOT: tt.dot
+    // CHECK: tt.reduce
+    %0 = tt.expand_dims %arg0 {axis = 2 : i32} : tensor<32x16xf32> -> tensor<32x16x1xf32>
+    %1 = tt.broadcast %0 : tensor<32x16x1xf32> -> tensor<32x16x32xf32>
+    %2 = tt.expand_dims %arg1 {axis = 0 : i32} : tensor<16x32xf32> -> tensor<1x16x32xf32>
+    %3 = tt.broadcast %2 : tensor<1x16x32xf32> -> tensor<32x16x32xf32>
+    %4 = arith.mulf %1, %3 : tensor<32x16x32xf32>
+    %5:2 = "tt.reduce"(%4, %4) <{axis = 1 : i32}> ({
+    ^bb0(%a0: f32, %a1: f32, %b0: f32, %b1: f32):
+        %6 = arith.addf %a0, %b0 : f32
+        tt.reduce.return %6, %6 : f32, f32
+    }) : (tensor<32x16x32xf32>, tensor<32x16x32xf32>) -> (tensor<32x32xf32>, tensor<32x32xf32>)
+    tt.return %5#0 : tensor<32x32xf32>
+}


### PR DESCRIPTION
Fixes #11662.

`tl.reduce` with more than one result crashes in `TritonCombineOps`.

`CombineBroadcastMulReducePattern` folds `sum(x[:, :, None] * y[None, :, :], 1)` into `dot(x, y)`. It never checks how many results the reduce has, so a multi-result reduce reached `replaceOpWithNewOp<DotOp>`:

```
PatternMatch.cpp:144: RewriterBase::replaceOp:
Assertion `op->getNumResults() == newOp->getNumResults()' failed.
```

To check the reduce, added `ReduceOp::getSingleCombiner()`.

### Tests

`test_combine_broadcast_mul_reduce_multiple_results` in `test/Triton/combine.mlir`, which hits the assert without this change. Full `lit` suite: 299 passed, 2 unsupported, 0 failed.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
