### PR TITLE
[Gluon] Run test_noinline_call_preserves_live_shared_allocation on AMD

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -313,9 +313,9 @@ def test_copy_kernel(layout, XBLOCK):
 
 
 @gluon.jit(noinline=True)
-def _noinline_convert_layout_scratch(input, output):
-    src_layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
-    dst_layout: ttgl.constexpr = ttgl.SliceLayout(1, ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0]))
+def _noinline_convert_layout_scratch(input, output, THREADS_PER_WARP: ttgl.constexpr):
+    src_layout: ttgl.constexpr = ttgl.BlockedLayout([1], [THREADS_PER_WARP], [4], [0])
+    dst_layout: ttgl.constexpr = ttgl.SliceLayout(1, ttgl.BlockedLayout([1, 1], [1, THREADS_PER_WARP], [1, 4], [1, 0]))
     src_offsets = ttgl.arange(0, 128, layout=src_layout)
     dst_offsets = ttgl.arange(0, 128, layout=dst_layout)
     values = ttgl.load(input + src_offsets)
@@ -323,27 +323,28 @@ def _noinline_convert_layout_scratch(input, output):
 
 
 @gluon.jit(noinline=True)
-def _noinline_forward_convert_layout_scratch(input, output):
-    _noinline_convert_layout_scratch(input, output)
+def _noinline_forward_convert_layout_scratch(input, output, THREADS_PER_WARP: ttgl.constexpr):
+    _noinline_convert_layout_scratch(input, output, THREADS_PER_WARP)
 
 
 @gluon.jit
-def _noinline_shared_allocation_call_kernel(input, output, sentinel_output, NESTED: ttgl.constexpr):
-    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+def _noinline_shared_allocation_call_kernel(input, output, sentinel_output, NESTED: ttgl.constexpr,
+                                            THREADS_PER_WARP: ttgl.constexpr):
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1], [THREADS_PER_WARP], [4], [0])
     shared_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [0])
     offsets = ttgl.arange(0, 128, layout=layout)
     sentinel = offsets + 4096
     caller_allocation = ttgl.allocate_shared_memory(ttgl.int32, [128], shared_layout, sentinel)
 
     if NESTED:
-        _noinline_forward_convert_layout_scratch(input, output)
+        _noinline_forward_convert_layout_scratch(input, output, THREADS_PER_WARP)
     else:
-        _noinline_convert_layout_scratch(input, output)
+        _noinline_convert_layout_scratch(input, output, THREADS_PER_WARP)
 
     ttgl.store(sentinel_output + offsets, caller_allocation.load(layout))
 
 
-@pytest.mark.skipif(not is_ampere_or_newer(), reason="Requires Ampere or newer")
+@pytest.mark.skipif(not (is_ampere_or_newer() or is_hip()), reason="Requires Ampere or newer, or AMD")
 @pytest.mark.parametrize("NESTED", [False, True], ids=["direct", "nested"])
 def test_noinline_call_preserves_live_shared_allocation(NESTED, fresh_knobs):
     fresh_knobs.compilation.instrumentation_mode = ""
@@ -351,7 +352,8 @@ def test_noinline_call_preserves_live_shared_allocation(NESTED, fresh_knobs):
     output = torch.empty_like(values)
     sentinel_output = torch.empty_like(values)
 
-    compiled = _noinline_shared_allocation_call_kernel[(1, )](values, output, sentinel_output, NESTED, num_warps=4)
+    compiled = _noinline_shared_allocation_call_kernel[(1, )](values, output, sentinel_output, NESTED, THREADS_PER_WARP,
+                                                              num_warps=4)
 
     assert compiled.metadata.shared >= 2 * values.numel() * values.element_size()
     assert compiled.asm["ttgir"].count("noinline = true") >= 1 + int(NESTED)


### PR DESCRIPTION
`test_noinline_call_preserves_live_shared_allocation` is gated on `is_ampere_or_newer()`, but nothing in it is NVIDIA specific. The gate is there because the layouts hardcode `threads_per_warp = 32`, which is wrong on CDNA.

Pass `THREADS_PER_WARP` in as a constexpr, the way the rest of the file already builds layouts. Thus the test can run on HIP too.

Also AMD has no equivalent coverage. `noinline` does not appear anywhere under `third_party/amd/python/test`, so nothing was checking that a noinline call preserves a live shared allocation there.

### Tests

Both kernels build for `gfx942` with the same shared size (1024) and `noinline` count as on CUDA. Generated code on CUDA is unchanged apart from the mangled callee name and line numbers. I have no AMD hardware, so the numerics are for CI to confirm.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
