### PR TITLE
[MEMBAR][CORRECTNESS] Preserve mbarrier wait progress before notifications

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -208,9 +208,6 @@ struct BlockInfo {
                          sliceFilter, allocation);
   }
 
-  /// Whether pending thread effects must rendezvous before the other's demands.
-  bool requiresThreadSync(const BlockInfo &other) const;
-
   /// Clears the effects because a barrier is inserted.
   void sync() {
     syncReadSlices.clear();
@@ -360,6 +357,9 @@ protected:
                      bool cluster = false);
   virtual triton::BarrierStages getBarrierStages(Operation *operation);
 
+  /// Whether pending thread effects must rendezvous before upcoming demands.
+  bool requiresThreadSync(const BlockInfo &pending, const BlockInfo &effects);
+
   Allocation &allocation;
   MembarFilterFn filter;
   triton::BufferRegionAnalysis &regions;
@@ -370,6 +370,10 @@ private:
   MembarSliceFilterFn sliceFilter;
   AccessMode accessMode;
   BufferIndexAnalysis bufferIndexAnalysis;
+  DenseMap<Value, bool> regionLocalAllocations;
+
+  bool isRegionLocal(Value value);
+  bool mayNotifyPeer(Operation *op);
 };
 
 /// Inserts shared-memory and operation rendezvous barriers across a module,

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/MBarrierUtilities.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/MBarrierUtilities.h
@@ -6,6 +6,8 @@
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 
+#include <optional>
+
 namespace mlir::triton::nvidia_gpu {
 
 bool isCrossCTALoadStore(::mlir::triton::gpu::MemDescType memDescTy,
@@ -14,7 +16,15 @@ bool isCrossCTALoadStore(::mlir::triton::gpu::MemDescType memDescTy,
 bool isCrossCTAGatherScatter(::mlir::triton::gpu::MemDescType memDescTy,
                              ::mlir::RankedTensorType regTy, unsigned axis);
 
+// Checks shared-memory payload accesses, including allocation initializers.
+// Returns nullopt for unsupported accesses or unknown CTA routing.
+std::optional<bool> hasCrossCTASharedAccess(Operation *op);
+
 bool hasTCGen5CommitCrossCTA(Operation *op);
+
+// Checks routing of explicit mbarrier operands; callers check barrier-layout
+// broadcast separately. Requires the module's two-CTA mode to be resolved.
+bool hasCrossCTAMBarrierUse(gpu::MBarrierOpInterface op);
 
 bool requiresCrossCTAMBarrierInitSync(
     FunctionOpInterface funcOp, Value barrier, int numCTAs,

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -4,7 +4,10 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/MBarrierUtilities.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 
 namespace ttng = mlir::triton::nvidia_gpu;
@@ -198,6 +201,56 @@ ThreadSyncInfo getThreadSyncInfo(Operation *op) {
   return {};
 }
 
+// Every observer stays in this region and CTA. Follow views and selects;
+// calls, captures and raw-address escapes reject the proof.
+bool hasRegionLocalUses(Value root) {
+  if (ttng::hasCrossCTASharedAccess(root.getDefiningOp()).value_or(false))
+    return false;
+  SmallVector<Value> worklist{root};
+  llvm::SmallPtrSet<Value, 8> seen;
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!seen.insert(value).second)
+      continue;
+    for (OpOperand &use : value.getUses()) {
+      Operation *user = use.getOwner();
+      if (user->hasTrait<OpTrait::MemDescViewTrait>() ||
+          isa<arith::SelectOp>(user)) {
+        llvm::append_range(worklist, user->getResults());
+        continue;
+      }
+      if (user->getParentRegion() != root.getParentRegion())
+        return false;
+      // TMEM loads and stores only access the issuing CTA's tensor memory.
+      if (isa<triton::gpu::LocalDeallocOp, ttng::TMEMLoadOp, ttng::TMEMStoreOp>(
+              user))
+        continue;
+      // Wait dependencies only keep allocations live.
+      if (auto wait = dyn_cast<ttng::WaitBarrierOp>(user);
+          wait && wait.getAlloc() != value)
+        continue;
+      auto barrier = dyn_cast<triton::gpu::MBarrierOpInterface>(user);
+      if (barrier && llvm::is_contained(barrier.getBarriers(), value)) {
+        if (ttng::hasCrossCTAMBarrierUse(barrier) ||
+            ttng::hasCGABroadcast(
+                cast<triton::gpu::MemDescType>(value.getType())))
+          return false;
+        if (isa<ttng::InitBarrierOp, ttng::InvalBarrierOp>(user))
+          continue;
+        for (const auto &access : triton::getMemoryAccesses(user))
+          if (access.value == value &&
+              access.sharedKind != triton::gpu::SharedKind::Barrier)
+            return false;
+        continue;
+      }
+      auto crossCTA = ttng::hasCrossCTASharedAccess(user);
+      if (!crossCTA || *crossCTA)
+        return false;
+    }
+  }
+  return true;
+}
+
 bool hasOnlyGlobalReads(Operation *op) {
   auto effects = getEffectsRecursively(op);
   return effects && !effects->empty() &&
@@ -220,20 +273,50 @@ bool haveSameThreadSyncIssuer(Operation *lhs, Operation *rhs) {
 
 } // namespace
 
-bool BlockInfo::requiresThreadSync(const BlockInfo &other) const {
+bool MembarAnalysis::isRegionLocal(Value value) {
+  auto *footprint = regions.getFootprint(value);
+  return footprint &&
+         llvm::all_of(footprint->regionInfo.views, [&](auto &view) {
+           Value root = view.allocation->getResult(0);
+           auto [it, inserted] =
+               regionLocalAllocations.try_emplace(root, false);
+           if (inserted)
+             it->second = hasRegionLocalUses(root);
+           return it->second;
+         });
+}
+
+bool MembarAnalysis::mayNotifyPeer(Operation *op) {
+  // Nested operations are checked separately; region scratch is private.
+  if (isa<RegionBranchOpInterface, triton::AtomicLoadOp, triton::AtomicPollOp>(
+          op))
+    return false;
+  auto effects = getEffectsRecursively(op);
+  return !effects || llvm::any_of(*effects, [&](const auto &effect) {
+    return isa<MemoryEffects::Write>(effect.getEffect()) &&
+           (!effect.getValue() || !isRegionLocal(effect.getValue()));
+  });
+}
+
+bool MembarAnalysis::requiresThreadSync(const BlockInfo &pending,
+                                        const BlockInfo &effects) {
   // Only effect -> demand edges require a rendezvous; independent completion
   // operations can publish together.
   // The maps also include implicit scratch and translated callee accesses.
   bool hasSharedAccesses =
-      !other.syncReadSlices.empty() || !other.syncWriteSlices.empty();
-  for (Operation *before : threadEffects) {
+      !effects.syncReadSlices.empty() || !effects.syncWriteSlices.empty();
+  for (Operation *before : pending.threadEffects) {
     auto sync = getThreadSyncInfo(before);
-    for (Operation *after : other.threadDemands)
+    auto wait = dyn_cast<ttng::WaitBarrierOp>(before);
+    for (Operation *after : effects.threadDemands)
       if ((sync.requiresAfter() &&
            (sync.kind != ThreadSyncKind::SharedCompletionNeedsSync ||
             hasSharedAccesses || !hasOnlyGlobalReads(after))) ||
           (getThreadSyncInfo(after).requiresBefore() &&
-           !haveSameThreadSyncIssuer(before, after)))
+           !haveSameThreadSyncIssuer(before, after)) ||
+          // A notification can let a peer advance a pending wait's phase.
+          // Private counter updates are already ordered by the slice hazards.
+          (wait && !isRegionLocal(wait.getAlloc()) && mayNotifyPeer(after)))
         return true;
   }
   return false;
@@ -253,7 +336,7 @@ void MembarAnalysis::syncIfNeeded(Operation *op, const BlockInfo &effects,
            (filter &&
             filter(before, after, beforeIsRead, afterIsRead, allocation));
   };
-  if (!pending.requiresThreadSync(effects) &&
+  if (!requiresThreadSync(pending, effects) &&
       !pending.isIntersected(effects, canSkip, &allocation, sliceFilter))
     return;
   // The barrier clears incoming state. The operation's own effects still

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -35,26 +35,8 @@ bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
   if (hasCrossCTAScratch(op) && isRead)
     return true;
 
-  if (auto load = dyn_cast<ttg::LocalLoadOp>(op)) {
-    return isCrossCTALoadStore(load.getSrc().getType(), load.getType());
-  } else if (auto store = dyn_cast<ttg::LocalStoreOp>(op)) {
-    return isCrossCTALoadStore(store.getDst().getType(),
-                               store.getSrc().getType());
-  } else if (auto alloc = dyn_cast<ttg::LocalAllocOp>(op)) {
-    return alloc.getSrc() &&
-           isCrossCTALoadStore(alloc.getType(), alloc.getSrc().getType());
-  } else if (auto gather = dyn_cast<ttg::LocalGatherOp>(op)) {
-    return isCrossCTAGatherScatter(gather.getSrc().getType(), gather.getType(),
-                                   gather.getAxis());
-  } else if (auto scatter = dyn_cast<ttg::LocalScatterOp>(op)) {
-    return isCrossCTAGatherScatter(scatter.getDst().getType(),
-                                   scatter.getValues().getType(),
-                                   scatter.getAxis());
-  } else if (auto atomic = dyn_cast<ttg::LocalAtomicScatterRMWOp>(op)) {
-    return isCrossCTAGatherScatter(atomic.getDst().getType(),
-                                   atomic.getValues().getType(),
-                                   atomic.getAxis());
-  }
+  if (auto crossCTA = hasCrossCTASharedAccess(op))
+    return *crossCTA;
 
   if (isa<ttng::CLCTryCancelOp>(op)) {
     return ttg::lookupNumCTAs(op) > 1;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MBarrierUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MBarrierUtilities.cpp
@@ -54,6 +54,41 @@ bool isCrossCTAGatherScatter(ttg::MemDescType memDescTy, RankedTensorType regTy,
   return !conversion.isIdentityOnOutDim(kBlock);
 }
 
+std::optional<bool> hasCrossCTASharedAccess(Operation *op) {
+  if (auto load = dyn_cast<ttg::LocalLoadOp>(op))
+    return isCrossCTALoadStore(load.getSrc().getType(), load.getType());
+  if (auto store = dyn_cast<ttg::LocalStoreOp>(op))
+    return isCrossCTALoadStore(store.getDst().getType(),
+                               store.getSrc().getType());
+  if (auto alloc = dyn_cast<ttg::LocalAllocOp>(op))
+    return alloc.getSrc() &&
+           isCrossCTALoadStore(alloc.getType(), alloc.getSrc().getType());
+  if (auto gather = dyn_cast<ttg::LocalGatherOp>(op))
+    return isCrossCTAGatherScatter(gather.getSrc().getType(), gather.getType(),
+                                   gather.getAxis());
+  if (auto scatter = dyn_cast<ttg::LocalScatterOp>(op))
+    return isCrossCTAGatherScatter(scatter.getDst().getType(),
+                                   scatter.getValues().getType(),
+                                   scatter.getAxis());
+  if (auto atomic = dyn_cast<ttg::LocalAtomicScatterRMWOp>(op))
+    return isCrossCTAGatherScatter(atomic.getDst().getType(),
+                                   atomic.getValues().getType(),
+                                   atomic.getAxis());
+  if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
+    if (ttg::lookupNumCTAs(op) == 1)
+      return false;
+    if (tma.getMulticast())
+      return true;
+    auto type = cast<ttg::MemDescType>(tma.getResult().getType());
+    auto encoding = type.getEncoding();
+    // Subview offsets can select another CTA.
+    if (ttg::dropPipeliningDim(type.getShape(), encoding) ==
+        ttg::dropPipeliningDim(type.getAllocShape(), encoding))
+      return false;
+  }
+  return std::nullopt;
+}
+
 bool hasTCGen5CommitCrossCTA(Operation *op) {
   SmallVector<Value> descs;
   if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op))
@@ -63,6 +98,26 @@ bool hasTCGen5CommitCrossCTA(Operation *op) {
   else
     return false;
   return !ttng::getCTABroadcastMasks(ttng::getModuleTwoCTAs(op), descs).empty();
+}
+
+bool hasCrossCTAMBarrierUse(ttg::MBarrierOpInterface barrier) {
+  Operation *op = barrier.getOperation();
+  int numCTAs = ttg::lookupNumCTAs(op);
+  if (numCTAs == 1)
+    return false;
+  if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op))
+    return tma.getMulticast();
+  if (isa<ttng::CLCTryCancelOp>(op))
+    return true;
+  if (auto store = dyn_cast<ttng::AsyncSharedStoreOp>(op))
+    return isCrossCTALoadStore(store.getDst().getType(),
+                               store.getSrc().getType());
+  if (auto expect = dyn_cast<ttng::BarrierExpectOp>(op))
+    return expect.getFromCTA().value_or(numCTAs - 1) != numCTAs - 1;
+  if (auto arrive = dyn_cast<ttng::ArriveBarrierOp>(op))
+    return arrive.isMulticast() ||
+           arrive.getFromCTA().value_or(numCTAs - 1) != numCTAs - 1;
+  return hasTCGen5CommitCrossCTA(op);
 }
 
 bool requiresCrossCTAMBarrierInitSync(
@@ -79,23 +134,8 @@ bool requiresCrossCTAMBarrierInitSync(
   // across CTAs even though the barrier allocation itself looks per-CTA.
   return funcOp
       ->walk<WalkOrder::PreOrder>([&](ttg::MBarrierOpInterface user) {
-        Operation *op = user.getOperation();
-        bool crossCTA = false;
-        if (isa<ttng::MMAv5OpInterface, ttng::TCGen5CommitOp>(op))
-          crossCTA = hasTCGen5CommitCrossCTA(op);
-        else if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op))
-          crossCTA = tma.getMulticast();
-        else if (isa<ttng::CLCTryCancelOp>(op))
-          crossCTA = true;
-        else if (auto store = dyn_cast<ttng::AsyncSharedStoreOp>(op))
-          crossCTA = isCrossCTALoadStore(store.getDst().getType(),
-                                         store.getSrc().getType());
-        else if (auto expect = dyn_cast<ttng::BarrierExpectOp>(op))
-          crossCTA = expect.getFromCTA().has_value();
-        else if (auto arrive = dyn_cast<ttng::ArriveBarrierOp>(op))
-          crossCTA = arrive.isMulticast() || arrive.getFromCTA().has_value();
-
-        return crossCTA && llvm::any_of(user.getBarriers(), aliasesBarrier)
+        return llvm::any_of(user.getBarriers(), aliasesBarrier) &&
+                       hasCrossCTAMBarrierUse(user)
                    ? WalkResult::interrupt()
                    : WalkResult::advance();
       })

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1174,6 +1174,149 @@ def test_warp_specialize_noinline_ids():
     torch.testing.assert_close(scan_out, expected + 1, rtol=0, atol=0)
 
 
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
+def test_mbarrier_tma_progress(device):
+
+    @gluon.jit
+    def consumer(desc, payload, ready, copied):
+        mbarrier.wait(ready, 0)
+        tma.async_load(desc, [0, 0], copied, payload)
+        mbarrier.wait(copied, 0, deps=[payload])
+
+    @gluon.jit
+    def producer(ready, copied):
+        mbarrier.arrive(ready)
+        mbarrier.wait(copied, 0)
+        mbarrier.arrive(ready)
+        mbarrier.wait(ready, 1)
+
+    @gluon.jit
+    def kernel(desc):
+        ready = mbarrier.allocate_mbarrier()
+        copied = mbarrier.allocate_mbarrier()
+        payload = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
+        mbarrier.init(ready, count=1)
+        mbarrier.init(copied, count=1)
+        mbarrier.expect(copied, desc.nbytes_per_cta)
+        ttgl.warp_specialize([
+            (consumer, (desc, payload, ready, copied)),
+            (producer, (ready, copied)),
+        ], [1])
+        mbarrier.invalidate(ready)
+        mbarrier.invalidate(copied)
+
+    inp = torch.zeros((16, 64), dtype=torch.float16, device=device)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    desc = TensorDescriptor.from_tensor(inp, [16, 64], shared_layout)
+    compiled = kernel.warmup(desc, grid=(1, ), num_warps=4)
+    ptx = compiled.asm["ptx"]
+    copy = ptx.index("cp.async.bulk.tensor.")
+    wait = ptx.rfind("mbarrier.try_wait.", 0, copy)
+    assert wait >= 0
+    # All consumer warps must finish waiting before the copy lets ready advance.
+    # Check before launch so a regression fails without hanging the GPU.
+    assert re.search(r"\bbar(?:rier)?\.sync\b", ptx[wait:copy])
+    kernel[(1, )](desc, num_warps=4)
+    torch.cuda.synchronize(device)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
+def test_mbarrier_private_phase_progress(device):
+
+    @gluon.jit
+    def kernel(desc):
+        ready = mbarrier.allocate_mbarrier()
+        payload = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
+        mbarrier.init(ready, count=1)
+        mbarrier.expect(ready, desc.nbytes_per_cta)
+        ttgl.barrier()
+        mbarrier.wait(ready, 1)
+        tma.async_load(desc, [0, 0], ready, payload)
+        mbarrier.wait(ready, 0, deps=[payload])
+        mbarrier.invalidate(ready)
+
+    inp = torch.zeros((16, 64), dtype=torch.float16, device=device)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    desc = TensorDescriptor.from_tensor(inp, [16, 64], shared_layout)
+    compiled = kernel.warmup(desc, grid=(1, ), num_warps=4)
+    ptx = compiled.asm["ptx"]
+    copy = ptx.index("cp.async.bulk.tensor.")
+    last_wait = ptx.rfind("mbarrier.try_wait.", 0, copy)
+    assert last_wait >= 0
+    # Completing a phase must not strand a warp waiting on the previous parity.
+    # Check before launch so a regression fails without hanging the GPU.
+    assert re.search(r"\bbar(?:rier)?\.sync\b", ptx[last_wait:copy])
+    kernel[(1, )](desc, num_warps=4)
+    torch.cuda.synchronize(device)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
+@pytest.mark.parametrize("num_ctas", [1, 2])
+def test_mbarrier_private_indexed_counter(num_ctas, device):
+
+    @gluon.jit
+    def kernel(out, slot):
+        barriers = mbarrier.allocate_mbarrier(batch=4)
+        ready = barriers.index(slot)
+        mbarrier.init(ready, count=1)
+        mbarrier.arrive(ready)
+        mbarrier.wait(ready, 0)
+        ttgl.store(out, 1)
+        mbarrier.invalidate(ready)
+
+    out = torch.zeros((), dtype=torch.int32, device=device)
+    compiled = kernel.warmup(out, 3, grid=(1, ), num_warps=4, num_ctas=num_ctas)
+    ptx = compiled.asm["ptx"]
+    store = re.search(r"\bst\.global\b", ptx)
+    assert store is not None
+    wait = ptx.rfind("mbarrier.try_wait.", 0, store.start())
+    assert wait >= 0
+    # The output write cannot let a peer advance these private counters.
+    assert not re.search(r"\bbar(?:rier)?\.sync\b", ptx[wait:store.start()])
+    kernel[(1, )](out, 3, num_warps=4, num_ctas=num_ctas)
+    assert out.item() == 1
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
+def test_mbarrier_atomic_progress(device):
+
+    @gluon.jit
+    def consumer(ready, flag, pred):
+        mbarrier.wait(ready, 0)
+        # A skipped later wait must preserve the first wait's progress requirement.
+        mbarrier.wait(ready, 1, pred=pred)
+        ttgl.atomic_xchg(flag, 1, sem="relaxed", scope="cta")
+
+    @gluon.jit
+    def producer(ready, flag):
+        mbarrier.arrive(ready)
+        ttgl.atomic_poll(flag, 1, sem="relaxed", scope="cta")
+        mbarrier.arrive(ready)
+        mbarrier.wait(ready, 1)
+
+    @gluon.jit
+    def kernel(flag, pred):
+        ready = mbarrier.allocate_mbarrier()
+        mbarrier.init(ready, count=1)
+        ttgl.warp_specialize([
+            (consumer, (ready, flag, pred)),
+            (producer, (ready, flag)),
+        ], [1])
+        mbarrier.invalidate(ready)
+
+    flag = torch.zeros((), dtype=torch.int32, device=device)
+    compiled = kernel.warmup(flag, False, grid=(1, ), num_warps=4)
+    ptx = compiled.asm["ptx"]
+    notify = re.search(r"\batom\.[^;\n]*\.exch\.", ptx)
+    assert notify is not None
+    last_wait = ptx.rfind("mbarrier.try_wait.", 0, notify.start())
+    assert last_wait >= 0
+    # Check before launch: advancing ready early can strand a phase-0 waiter.
+    assert re.search(r"\bbar(?:rier)?\.sync\b", ptx[last_wait:notify.start()])
+    kernel[(1, )](flag, False, num_warps=4)
+    assert flag.item() == 1
+
+
 # Equivalence-class multicast: multicast_cta selects which CTA-ID bits to multicast
 # along.  Two CTAs share a class when (id_a & ~mask) == (id_b & ~mask).
 #


### PR DESCRIPTION
Ensure all participating warps finish a pending mbarrier wait before a write can notify a peer that advances its phase. Omit the extra rendezvous when the mbarrier or write destinations are confined to the same execution region and CTA.

Stacked on #11481.