### PR TITLE
[MEMBAR] Refine TMA and mbarrier synchronization

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -22,9 +22,9 @@ struct AllocationSlice;
 /// Callback to allow backend to provide more information on whether a barrier
 /// is needed between two operations. Even though two operations access the same
 /// shared memory they may not require a barrier in between them.
-using MembarFilterFn =
-    std::function<bool(Operation *, Operation *, bool /*lhsIsRead*/,
-                       bool /*rhsIsRead*/, Allocation *)>;
+using MembarFilterFn = std::function<bool(
+    Operation *, Operation *, bool /*lhsIsRead*/, bool /*rhsIsRead*/,
+    Allocation *, const AllocationSlice &, const AllocationSlice &)>;
 
 /// Slice-level filter to allow backends to ignore specific aliasing cases.
 using MembarSliceFilterFn =
@@ -80,6 +80,10 @@ public:
   // The owning BufferRegionAnalysis outlives every slice using this pointer.
   const triton::BufferRegionFootprint *physicalFootprint = nullptr;
 
+  // Effect classification is preserved when geometry is widened or translated.
+  // Unknown for implicit scratch and non-shared accesses.
+  std::optional<triton::gpu::SharedKind> sharedKind;
+
   // Buffer-index expression attached by BufferIndexAnalysis. It participates
   // in ordering/equality so accesses to different slots remain separate.
   // Must not be mutated after the slice is inserted into a sorted container
@@ -94,7 +98,8 @@ public:
 private:
   std::tuple<Interval<size_t>, Allocation::BufferId, const void *,
              llvm::ArrayRef<int32_t>, const BufferIndexExpr *, const void *,
-             const void *, std::optional<unsigned>>
+             const void *, std::optional<unsigned>,
+             std::optional<triton::gpu::SharedKind>>
   asTuple() const {
     return {allocationInterval,
             bufferId,
@@ -103,7 +108,8 @@ private:
             bufferIndexExpr,
             subsliceSource.getAsOpaquePointer(),
             physicalFootprint,
-            argumentIndex};
+            argumentIndex,
+            sharedKind};
   }
   // Offsets from subslice, borrowed from its immutable context-owned attribute.
   // Empty when offsets are unknown.
@@ -244,8 +250,8 @@ struct BlockInfo {
                                            rhsIsRead, allocation))
             for (auto lhsOp : lhs.second)
               for (auto rhsOp : rhs.second)
-                if (!filter ||
-                    !filter(lhsOp, rhsOp, lhsIsRead, rhsIsRead, allocation))
+                if (!filter || !filter(lhsOp, rhsOp, lhsIsRead, rhsIsRead,
+                                       allocation, lhs.first, rhs.first))
                   return true;
     return false;
   }
@@ -386,7 +392,9 @@ protected:
   triton::BufferRegionAnalysis &regions;
 
 private:
-  SmallVector<AllocationSlice> getAllocationSlices(Value value);
+  SmallVector<AllocationSlice>
+  getAllocationSlices(Value value,
+                      std::optional<triton::gpu::SharedKind> sharedKind);
 
   MembarSliceFilterFn sliceFilter;
   AccessMode accessMode;

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -337,14 +337,16 @@ Operation *MembarAnalysis::syncIfNeeded(Operation *op, const BlockInfo &effects,
     return nullptr;
   auto &pending = membarInfo->pending;
   auto canSkip = [&](Operation *before, Operation *after, bool beforeIsRead,
-                     bool afterIsRead, Allocation *allocation) {
+                     bool afterIsRead, Allocation *allocation,
+                     const AllocationSlice &beforeSlice,
+                     const AllocationSlice &afterSlice) {
     // Effects issued by the same thread are ordered with respect to each other.
     // A fixed thread-zero issuer and an elected warp-zero leader may differ.
     return (pending.threadEffects.count(before) &&
             effects.threadEffects.count(after) &&
             haveSameThreadSyncIssuer(before, after)) ||
-           (filter &&
-            filter(before, after, beforeIsRead, afterIsRead, allocation));
+           (filter && filter(before, after, beforeIsRead, afterIsRead,
+                             allocation, beforeSlice, afterSlice));
   };
   if (!requiresThreadSync(pending, effects) &&
       !pending.isIntersected(effects, canSkip, &allocation, sliceFilter))
@@ -513,7 +515,8 @@ void MembarAnalysis::update(Operation *op, MembarInfo *membarInfo,
                       std::move(effects));
 }
 
-SmallVector<AllocationSlice> MembarAnalysis::getAllocationSlices(Value value) {
+SmallVector<AllocationSlice> MembarAnalysis::getAllocationSlices(
+    Value value, std::optional<triton::gpu::SharedKind> sharedKind) {
   auto function = cast<FunctionOpInterface>(allocation.getOperation());
   // Device-function views use their own frame until imported at a call;
   // foreign or mixed frames, including returned descriptors, stay unknown.
@@ -523,6 +526,7 @@ SmallVector<AllocationSlice> MembarAnalysis::getAllocationSlices(Value value) {
                       Allocation::BufferId bufferId) {
     auto slice = bufferIndexAnalysis.makeSlice(value, interval, bufferId);
     slice.physicalFootprint = footprint;
+    slice.sharedKind = sharedKind;
     slices.push_back(std::move(slice));
   };
   Allocation::BufferIdSetT bufferIds;
@@ -533,6 +537,7 @@ SmallVector<AllocationSlice> MembarAnalysis::getAllocationSlices(Value value) {
     for (unsigned argument : allocation.getAliasedArgumentIndices(value)) {
       AllocationSlice slice(Interval<size_t>{});
       slice.argumentIndex = argument;
+      slice.sharedKind = sharedKind;
       slices.push_back(std::move(slice));
     }
   } else if (footprint) {
@@ -575,7 +580,7 @@ void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
               return SmallVector<AllocationSlice>{
                   slice.translateToCallsite(call, callee, regions)};
             Value actual = call.getArgOperands()[*slice.argumentIndex];
-            auto slices = getAllocationSlices(actual);
+            auto slices = getAllocationSlices(actual, slice.sharedKind);
             // A callee can reinterpret the argument's view. Retain the caller's
             // allocation IDs, but cover each whole allocation without shifting.
             for (AllocationSlice &bound : slices) {
@@ -600,7 +605,8 @@ void MembarAnalysis::updateMemoryEffects(Operation *op, MembarInfo *membarInfo,
       continue;
     // Shared effects cover only descriptor elements, including gather/scatter
     // and async copies. Footprints retain padding, partitions and CTA identity.
-    for (const AllocationSlice &slice : getAllocationSlices(value)) {
+    for (const AllocationSlice &slice :
+         getAllocationSlices(value, access.sharedKind)) {
       if (access.isWrite)
         curBlockInfo.syncWriteSlices[slice].insert(op);
       if (access.isRead)

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -315,7 +315,9 @@ void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
     return;
 
   MembarFilterFn filterFn = [](Operation *lhs, Operation *rhs, bool lhsIsRead,
-                               bool rhsIsRead, Allocation * /*allocation*/) {
+                               bool rhsIsRead, Allocation * /*allocation*/,
+                               const AllocationSlice &,
+                               const AllocationSlice &) {
     // Filter ops that do not touch distributed shared memory. Whether the
     // aliasing was already present in TTGIR is handled per-allocation slice.
     bool lhsDist = isDistributedMultiCTAOp(lhs, lhsIsRead);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -403,7 +403,8 @@ static LogicalResult runTMemAnalysis(ModuleOp mod) {
     return failure();
   TMemWarpOwnership ownership(*regions);
   auto filter = [&](Operation *lhs, Operation *rhs, bool /*lhsIsRead*/,
-                    bool /*rhsIsRead*/, Allocation *allocation) {
+                    bool /*rhsIsRead*/, Allocation *allocation,
+                    const AllocationSlice &, const AllocationSlice &) {
     // A completion wait orders same-warp RAW, WAR, and WAW dependencies.
     return ownership.isSameWarp(lhs, rhs, allocation);
   };

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1110,9 +1110,12 @@ def async_copy_mbarrier_kernel(out, inp, xnumel, XBLOCK: ttgl.constexpr, YBLOCK:
     )
     mbar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
     mbarrier.init(mbar, count=1)
-    async_copy.mbarrier_arrive(mbar)
     mbarrier.arrive(mbar)
     mbarrier.wait(mbar, 0)
+    async_copy.mbarrier_arrive(mbar)
+    mbarrier.wait(mbar, 0)
+    mbarrier.arrive(mbar)
+    mbarrier.wait(mbar, 1)
 
     val = smem.load(block_layout)
     ttgl.store(out + xindex * YBLOCK + yindex, val)
@@ -1219,6 +1222,74 @@ def test_mbarrier_tma_progress(device):
     assert re.search(r"\bbar(?:rier)?\.sync\b", ptx[wait:copy])
     kernel[(1, )](desc, num_warps=4)
     torch.cuda.synchronize(device)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
+@pytest.mark.parametrize("expect_before_copy", [True, False])
+@pytest.mark.parametrize("synchronize_expect", [True, False])
+def test_mbarrier_multiple_tma_expectations(device, expect_before_copy, synchronize_expect):
+
+    @gluon.jit
+    def kernel(desc, out, iterations, EXPECT_BEFORE_COPY: ttgl.constexpr, SYNCHRONIZE_EXPECT: ttgl.constexpr):
+        a = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
+        b = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=2)
+        for i in range(iterations):
+            if EXPECT_BEFORE_COPY:
+                if SYNCHRONIZE_EXPECT:
+                    ttgl.barrier()
+                mbarrier.expect(bar, desc.nbytes_per_cta)
+            tma.async_load(desc, [32 * i, 0], bar, a)
+            if not EXPECT_BEFORE_COPY:
+                if SYNCHRONIZE_EXPECT:
+                    ttgl.barrier()
+                mbarrier.expect(bar, desc.nbytes_per_cta)
+            if EXPECT_BEFORE_COPY:
+                if SYNCHRONIZE_EXPECT:
+                    ttgl.barrier()
+                mbarrier.expect(bar, desc.nbytes_per_cta)
+            tma.async_load(desc, [32 * i + 16, 0], bar, b)
+            if not EXPECT_BEFORE_COPY:
+                if SYNCHRONIZE_EXPECT:
+                    ttgl.barrier()
+                mbarrier.expect(bar, desc.nbytes_per_cta)
+            mbarrier.wait(bar, i & 1, deps=[a, b])
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 4], [4, 8], [4, 1], [1, 0])
+        rows = ttgl.arange(0, 16, ttgl.SliceLayout(1, layout))[:, None]
+        cols = ttgl.arange(0, 64, ttgl.SliceLayout(0, layout))[None, :]
+        ttgl.store(out + rows * 64 + cols, a.load(layout))
+        ttgl.store(out + (rows + 16) * 64 + cols, b.load(layout))
+        mbarrier.invalidate(bar)
+
+    iterations = 64
+    inp = torch.arange(iterations * 32 * 64, dtype=torch.float32, device=device).reshape(-1, 64)
+    out = torch.empty((32, 64), dtype=inp.dtype, device=device)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=32, rank=2)
+    desc = TensorDescriptor.from_tensor(inp, [16, 64], shared_layout)
+    compiled = kernel.warmup(desc, out, iterations, expect_before_copy, synchronize_expect, grid=(1, ), num_warps=4)
+    ptx = compiled.asm["ptx"]
+    # Check the physical counts before launch so a mismatch fails without hanging.
+    initial_count = "2" if synchronize_expect else "8"
+    assert re.findall(r"mbarrier\.init\.shared::cta\.b64\s+\[[^\]]+\],\s*(\d+)", ptx) == [initial_count]
+    expectations = list(re.finditer(r"mbarrier\.arrive\.expect_tx\.shared::cta\.b64\s+_,\s*\[[^\]]+\],\s*(\d+)", ptx))
+    byte_counts = [expect.group(1) for expect in expectations]
+    # Membar already synchronizes the first expectation when it precedes copies.
+    assert byte_counts == [
+        "4096" if synchronize_expect or expect_before_copy else "1024",
+        "4096" if synchronize_expect else "1024",
+    ]
+    arrival_counts = re.findall(r"mbarrier\.arrive\.shared::cta\.b64\s+_,\s*\[[^\]]+\],\s*(\d+)", ptx)
+    assert arrival_counts == ([] if synchronize_expect else ["3"] * byte_counts.count("4096"))
+    # Folding must not add a CTA barrier before the next copy or wait.
+    for expect in expectations:
+        if expect.group(1) == "4096":
+            following = ptx[expect.end():]
+            next_op = re.search(r"cp\.async\.bulk\.tensor\.|mbarrier\.try_wait\.", following)
+            assert next_op is not None
+            assert not re.search(r"\bbar(?:rier)?\.sync\b", following[:next_op.start()])
+    kernel[(1, )](desc, out, iterations, expect_before_copy, synchronize_expect, num_warps=4)
+    torch.testing.assert_close(out, inp[-32:])
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
@@ -1387,11 +1458,47 @@ def test_mbarrier_automatic_warp_arrivals(producer_warps, num_ctas):
     assert Counter(expected_inits) <= Counter(map(int, init_counts))
     arrive_counts = re.findall(r"mbarrier\.arrive\.shared::(?:cta|cluster)\.b64\s+_,\s*\[[^\]]+\](?:,\s*(\d+))?;", ptx)
     # The launch rendezvous covers the first bootstrap arrival's full count.
-    expected_arrivals = [scale, scale // producer_warps, 1, scale // 4]
-    assert Counter(expected_arrivals) <= Counter(int(count or 1) for count in arrive_counts)
+    # A CTA barrier before the consumer's arrival can also fold its full count.
+    expected_arrivals = [scale, scale // producer_warps, 1]
+    actual_arrivals = Counter(int(count or 1) for count in arrive_counts)
+    assert any(Counter(expected_arrivals + [count]) <= actual_arrivals for count in (scale // 4, scale))
     assert "bar.warp.sync" in ptx
     kernel[(8, )](inp, out, iterations, block, producer_warps, num_warps=4, num_ctas=num_ctas)
     torch.testing.assert_close(out, inp + 1)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
+def test_mbarrier_wait_before_distributed_arrival():
+
+    @gluon.jit
+    def kernel(inp, out, iterations, BLOCK: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+        offsets = ttgl.arange(0, BLOCK, layout=layout)
+        pid = ttgl.program_id(0)
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+        mbarrier.arrive(bar)
+        total = ttgl.full([BLOCK], 0, ttgl.int32, layout)
+        for i in range(iterations):
+            # Retire earlier arrivals before testing the wait-to-arrive edge.
+            ttgl.barrier()
+            mbarrier.wait(bar, phase=i & 1)
+            total += ttgl.load(inp + (pid * iterations + i) * BLOCK + offsets)
+            mbarrier.arrive(bar)
+        mbarrier.wait(bar, phase=iterations & 1)
+        mbarrier.invalidate(bar)
+        ttgl.store(out + pid * BLOCK + offsets, total)
+
+    blocks, iterations, block = 16, 128, 128
+    inp = torch.arange(blocks * iterations * block, device="cuda", dtype=torch.int32)
+    out = torch.empty((blocks, block), device="cuda", dtype=torch.int32)
+    compiled = kernel.warmup(inp, out, iterations, block, grid=(blocks, ), num_warps=4)
+    arrive_counts = re.findall(r"mbarrier\.arrive\.shared::cta\.b64\s+_,\s*\[[^\]]+\](?:,\s*(\d+))?;",
+                               compiled.asm["ptx"])
+    # The bootstrap arrives for the CTA; each loop arrival counts one warp.
+    assert {int(count or 1) for count in arrive_counts} == {4, 1}
+    kernel[(blocks, )](inp, out, iterations, block, num_warps=4)
+    torch.testing.assert_close(out, inp.reshape(blocks, iterations, block).sum(dim=1, dtype=torch.int32))
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")

--- a/test/Analysis/test-membar-ttng.mlir
+++ b/test/Analysis/test-membar-ttng.mlir
@@ -79,6 +79,9 @@ tt.func @warpgroup_wait_before_barrier_invalidation(%acc: tensor<256xf32, #block
 // -----
 
 #barrier_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#load = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#tma_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
@@ -122,20 +125,87 @@ tt.func @arrive_then_wait_barrier() {
   tt.return
 }
 
+// A wait does not publish unrelated shared writes.
+// CHECK-LABEL: @waits_preserve_shared_writes
+tt.func @waits_preserve_shared_writes(%data: tensor<128xi32, #blocked>) -> tensor<128xi32, #load> {
+  %c0 = arith.constant 0 : i32
+  %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.arrive_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  // CHECK: ttg.local_alloc %{{.*}}
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttg.local_load
+  %mem = ttg.local_alloc %data : (tensor<128xi32, #blocked>) -> !ttg.memdesc<128xi32, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  %result = ttg.local_load %mem : !ttg.memdesc<128xi32, #barrier_shared, #smem, mutable> -> tensor<128xi32, #load>
+  ttng.inval_barrier %barrier : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return %result : tensor<128xi32, #load>
+}
+
+// CHECK-LABEL: @clc_then_wait
+tt.func @clc_then_wait(%desc: !tt.tensordesc<16x64xf16, #tma_shared>) -> i128 {
+  %c0 = arith.constant 0 : i32
+  %true = arith.constant true
+  %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  %response = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrier_shared, #smem, mutable>
+  %payload = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #tma_shared, #smem, mutable>
+  ttng.init_barrier %barrier, 2 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.barrier_expect %barrier, 2064, %true : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  // CHECK: ttng.tc_gen5_commit
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  // CHECK-NEXT: ttng.clc_try_cancel
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: {{.*}}ttng.clc_load_result
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.inval_barrier
+  ttng.tc_gen5_commit %barrier : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %payload, %barrier, %true : !tt.tensordesc<16x64xf16, #tma_shared>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !ttg.memdesc<16x64xf16, #tma_shared, #smem, mutable>
+  ttng.clc_try_cancel %response, %barrier : !ttg.memdesc<2xi64, #barrier_shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %barrier, %c0 deps %response, %payload : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>, !ttg.memdesc<2xi64, #barrier_shared, #smem, mutable>, !ttg.memdesc<16x64xf16, #tma_shared, #smem, mutable>
+  %result = ttng.clc_load_result %response : !ttg.memdesc<2xi64, #barrier_shared, #smem, mutable> -> i128
+  ttng.inval_barrier %barrier : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return %result : i128
+}
+
 // CHECK-LABEL: @async_copy_arrive_then_wait_barrier
 tt.func @async_copy_arrive_then_wait_barrier() {
   %phase = arith.constant 0 : i32
+  %true = arith.constant true
   %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   // CHECK: ttng.init_barrier
   // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.barrier_expect
   // CHECK-NEXT: ttng.async_copy_mbarrier_arrive
   // CHECK-NEXT: ttng.wait_barrier
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.inval_barrier
-  // Each thread contributes one arrival for its empty copy group.
-  ttng.init_barrier %barrier, 128 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  // Expect contributes one arrival, followed by one async arrival per thread.
+  ttng.init_barrier %barrier, 129 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.barrier_expect %barrier, 0, %true : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.async_copy_mbarrier_arrive %barrier {noIncrement} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.wait_barrier %barrier, %phase : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.inval_barrier %barrier : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return
+}
+
+// CHECK-LABEL: @incrementing_arrive_before_tma
+tt.func @incrementing_arrive_before_tma(%desc: !tt.tensordesc<16x64xf16, #tma_shared>) {
+  %c0 = arith.constant 0 : i32
+  %true = arith.constant true
+  %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  %payload = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #tma_shared, #smem, mutable>
+  ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.barrier_expect %barrier, 2048, %true : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  // Register every thread before the TMA completion can finish this phase.
+  // CHECK: ttng.async_copy_mbarrier_arrive
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  ttng.async_copy_mbarrier_arrive %barrier : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %payload, %barrier, %true : !tt.tensordesc<16x64xf16, #tma_shared>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !ttg.memdesc<16x64xf16, #tma_shared, #smem, mutable>
+  ttng.wait_barrier %barrier, %c0 deps %payload : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>, !ttg.memdesc<16x64xf16, #tma_shared, #smem, mutable>
   ttng.inval_barrier %barrier : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   tt.return
 }
@@ -147,11 +217,12 @@ tt.func @incrementing_async_copy_arrive_then_wait_barrier() {
   %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.arrive_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
-  // Register an empty copy group for phase 1 before waiting on completed phase 0.
-  // Incrementing arrivals must retain the rendezvous before the wait.
+  ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  // Polling phase 0 may overlap phase-1 registration; completing phase 1 may not.
   // CHECK: ttng.async_copy_mbarrier_arrive
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.arrive_barrier
   ttng.async_copy_mbarrier_arrive %barrier : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.arrive_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
@@ -264,7 +335,6 @@ tt.func @tma_special_cases(%arg1: !tt.tensordesc<256x64xf16, #shared>, %arg2: !t
 
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.barrier_expect
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.async_tma_copy_global_to_local
   // CHECK-NEXT: ttng.wait_barrier
   ttng.barrier_expect %barrier, 49152, %true : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
@@ -285,7 +355,6 @@ tt.func @tma_special_cases(%arg1: !tt.tensordesc<256x64xf16, #shared>, %arg2: !t
 
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.barrier_expect
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.async_tma_copy_global_to_local
   // CHECK-NEXT: ttng.wait_barrier
   ttng.barrier_expect %barrier, 49152, %true : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
@@ -295,7 +364,6 @@ tt.func @tma_special_cases(%arg1: !tt.tensordesc<256x64xf16, #shared>, %arg2: !t
   // CHECK-NEXT: memdesc_subslice
   // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.barrier_expect
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.async_tma_gather
   // CHECK-NEXT: ttng.wait_barrier
   %view = ttg.memdesc_subslice %gather_alloc [0, 0]  : !ttg.memdesc<32x64xf16, #shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<32x64xf16, #shared, #ttg.shared_memory, mutable>
@@ -566,6 +634,17 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.thr
 !col_tile = tensor<16x16xf32, #cols>
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // Counter waits do not require known allocation origins.
+  // CHECK-LABEL: @consecutive_waits_argument
+  // CHECK: ttng.wait_barrier
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: tt.return
+  tt.func private @consecutive_waits_argument(%barrier: !barrier, %phase: i32) {
+    ttng.wait_barrier %barrier, %phase : !barrier
+    ttng.wait_barrier %barrier, %phase : !barrier
+    tt.return
+  }
+
   // Same-thread publications share one rendezvous even with pure work and
   // runtime predicates between them. Each barrier starts with count one.
   // CHECK-LABEL: @same_thread_publications
@@ -844,9 +923,36 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.thr
 // -----
 
 #bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#store_layout = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+#payload_layout = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 !barrier = !ttg.memdesc<2xi64, #bar, #ttg.shared_memory, mutable>
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // Complete-tx updates commute, and the wait completes both generic stores.
+  // CHECK-LABEL: @async_store_payload
+  // CHECK: ttng.async_shared_store
+  // CHECK-NEXT: ttng.async_shared_store
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: {{.*}}ttg.local_load
+  // CHECK-NEXT: {{.*}}ttg.local_load
+  tt.func @async_store_payload(%data: tensor<128xi32, #store_layout>) -> tensor<128xi32, #store_layout> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %barrier = ttg.local_alloc : () -> !barrier
+    %first = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #payload_layout, #ttg.shared_memory, mutable>
+    %second = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #payload_layout, #ttg.shared_memory, mutable>
+    ttng.init_barrier %barrier, 1 : !barrier
+    ttng.barrier_expect %barrier, 1024, %true : !barrier
+    ttng.async_shared_store %data, %first, %barrier : tensor<128xi32, #store_layout> -> !ttg.memdesc<128xi32, #payload_layout, #ttg.shared_memory, mutable>, !barrier
+    ttng.async_shared_store %data, %second, %barrier : tensor<128xi32, #store_layout> -> !ttg.memdesc<128xi32, #payload_layout, #ttg.shared_memory, mutable>, !barrier
+    ttng.wait_barrier %barrier, %c0 deps %first, %second : !barrier, !ttg.memdesc<128xi32, #payload_layout, #ttg.shared_memory, mutable>, !ttg.memdesc<128xi32, #payload_layout, #ttg.shared_memory, mutable>
+    %a = ttg.local_load %first : !ttg.memdesc<128xi32, #payload_layout, #ttg.shared_memory, mutable> -> tensor<128xi32, #store_layout>
+    %b = ttg.local_load %second : !ttg.memdesc<128xi32, #payload_layout, #ttg.shared_memory, mutable> -> tensor<128xi32, #store_layout>
+    %result = arith.addi %a, %b : tensor<128xi32, #store_layout>
+    ttng.inval_barrier %barrier : !barrier
+    tt.return %result : tensor<128xi32, #store_layout>
+  }
+
   // CHECK-LABEL: @arrive_then_wait_barrier_multicta
   tt.func @arrive_then_wait_barrier_multicta() {
     %phase = arith.constant 0 : i32

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -2,6 +2,33 @@
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Each CTA waits for its own copy before overwriting the destination.
+  // CHECK-LABEL: @tma_payload_generic_store
+  // CHECK: ttng.wait_barrier
+  // CHECK-NEXT: ttg.local_store
+  tt.func @tma_payload_generic_store(%desc: !tt.tensordesc<16x64xf16, #shared>, %value: tensor<16x64xf16, #blocked>) -> tensor<16x64xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    %mem = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %bar, 2048, %true : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %mem, %bar, %true : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<2xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    ttg.local_store %value, %mem : tensor<16x64xf16, #blocked> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    %result = ttg.local_load %mem : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
+    ttng.inval_barrier %bar : !ttg.memdesc<2xi64, #barrier, #smem, mutable>
+    tt.return %result : tensor<16x64xf16, #blocked>
+  }
+}
+
+// -----
+
 #blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #blockedSplitN = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
@@ -1392,15 +1419,14 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
   // CHECK: cf.cond_br
   // CHECK: ttng.barrier_expect
   // CHECK-NOT: ttng.cluster_barrier
-  // CHECK: ttg.barrier local
-  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
-  // CHECK-NOT: ttng.cluster_barrier
-  // CHECK: ttg.barrier local
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: ttng.async_tma_copy_global_to_local
   // CHECK-NEXT: ttng.async_tma_copy_global_to_local
   // CHECK-NOT: ttng.cluster_barrier
   // CHECK: ttng.wait_barrier
   // CHECK-NOT: ttng.cluster_barrier
-  // CHECK: ttng.tc_gen5_mma
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttng.tc_gen5_mma
   // CHECK: ttng.wait_barrier
   tt.func @example_matmul(%a_desc: !tt.tensordesc<256x16xf16, #sharedA>, %b_desc: !tt.tensordesc<16x64xf16, #sharedB>) {
     %c0 = arith.constant 0 : i32

--- a/test/TritonNvidiaGPU/membar.mlir
+++ b/test/TritonNvidiaGPU/membar.mlir
@@ -376,15 +376,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
-  // Barrier-state dependencies keep both arrivals scalar.
-  // FOLD-LABEL: @distributed_arrival_keeps_barrier_hazards
-  // FOLD: ttng.init_barrier {{.*}}, 2 :
+  // Partial contributions share a counter with only warp synchronization.
+  // FOLD-LABEL: @distributed_arrival_keeps_warp_barrier
+  // FOLD: ttng.init_barrier {{.*}}, 8 :
   // FOLD-NEXT: ttg.barrier local
-  // FOLD-NEXT: ttng.arrive_barrier {{.*}}, 1 :
-  // FOLD-NEXT: ttg.barrier local
-  // FOLD-NEXT: ttng.arrive_barrier {{.*}}, 1 :
+  // FOLD-NEXT: ttng.arrive_barrier {{.*}}, 4 :
+  // FOLD-NEXT: ttg.barrier warp local
+  // FOLD-NEXT: ttng.arrive_barrier {{.*}}, 4 {per_warp}
   // FOLD-NEXT: ttng.wait_barrier
-  tt.func @distributed_arrival_keeps_barrier_hazards() {
+  tt.func @distributed_arrival_keeps_warp_barrier() {
     %phase = arith.constant 0 : i32
     %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.init_barrier %bar, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -549,10 +549,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
   // Each barrier receives one local, one routed, and two multicast contributions.
   // FOLD-LABEL: @distributed_arrival_cta_routes
-  // FOLD: ttng.init_barrier {{.*}}, 4 :
-  // FOLD: ttng.arrive_barrier {{.*}}, 1 :
-  // FOLD: ttng.arrive_barrier {{.*}}, 1 {fromCTA = 0 : i32} :
-  // FOLD: ttng.arrive_barrier {{.*}}, 1 {multicastCTA = 1 : i32} :
+  // FOLD: ttng.init_barrier {{.*}}, 16 :
+  // FOLD: ttng.arrive_barrier {{.*}}, 4 :
+  // FOLD: ttng.arrive_barrier {{.*}}, 4 {fromCTA = 0 : i32, per_warp} :
+  // FOLD: ttng.arrive_barrier {{.*}}, 4 {multicastCTA = 1 : i32, per_warp} :
   // FOLD-NEXT: ttng.wait_barrier
   tt.func @distributed_arrival_cta_routes() {
     %phase = arith.constant 0 : i32
@@ -743,5 +743,274 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
     ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
     tt.return %old : tensor<16x64xf16, #blocked>
+  }
+
+  // Completion permits another TMA write to the same live payload.
+  // CHECK-LABEL: @tma_rows_reuse_payload
+  // CHECK: ttng.async_tma_copy_global_to_local
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: {{.*}}ttg.local_load
+  // FOLD-LABEL: @tma_rows_reuse_payload
+  // FOLD: ttng.init_barrier %[[FIRST:.*]], 1 :
+  // FOLD: ttng.init_barrier {{.*}}, 4 :
+  // FOLD: ttng.barrier_expect %[[FIRST]], 2048, {{.*}} :
+  // FOLD-NOT: ttng.arrive_barrier
+  // FOLD: ttng.barrier_expect {{.*}}, 2048 {per_warp},
+  // FOLD: ttng.async_tma_copy_global_to_local
+  // FOLD-NEXT: ttng.wait_barrier
+  // FOLD-NEXT: ttng.async_tma_copy_global_to_local
+  tt.func @tma_rows_reuse_payload(%desc: !tt.tensordesc<16x64xf16, #shared>) -> tensor<16x64xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %c16 = arith.constant 16 : i32
+    %true = arith.constant true
+    %first = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %second = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %mem = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.init_barrier %first, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.init_barrier %second, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %first, 2048, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %second, 2048, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %mem, %first, %true : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.wait_barrier %first, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c16, %c0] %mem, %second, %true : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.wait_barrier %second, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %result = ttg.local_load %mem : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
+    ttng.inval_barrier %first : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.inval_barrier %second : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return %result : tensor<16x64xf16, #blocked>
+  }
+
+  // Distinct allocation origins keep physical storage reuse conservative.
+  // CHECK-LABEL: @tma_payload_distinct_allocations
+  // CHECK: ttg.local_alloc {{.*}}allocation.offset = [[PAYLOAD_OFFSET:[0-9]+]] : i32{{.*}}!ttg.memdesc<16x64xf16
+  // CHECK: ttng.async_tma_copy_global_to_local
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: ttg.local_dealloc
+  // CHECK-NEXT: ttg.local_alloc {{.*}}allocation.offset = [[PAYLOAD_OFFSET]] : i32{{.*}}!ttg.memdesc<16x64xf16
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  tt.func @tma_payload_distinct_allocations(%desc: !tt.tensordesc<16x64xf16, #shared>) -> tensor<16x64xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %c16 = arith.constant 16 : i32
+    %true = arith.constant true
+    %first = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %second = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.init_barrier %first, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.init_barrier %second, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %first, 2048, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %second, 2048, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %a = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %a, %first, %true : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.wait_barrier %first, %c0 deps %a : !ttg.memdesc<1xi64, #barrier, #smem, mutable>, !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttg.local_dealloc %a : !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c16, %c0] %b, %second, %true : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.wait_barrier %second, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %result = ttg.local_load %b : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
+    ttng.inval_barrier %first : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.inval_barrier %second : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return %result : tensor<16x64xf16, #blocked>
+  }
+
+  // The ordinary read must finish before another TMA overwrites the payload.
+  // CHECK-LABEL: @tma_payload_after_generic_read
+  // CHECK: ttng.async_tma_copy_global_to_local
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: {{.*}}ttg.local_load
+  // CHECK-NEXT: ttng.fence_async_shared
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  tt.func @tma_payload_after_generic_read(%desc: !tt.tensordesc<16x64xf16, #shared>) -> tensor<16x64xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %c16 = arith.constant 16 : i32
+    %true = arith.constant true
+    %first = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %second = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %mem = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.init_barrier %first, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.init_barrier %second, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %first, 2048, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %second, 2048, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %mem, %first, %true : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.wait_barrier %first, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %before = ttg.local_load %mem : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
+    ttng.fence_async_shared {bCluster = false}
+    ttng.async_tma_copy_global_to_local %desc[%c16, %c0] %mem, %second, %true : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.wait_barrier %second, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %after = ttg.local_load %mem : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
+    %result = arith.addf %before, %after : tensor<16x64xf16, #blocked>
+    ttng.inval_barrier %first : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.inval_barrier %second : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return %result : tensor<16x64xf16, #blocked>
+  }
+
+  // A uniform selection preserves completion for either allocation and proxy.
+  // CHECK-LABEL: @tma_payload_selected_allocation
+  // CHECK: ttng.wait_barrier
+  // CHECK-NEXT: ttng.async_tma_copy_local_to_global
+  tt.func @tma_payload_selected_allocation(%src: !tt.tensordesc<16x64xf16, #shared>, %dst: !tt.tensordesc<16x64xf16, #shared>, %choose: i1) {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %a = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    %mem = arith.select %choose, %a, %b : !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %bar, 2048, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %src[%c0, %c0] %mem, %bar, %true : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.async_tma_copy_local_to_global %dst[%c0, %c0] %mem : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    ttg.local_dealloc %a : !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttg.local_dealloc %b : !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // The same progress guarantee holds for a distributed expectation.
+  // FOLD-LABEL: @wait_before_distributed_expectation
+  // FOLD: ttng.wait_barrier
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: ttng.wait_barrier
+  // FOLD-NEXT: ttg.barrier warp local
+  // FOLD-NEXT: ttng.barrier_expect {{.*}}, 0 {per_warp},
+  // FOLD-NEXT: ttng.wait_barrier
+  tt.func @wait_before_distributed_expectation(%pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.barrier_expect %bar, 0, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.barrier local
+    ttng.wait_barrier %bar, %c0, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.barrier_expect %bar, 0, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c1, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // Each warp finishes its wait before contributing to the next phase.
+  // FOLD-LABEL: @wait_before_distributed_arrival
+  // FOLD: ttng.wait_barrier
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: ttng.wait_barrier
+  // FOLD-NEXT: ttg.barrier warp local
+  // FOLD-NEXT: ttng.arrive_barrier {{.*}}, 4, {{.*}} {per_warp}
+  // FOLD-NEXT: ttng.wait_barrier
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: ttng.inval_barrier
+  tt.func @wait_before_distributed_arrival(%pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.barrier local
+    ttng.wait_barrier %bar, %c0, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 1, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c1, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // The preceding wait is in the previous iteration, after the static arrival.
+  // FOLD-LABEL: @distributed_arrival_on_backedge
+  // FOLD: cf.cond_br
+  // FOLD: ttg.barrier warp local
+  // FOLD-NEXT: ttng.arrive_barrier {{.*}} {per_warp}
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD: ttng.wait_barrier
+  tt.func @distributed_arrival_on_backedge(%iterations: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.barrier local
+    scf.for %i = %c0 to %iterations step %c1 : i32 {
+      ttng.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttg.barrier local
+      %phase = arith.andi %i, %c1 : i32
+      ttng.wait_barrier %bar, %phase : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    }
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#per_cta = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#broadcast = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
+  // CTA 0's arrivals do not establish that CTA 1's warps passed their waits.
+  // FOLD-LABEL: @routed_arrival_after_wait
+  // FOLD: ttng.arrive_barrier
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: ttng.wait_barrier
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: ttng.arrive_barrier {{.*}}fromCTA = 0
+  tt.func @routed_arrival_after_wait() {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttg.barrier local
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 {fromCTA = 0 : i32} : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttng.wait_barrier %bar, %c1 : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    tt.return
+  }
+
+  // Multicast includes every waiting CTA's own contribution.
+  // FOLD-LABEL: @multicast_arrival_after_wait
+  // FOLD: ttng.wait_barrier
+  // FOLD-NEXT: ttg.barrier warp local
+  // FOLD-NEXT: ttng.arrive_barrier {{.*}}multicastCTA = 1
+  tt.func @multicast_arrival_after_wait() {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttng.init_barrier %bar, 2 : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttng.arrive_barrier %bar, 2 : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttg.barrier local
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 {multicastCTA = 1 : i32} : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttng.wait_barrier %bar, %c1 : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<2xi64, #per_cta, #smem, mutable>
+    tt.return
+  }
+
+  // A broadcast barrier only waits on its leader CTA.
+  // FOLD-LABEL: @broadcast_arrival_after_wait
+  // FOLD: ttng.wait_barrier
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: ttng.arrive_barrier
+  tt.func @broadcast_arrival_after_wait() {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #broadcast, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #broadcast, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #broadcast, #smem, mutable>
+    ttng.cluster_barrier
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #broadcast, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #broadcast, #smem, mutable>
+    ttng.cluster_barrier
+    ttng.wait_barrier %bar, %c1 : !ttg.memdesc<1xi64, #broadcast, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #broadcast, #smem, mutable>
+    tt.return
   }
 }

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -4,6 +4,10 @@
 #include "mlir/IR/Operation.h"
 #include "triton/Analysis/Allocation.h"
 
+namespace mlir {
+struct AllocationSlice;
+}
+
 namespace mlir::triton::AMD {
 
 // Filter function used in the AMDGPU backend to filter unnecessary barriers
@@ -29,7 +33,8 @@ namespace mlir::triton::AMD {
 // 2) Do not create barriers between two async loads. The synchronization
 // between them do not make sense.
 bool membarFilter(Operation *op1, Operation *op2, bool op1IsRead,
-                  bool op2IsRead, Allocation *allocation);
+                  bool op2IsRead, Allocation *allocation,
+                  const AllocationSlice &, const AllocationSlice &);
 } // namespace mlir::triton::AMD
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -88,7 +88,8 @@ bool filterLDSMemoryBarriersDependencies(Operation *op1, Operation *op2) {
 } // namespace
 
 bool membarFilter(Operation *op1, Operation *op2, bool /*op1IsRead*/,
-                  bool /*op2IsRead*/, Allocation *allocation) {
+                  bool /*op2IsRead*/, Allocation *allocation,
+                  const AllocationSlice &, const AllocationSlice &) {
   return (filterAsyncLocalLoadsDependencies(op1, op2, allocation) ||
           filterLDSMemoryBarriersDependencies(op1, op2));
 }

--- a/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Utility.h
@@ -5,13 +5,16 @@
 #include "triton/Analysis/Allocation.h"
 
 namespace mlir {
+struct AllocationSlice;
 namespace triton {
 namespace NVIDIA {
 
 /// Return true if we can skip a barrier synchronization between two operations
 /// even if they access the same shared memory.
 bool canSkipBarSync(Operation *before, Operation *after, bool beforeIsRead,
-                    bool afterIsRead, Allocation *allocation);
+                    bool afterIsRead, Allocation *allocation,
+                    const AllocationSlice &beforeSlice,
+                    const AllocationSlice &afterSlice);
 } // namespace NVIDIA
 } // namespace triton
 } // namespace mlir

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Membar.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Membar.cpp
@@ -12,6 +12,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 
 namespace mlir::triton {
 #define GEN_PASS_DEF_TRITONNVIDIAGPUMEMBAR
@@ -56,17 +57,77 @@ struct TritonNvidiaGPUMembar
 
 } // namespace
 
+// Preserve aliases introduced by allocator reuse. Multiple possible origins
+// are safe when every physical overlap has the same allocation origin.
+static bool hasOnlySourceAliases(const AllocationSlice &lhs,
+                                 const AllocationSlice &rhs) {
+  auto *before = lhs.physicalFootprint;
+  auto *after = rhs.physicalFootprint;
+  if (!before || !after)
+    return false;
+  for (const auto &a : before->regionInfo.views) {
+    assert(isa_and_nonnull<gpu::LocalAllocOp>(a.allocation) &&
+           "shared descriptor footprints must have allocation origins");
+    for (const auto &b : after->regionInfo.views) {
+      assert(a.allocationFrame && a.allocationFrame == b.allocationFrame &&
+             "shared accesses must use the current function frame");
+      if (a.region.intersects(b.region) && a.allocation != b.allocation)
+        return false;
+    }
+  }
+  return true;
+}
+
 bool NVIDIA::canSkipBarSync(Operation *before, Operation *after,
                             bool /*beforeIsRead*/, bool /*afterIsRead*/,
-                            Allocation * /*allocation*/) {
-  if (isa<ttng::WaitBarrierOp>(after)) {
-    // All threads must register incrementing arrivals before any can wait.
-    if (auto arrive = dyn_cast<ttng::AsyncCopyMbarrierArriveOp>(before))
-      return arrive.getNoIncrement();
-    // Signals and waits can access the same live barrier concurrently;
-    // accesses to distinct barriers are independent.
-    if (isa<ttng::TMALoadLikeOpInterface, ttng::BarrierExpectOp,
-            ttng::ArriveBarrierOp, ttng::TCGen5CommitOp>(before))
+                            Allocation * /*allocation*/,
+                            const AllocationSlice &beforeSlice,
+                            const AllocationSlice &afterSlice) {
+  auto completesTransactions = [](Operation *op) {
+    return isa<ttng::TMALoadLikeOpInterface, ttng::CLCTryCancelOp,
+               ttng::AsyncSharedStoreOp>(op);
+  };
+  // Accessing these live destinations requires completion, which makes their
+  // writes visible to the generic proxy.
+  if (completesTransactions(before) &&
+      beforeSlice.sharedKind != gpu::SharedKind::Barrier &&
+      hasOnlySourceAliases(beforeSlice, afterSlice))
+    return true;
+
+  // If before and after are mbarriers
+  if (beforeSlice.sharedKind == gpu::SharedKind::Barrier &&
+      afterSlice.sharedKind == gpu::SharedKind::Barrier) {
+    auto signalsCompletion = [&](Operation *op) {
+      if (auto arrive = dyn_cast<ttng::AsyncCopyMbarrierArriveOp>(op))
+        return arrive.getNoIncrement();
+      return completesTransactions(op) ||
+             isa<ttng::ArriveBarrierOp, ttng::BarrierExpectOp,
+                 ttng::TCGen5CommitOp, ttng::MMAv5OpInterface>(op);
+    };
+    // Signaling completion via incrementing or decrementing
+    // expect / arrive counters commutes with each other
+    // Note that this is just for mbarriers
+    // Data accessed by these ops may still add barriers
+    if (signalsCompletion(before) && signalsCompletion(after))
+      return true;
+
+    // A wait can observe a live counter concurrently with signals or waits.
+    if (isa<ttng::WaitBarrierOp>(after))
+      return true;
+
+    auto wait = dyn_cast<ttng::WaitBarrierOp>(before);
+    auto expect = dyn_cast<ttng::BarrierExpectOp>(after);
+    // Every warp finishes its wait before contributing to the next phase.
+    if (wait && expect && expect.getPerWarp() &&
+        wait.getAlloc() == expect.getAlloc())
+      return true;
+    auto arrive = dyn_cast<ttng::ArriveBarrierOp>(after);
+    // Each CTA must wait and contribute before the next phase can complete.
+    // Broadcast waits and nonidentity fromCTA routing omit participating CTAs.
+    if (wait && arrive && arrive.getPerWarp() &&
+        wait.getAlloc() == arrive.getAlloc() &&
+        !ttng::hasCGABroadcast(wait.getAlloc().getType()) &&
+        !arrive.getFromCTA())
       return true;
   }
 


### PR DESCRIPTION
Use access kinds and physical allocation slices to skip redundant synchronization between mbarrier signals, waits, and completed TMA accesses. Retain barriers for payload hazards and storage reuse.

Stacked on #11697.
