### PR TITLE
[TritonGPU] Avoid wide weak byte-load layouts on SM80

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/CoalesceUtils.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CoalesceUtils.cpp
@@ -13,6 +13,24 @@
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::triton::gpu {
+
+static bool isSm80FourWarpScalarByteLoad(Operation *op, int numWarps,
+                                         RankedTensorType tensorType,
+                                         ArrayRef<int64_t> contiguity) {
+  if (!isa<triton::LoadOp>(op) || numWarps != 4 || tensorType.getRank() != 2 ||
+      getElementBitWidth(tensorType) != 8 ||
+      !llvm::all_of(contiguity, [](int64_t value) { return value == 1; }))
+    return false;
+
+  auto moduleOp = op->getParentOfType<ModuleOp>();
+  auto targetAttr =
+      moduleOp
+          ? moduleOp->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName)
+          : nullptr;
+  return targetAttr && targetAttr.getValue().starts_with("cuda:") &&
+         getNVIDIAComputeCapability(moduleOp) == 80;
+}
+
 BlockedEncodingAttr
 buildCoalescedEncoding(ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op,
                        int numWarps, int threadsPerWarp,
@@ -30,19 +48,40 @@ buildCoalescedEncoding(ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op,
 
   auto contiguity = axisInfoAnalysis.getAxisInfo(ptr)->getContiguity();
   SmallVector<unsigned> order = getOrderFromContiguity(contiguity);
-  LDBG("order=[" << triton::join(order, ", ") << "]");
 
   auto matchesShape = [&refTensorType](const Value &val) {
     auto rttType = dyn_cast<RankedTensorType>(val.getType());
     return rttType && rttType.getShape() == refTensorType.getShape();
   };
+  llvm::SetVector<Operation *> slice;
+  if (ptr.getDefiningOp())
+    slice = mlir::getSlice(op);
+
+  if (isSm80FourWarpScalarByteLoad(op, numWarps, refTensorType, contiguity)) {
+    // All-one i8 roots can inherit sizePerThread=16 from a coalesced peer
+    // because their default orders tie. On SM80 with four warps this spills;
+    // use the alternate order to keep the weak root scalar.
+    bool borrowsWideLayout = llvm::any_of(slice, [&](Operation *use) {
+      Value val = getMemAccessPtr(use);
+      if (!val || use == op || !matchesShape(val))
+        return false;
+      auto currOrder = getOrderFromContiguity(
+          axisInfoAnalysis.getAxisInfo(val)->getContiguity());
+      return order == currOrder &&
+             getNumElementsPerThread(use, order, axisInfoAnalysis,
+                                     shapePerCTA) >= 16;
+    });
+    if (borrowsWideLayout)
+      order = {0, 1};
+  }
+  LDBG("order=[" << triton::join(order, ", ") << "]");
 
   // The desired divisibility is the maximum divisibility among all dependent
   // pointers which have the same shape and order as `ptr`.
   llvm::SmallSetVector<Operation *, 32> memAccessesSameOrder;
   memAccessesSameOrder.insert(op);
   if (ptr.getDefiningOp()) {
-    for (Operation *use : mlir::getSlice(op)) {
+    for (Operation *use : slice) {
       Value val = getMemAccessPtr(use);
       if (!val || !matchesShape(val) || memAccessesSameOrder.contains(use))
         continue;

--- a/test/TritonGPU/coalesce.mlir
+++ b/test/TritonGPU/coalesce.mlir
@@ -299,6 +299,72 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:80", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: #[[$WEAK_LAYOUT:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+  // CHECK: #[[$WIDE_LAYOUT:.*]] = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+  // CHECK-LABEL: @uncoalesced_byte_load_sm80_w4
+  // CHECK: tt.load {{.*}} : tensor<32x512x!tt.ptr<i8>, #[[$WEAK_LAYOUT]]>
+  // CHECK: tt.load {{.*}} : tensor<32x512x!tt.ptr<i8>, #[[$WIDE_LAYOUT]]>
+  tt.func public @uncoalesced_byte_load_sm80_w4(
+      %weak: tensor<32x512x!tt.ptr<i8>, #blocked> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[1, 1]> : tensor<2xi32>},
+      %wide: tensor<32x512x!tt.ptr<i8>, #blocked> {tt.contiguity = dense<[1, 512]> : tensor<2xi32>, tt.divisibility = dense<[1, 16]> : tensor<2xi32>}) -> tensor<32x512xi8, #blocked> {
+    %zero = arith.constant dense<0> : tensor<32x512xi32, #blocked>
+    %weak_ptr = tt.addptr %weak, %zero : tensor<32x512x!tt.ptr<i8>, #blocked>, tensor<32x512xi32, #blocked>
+    %wide_ptr = tt.addptr %wide, %zero : tensor<32x512x!tt.ptr<i8>, #blocked>, tensor<32x512xi32, #blocked>
+    %weak_value = tt.load %weak_ptr : tensor<32x512x!tt.ptr<i8>, #blocked>
+    %wide_value = tt.load %wide_ptr : tensor<32x512x!tt.ptr<i8>, #blocked>
+    %sum = arith.addi %weak_value, %wide_value : tensor<32x512xi8, #blocked>
+    tt.return %sum : tensor<32x512xi8, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:80", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: order = [0, 1]
+  // CHECK: #[[$W8_LAYOUT:.*]] = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+  // CHECK-LABEL: @uncoalesced_byte_load_sm80_w8
+  // CHECK: tt.load {{.*}} : tensor<32x512x!tt.ptr<i8>, #[[$W8_LAYOUT]]>
+  // CHECK: tt.load {{.*}} : tensor<32x512x!tt.ptr<i8>, #[[$W8_LAYOUT]]>
+  tt.func public @uncoalesced_byte_load_sm80_w8(
+      %weak: tensor<32x512x!tt.ptr<i8>, #blocked> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[1, 1]> : tensor<2xi32>},
+      %wide: tensor<32x512x!tt.ptr<i8>, #blocked> {tt.contiguity = dense<[1, 512]> : tensor<2xi32>, tt.divisibility = dense<[1, 16]> : tensor<2xi32>}) -> tensor<32x512xi8, #blocked> {
+    %zero = arith.constant dense<0> : tensor<32x512xi32, #blocked>
+    %weak_ptr = tt.addptr %weak, %zero : tensor<32x512x!tt.ptr<i8>, #blocked>, tensor<32x512xi32, #blocked>
+    %wide_ptr = tt.addptr %wide, %zero : tensor<32x512x!tt.ptr<i8>, #blocked>, tensor<32x512xi32, #blocked>
+    %weak_value = tt.load %weak_ptr : tensor<32x512x!tt.ptr<i8>, #blocked>
+    %wide_value = tt.load %wide_ptr : tensor<32x512x!tt.ptr<i8>, #blocked>
+    %sum = arith.addi %weak_value, %wide_value : tensor<32x512xi8, #blocked>
+    tt.return %sum : tensor<32x512xi8, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: order = [0, 1]
+  // CHECK: #[[$SM90_LAYOUT:.*]] = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+  // CHECK-LABEL: @uncoalesced_byte_load_sm90
+  // CHECK: tt.load {{.*}} : tensor<32x512x!tt.ptr<i8>, #[[$SM90_LAYOUT]]>
+  // CHECK: tt.load {{.*}} : tensor<32x512x!tt.ptr<i8>, #[[$SM90_LAYOUT]]>
+  tt.func public @uncoalesced_byte_load_sm90(
+      %weak: tensor<32x512x!tt.ptr<i8>, #blocked> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[1, 1]> : tensor<2xi32>},
+      %wide: tensor<32x512x!tt.ptr<i8>, #blocked> {tt.contiguity = dense<[1, 512]> : tensor<2xi32>, tt.divisibility = dense<[1, 16]> : tensor<2xi32>}) -> tensor<32x512xi8, #blocked> {
+    %zero = arith.constant dense<0> : tensor<32x512xi32, #blocked>
+    %weak_ptr = tt.addptr %weak, %zero : tensor<32x512x!tt.ptr<i8>, #blocked>, tensor<32x512xi32, #blocked>
+    %wide_ptr = tt.addptr %wide, %zero : tensor<32x512x!tt.ptr<i8>, #blocked>, tensor<32x512xi32, #blocked>
+    %weak_value = tt.load %weak_ptr : tensor<32x512x!tt.ptr<i8>, #blocked>
+    %wide_value = tt.load %wide_ptr : tensor<32x512x!tt.ptr<i8>, #blocked>
+    %sum = arith.addi %weak_value, %wide_value : tensor<32x512xi8, #blocked>
+    tt.return %sum : tensor<32x512xi8, #blocked>
+  }
+}
+
+// -----
+
 // CHECK: #[[$LAYOUT:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {


### PR DESCRIPTION
## Why

On SM80, a rank-2 i8 load with all-one contiguity can be grouped with a wider dependent load because both roots tie to the same default order. The weak root then inherits `sizePerThread=16` even though it cannot issue a 128-bit vector load. In the four-warp reproducer from #11373, this creates heavy register spilling.

This gives that weak root the alternate tied order only when all of the following hold: SM80, four warps, rank-2 i8 load, all-one contiguity, and a same-shape dependent memory access that actually supports at least 16 elements per thread. Eight-warp and non-SM80 layouts keep the existing behavior.

Addresses #11373.

## Result

A100-SXM4-80GB, fixed input, 10 groups × 20 calls:

| Metric | main | patch |
|---|---:|---:|
| w4 median | 6.48 ms | 2.46 ms |
| w8 median | 1.98 ms | 1.98 ms |
| w4 stack/thread | 3136 B | 496 B |
| w4 SASS LDL/STL | 1728/1710 | 248/244 |
| w4 NCU local read/write | 4.87/4.57 GB | 701/647 MB |

The fixed-seed output SHA256 is identical across main, patch, w4, and w8. The output is finite and matches the PyTorch reference at `atol=rtol=2e-2` (`max_abs=0.0625`, `mean_abs=2.27e-4`). A nearby byte-gather that does not meet the wide-peer condition produces identical SASS before and after this change.

## Testing

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- Triton lit suite: 299 passed, 2 unsupported
- A100 fixed-seed correctness and A-B-B-A timing
- Nsight Compute local-memory metrics and static cubin inspection

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
