### PR TITLE
[IR] Canonicalize operations with false predicates

### DIFF
--- a/include/triton/Dialect/Triton/IR/OpInterfaces.h
+++ b/include/triton/Dialect/Triton/IR/OpInterfaces.h
@@ -15,8 +15,8 @@ namespace triton {
 enum class MemSemantic : uint32_t;
 class PredicatedOpInterface;
 
-// Opt in only when a false predicate suppresses all effects. Operations with
-// results need their own replacement semantics and are left unchanged.
+// Call only for operations whose false predicate suppresses all effects.
+// Operations with results need their own replacement semantics.
 LogicalResult eraseIfPredicateIsFalse(PredicatedOpInterface op,
                                       PatternRewriter &rewriter);
 

--- a/include/triton/Dialect/Triton/IR/OpInterfaces.h
+++ b/include/triton/Dialect/Triton/IR/OpInterfaces.h
@@ -8,9 +8,17 @@
 
 namespace mlir {
 
+class PatternRewriter;
+
 namespace triton {
 
 enum class MemSemantic : uint32_t;
+class PredicatedOpInterface;
+
+// Opt in only when a false predicate suppresses all effects. Operations with
+// results need their own replacement semantics and are left unchanged.
+LogicalResult eraseIfPredicateIsFalse(PredicatedOpInterface op,
+                                      PatternRewriter &rewriter);
 
 namespace impl {
 

--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -131,6 +131,10 @@ def PredicatedOpInterface : OpInterface<"PredicatedOpInterface"> {
   let description = [{
     Common interface for operations that carry a predicate or mask operand that
     can be combined with a pipeline predicate.
+
+    A false predicate can still leave effects such as masked-copy zero filling
+    or MMA completion signals. Erasing an inactive operation requires a separate
+    guarantee that its predicate suppresses all effects.
   }];
 
   let cppNamespace = "::mlir::triton";

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -372,6 +372,7 @@ def TT_AtomicStoreOp : TT_Op<"atomic_store", [
     }];
 
     let hasVerifier = 1;
+    let hasCanonicalizeMethod = 1;
 }
 
 def TT_AtomicPollOp : TT_Op<"atomic_poll", [

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -358,6 +358,7 @@ def TTNG_WaitBarrierOp : TTNG_Op<"wait_barrier", [AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>,
     DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
   let summary = "wait until the mbarrier phase completes.";
+  let hasCanonicalizeMethod = 1;
 
   let description = [{
     Blocks the program progress until the mbarrier object in `alloc` completes
@@ -511,6 +512,7 @@ def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local",
     AttrSizedOperandSegments, DeclareOpInterfaceMethods<MBarrierOpInterface>,
     DeclareOpInterfaceMethods<PredicatedOpInterface>, TMALoadLikeOpInterface]> {
   let summary = "copy data based on descriptor from global memory to local memory asynchronously";
+  let hasCanonicalizeMethod = 1;
 
   let description = [{
     This operation copies data from global memory to local memory
@@ -629,6 +631,7 @@ def TTNG_AsyncTMAGatherOp : TTNG_Op<"async_tma_gather", [
     DeclareOpInterfaceMethods<MBarrierOpInterface>,
     DeclareOpInterfaceMethods<PredicatedOpInterface>, TMALoadLikeOpInterface]> {
   let summary = "gather data based on descriptor from global memory to local memory asynchronously";
+  let hasCanonicalizeMethod = 1;
 
   let description = [{
     This operation gathers multiple rows of data from a global memory matrix to
@@ -839,6 +842,7 @@ def TTNG_TCGen5CommitOp : TTNG_Op<"tc_gen5_commit", [AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<MBarrierOpInterface>,
     DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
   let summary = "make an mbarrier track completion of all prior async tcgen5 ops";
+  let hasCanonicalizeMethod = 1;
 
   let description = [{
     The `ttng.tc_gen5_commit` is an asynchronous operation that makes the
@@ -1001,6 +1005,7 @@ def TTNG_TMEMLoadOp : TTNG_Op<"tmem_load", [AttrSizedResultSegments]> {
 def TTNG_TMEMStoreOp : TTNG_Op<"tmem_store", [
     DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
   let summary = "Store a distributed tensor into a buffer in tensor memory";
+  let hasCanonicalizeMethod = 1;
 
   let description = [{
     This is similar to ttg.local_store except the source layout is restricted to

--- a/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
+++ b/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
@@ -55,6 +55,7 @@ void Canonicalize::runOnOperation() {
   // patterns.
   LoadOp::getCanonicalizationPatterns(patterns, ctx);
   StoreOp::getCanonicalizationPatterns(patterns, ctx);
+  AtomicStoreOp::getCanonicalizationPatterns(patterns, ctx);
   BroadcastOp::getCanonicalizationPatterns(patterns, ctx);
   ExpandDimsOp::getCanonicalizationPatterns(patterns, ctx);
   ReshapeOp::getCanonicalizationPatterns(patterns, ctx);
@@ -63,6 +64,11 @@ void Canonicalize::runOnOperation() {
   ttg::WarpSpecializePartitionsOp::getCanonicalizationPatterns(patterns, ctx);
   ttng::BarrierExpectOp::getCanonicalizationPatterns(patterns, ctx);
   ttng::ArriveBarrierOp::getCanonicalizationPatterns(patterns, ctx);
+  ttng::WaitBarrierOp::getCanonicalizationPatterns(patterns, ctx);
+  ttng::AsyncTMACopyGlobalToLocalOp::getCanonicalizationPatterns(patterns, ctx);
+  ttng::AsyncTMAGatherOp::getCanonicalizationPatterns(patterns, ctx);
+  ttng::TCGen5CommitOp::getCanonicalizationPatterns(patterns, ctx);
+  ttng::TMEMStoreOp::getCanonicalizationPatterns(patterns, ctx);
 
   (void)applyPatternsGreedily(getOperation(), std::move(patterns));
 }

--- a/lib/Dialect/Triton/IR/OpInterfaces.cpp
+++ b/lib/Dialect/Triton/IR/OpInterfaces.cpp
@@ -1,5 +1,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
 
 #include "triton/Dialect/Triton/IR/OpInterfaces.h"
@@ -7,6 +9,16 @@
 
 namespace mlir {
 namespace triton {
+
+LogicalResult eraseIfPredicateIsFalse(PredicatedOpInterface op,
+                                      PatternRewriter &rewriter) {
+  Value pred = op.getPredicateOperand();
+  if (op->getNumResults() || !pred || !matchPattern(pred, m_Zero()))
+    return failure();
+  rewriter.eraseOp(op);
+  return success();
+}
+
 namespace impl {
 
 LogicalResult verifyTransposeOpInterface(Operation *op) {

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -3,6 +3,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -121,29 +122,16 @@ struct CanonicalizeMaskedLoadPattern : public OpRewritePattern<LoadOp> {
     if (!mask)
       return failure();
 
-    auto constantMask = mask.getDefiningOp<arith::ConstantOp>();
-    if (!constantMask)
-      return failure();
-
-    auto splatMask = mlir::dyn_cast<SplatElementsAttr>(constantMask.getValue());
-    if (!splatMask)
-      return failure();
-
-    if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
-      // mask = splat(1)
+    if (matchPattern(mask, m_One())) {
       rewriter.replaceOpWithNewOp<LoadOp>(
           loadOp, loadOp.getType(), loadOp.getPtr(), Value(), Value(),
           loadOp.getCachePolicyAttr(), loadOp.getIsVolatile());
-    } else {
-      // mask = splat(0)
-
-      // If there's no "other", the value is "undef".  Perhaps we want to
-      // optimize it in the future.x
-      auto otherVal = loadOp.getOther();
-      if (!otherVal)
-        return failure();
-      rewriter.replaceOp(loadOp, otherVal);
+      return success();
     }
+    // Without "other", a false-masked load produces an undefined value.
+    if (!matchPattern(mask, m_Zero()) || !loadOp.getOther())
+      return failure();
+    rewriter.replaceOp(loadOp, loadOp.getOther());
     return success();
   }
 };

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -185,27 +185,14 @@ struct CanonicalizeMaskedStorePattern : public OpRewritePattern<StoreOp> {
 
   LogicalResult matchAndRewrite(StoreOp storeOp,
                                 PatternRewriter &rewriter) const override {
+    if (succeeded(eraseIfPredicateIsFalse(storeOp, rewriter)))
+      return success();
     auto mask = storeOp.getMask();
-    if (!mask)
+    if (!mask || !matchPattern(mask, m_One()))
       return failure();
-
-    auto constantMask = mask.getDefiningOp<arith::ConstantOp>();
-    if (!constantMask)
-      return failure();
-
-    auto splatMask = mlir::dyn_cast<SplatElementsAttr>(constantMask.getValue());
-    if (!splatMask)
-      return failure();
-
-    if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
-      // mask = splat(1)
-      rewriter.replaceOpWithNewOp<StoreOp>(
-          storeOp, storeOp.getPtr(), storeOp.getValue(), Value(),
-          storeOp.getCachePolicyAttr(), storeOp.getIgnoreCta());
-    } else {
-      // mask = splat(0)
-      rewriter.eraseOp(storeOp);
-    }
+    rewriter.replaceOpWithNewOp<StoreOp>(
+        storeOp, storeOp.getPtr(), storeOp.getValue(), Value(),
+        storeOp.getCachePolicyAttr(), storeOp.getIgnoreCta());
     return success();
   }
 };
@@ -233,6 +220,11 @@ void AtomicStoreOp::setPredicateOperand(Value pred) {
 }
 
 Type AtomicStoreOp::getPredicateOperandTypeLike() { return getPtr().getType(); }
+
+LogicalResult AtomicStoreOp::canonicalize(AtomicStoreOp op,
+                                          PatternRewriter &rewriter) {
+  return eraseIfPredicateIsFalse(op, rewriter);
+}
 
 static LogicalResult verifyAtomicLoadStoreType(Operation *op, Type ptrTy) {
   Type elementTy = getElementTypeOrSelf(getPointeeType(ptrTy));

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -430,6 +430,8 @@ LogicalResult BarrierExpectOp::verify() {
 
 LogicalResult BarrierExpectOp::canonicalize(BarrierExpectOp op,
                                             PatternRewriter &rewriter) {
+  if (succeeded(eraseIfPredicateIsFalse(op, rewriter)))
+    return success();
   return canonicalizeBarrierFromCTA(op, rewriter);
 }
 
@@ -446,6 +448,14 @@ Type BarrierExpectOp::getPredicateOperandTypeLike() {
 }
 
 // -- WaitBarrierOp --
+LogicalResult WaitBarrierOp::canonicalize(WaitBarrierOp op,
+                                          PatternRewriter &rewriter) {
+  // Dependencies keep allocations live even when the wait is predicated off.
+  if (!op.getDeps().empty())
+    return failure();
+  return eraseIfPredicateIsFalse(op, rewriter);
+}
+
 TypedValue<MemDescType> WaitBarrierOp::getBarrier() { return getAlloc(); }
 
 Value WaitBarrierOp::getPredicateOperand() { return getPred(); }
@@ -488,6 +498,8 @@ LogicalResult ArriveBarrierOp::verify() {
 
 LogicalResult ArriveBarrierOp::canonicalize(ArriveBarrierOp op,
                                             PatternRewriter &rewriter) {
+  if (succeeded(eraseIfPredicateIsFalse(op, rewriter)))
+    return success();
   return canonicalizeBarrierFromCTA(op, rewriter);
 }
 
@@ -831,6 +843,12 @@ bool AsyncTMAReduceOp::isSupportedReduceKind(DescriptorReduceKind kind,
 }
 
 // -- AsyncTMACopyGlobalToLocalOp --
+LogicalResult
+AsyncTMACopyGlobalToLocalOp::canonicalize(AsyncTMACopyGlobalToLocalOp op,
+                                          PatternRewriter &rewriter) {
+  return eraseIfPredicateIsFalse(op, rewriter);
+}
+
 LogicalResult AsyncTMACopyGlobalToLocalOp::verify() {
   auto descType = getDesc().getType();
   bool isIm2Col = isIm2ColDescriptor(descType);
@@ -894,6 +912,11 @@ LogicalResult AsyncTMAReduceOp::verify() {
 }
 
 // -- AsyncTMAGatherOp --
+LogicalResult AsyncTMAGatherOp::canonicalize(AsyncTMAGatherOp op,
+                                             PatternRewriter &rewriter) {
+  return eraseIfPredicateIsFalse(op, rewriter);
+}
+
 LogicalResult AsyncTMAGatherOp::verify() {
   auto resultType = getResult().getType();
   if (failed(verifyAsyncTMALoadOp(*this, getDesc().getType(), getBarrier(),
@@ -1288,6 +1311,11 @@ void TCGen5MMAOp::build(OpBuilder &builder, OperationState &state, Type token,
 bool TCGen5MMAOp::isAsync() { return getIsAsync(); }
 
 // -- TCGen5CommitOp --
+LogicalResult TCGen5CommitOp::canonicalize(TCGen5CommitOp op,
+                                           PatternRewriter &rewriter) {
+  return eraseIfPredicateIsFalse(op, rewriter);
+}
+
 LogicalResult TCGen5CommitOp::verify() {
   auto numDescs = getDescs().size();
   if (numDescs > 4)
@@ -1666,6 +1694,11 @@ static LogicalResult verifyTMEMOperand(Operation *op, RankedTensorType type,
   for (Attribute layout : layouts)
     diag.attachNote() << "potential TMEM layout: " << layout;
   return diag;
+}
+
+LogicalResult TMEMStoreOp::canonicalize(TMEMStoreOp op,
+                                        PatternRewriter &rewriter) {
+  return eraseIfPredicateIsFalse(op, rewriter);
 }
 
 LogicalResult TMEMStoreOp::verify() {

--- a/test/Triton/canonicalize.mlir
+++ b/test/Triton/canonicalize.mlir
@@ -1,5 +1,23 @@
 // RUN: triton-opt %s -split-input-file -canonicalize | FileCheck %s
 
+// CHECK-LABEL: @false_store_predicates
+// CHECK-NEXT: tt.store %arg0, %arg1, %arg2 :
+// CHECK-NEXT: tt.atomic_store release, gpu, %arg0, %arg1, %arg2 :
+// CHECK-NEXT: tt.return
+tt.func @false_store_predicates(%ptr: !tt.ptr<i32>, %value: i32, %pred: i1, %ptrs: tensor<4x!tt.ptr<i32>>, %values: tensor<4xi32>) {
+  %false = arith.constant false
+  %mask = arith.constant dense<false> : tensor<4xi1>
+  tt.store %ptr, %value, %false : !tt.ptr<i32>
+  tt.atomic_store release, gpu, %ptr, %value, %false : !tt.ptr<i32>
+  tt.store %ptrs, %values, %mask : tensor<4x!tt.ptr<i32>>
+  tt.atomic_store release, gpu, %ptrs, %values, %mask : tensor<4x!tt.ptr<i32>>
+  tt.store %ptr, %value, %pred : !tt.ptr<i32>
+  tt.atomic_store release, gpu, %ptr, %value, %pred : !tt.ptr<i32>
+  tt.return
+}
+
+// -----
+
 // CHECK-LABEL: dead_load
 tt.func @dead_load(%ptr: tensor<32x128x!tt.ptr<f16>>) {
   %mask = arith.constant dense<true> : tensor<32x128xi1>

--- a/test/Triton/canonicalize.mlir
+++ b/test/Triton/canonicalize.mlir
@@ -6,6 +6,7 @@
 // CHECK-NEXT: tt.return
 tt.func @false_store_predicates(%ptr: !tt.ptr<i32>, %value: i32, %pred: i1, %ptrs: tensor<4x!tt.ptr<i32>>, %values: tensor<4xi32>) {
   %false = arith.constant false
+  // m_Zero matches both scalar false and dense<false> tensor masks.
   %mask = arith.constant dense<false> : tensor<4xi1>
   tt.store %ptr, %value, %false : !tt.ptr<i32>
   tt.atomic_store release, gpu, %ptr, %value, %false : !tt.ptr<i32>
@@ -14,6 +15,27 @@ tt.func @false_store_predicates(%ptr: !tt.ptr<i32>, %value: i32, %pred: i1, %ptr
   tt.store %ptr, %value, %pred : !tt.ptr<i32>
   tt.atomic_store release, gpu, %ptr, %value, %pred : !tt.ptr<i32>
   tt.return
+}
+
+// -----
+
+// CHECK-LABEL: @load_false_mask_with_other
+// CHECK-NEXT: tt.return %arg1 : i32
+tt.func @load_false_mask_with_other(%ptr: !tt.ptr<i32>, %other: i32) -> i32 {
+  %false = arith.constant false
+  %value = tt.load %ptr, %false, %other : !tt.ptr<i32>
+  tt.return %value : i32
+}
+
+// -----
+
+// CHECK-LABEL: @load_true_mask
+// CHECK-NEXT: %[[VALUE:.*]] = tt.load %arg0 : !tt.ptr<i32>
+// CHECK-NEXT: tt.return %[[VALUE]] : i32
+tt.func @load_true_mask(%ptr: !tt.ptr<i32>) -> i32 {
+  %true = arith.constant true
+  %value = tt.load %ptr, %true : !tt.ptr<i32>
+  tt.return %value : i32
 }
 
 // -----

--- a/test/TritonGPU/canonicalize.mlir
+++ b/test/TritonGPU/canonicalize.mlir
@@ -1,5 +1,22 @@
 // RUN: triton-opt %s -split-input-file -canonicalize -allow-unregistered-dialect | FileCheck %s
 
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32} {
+// A false copy mask still fills shared memory with the other value.
+// CHECK-LABEL: @false_async_copy_keeps_fill
+// CHECK: %[[TOKEN:.*]] = ttg.async_copy_global_to_local
+// CHECK-NEXT: tt.return %[[TOKEN]] : !ttg.async.token
+tt.func @false_async_copy_keeps_fill(%ptr: tensor<128x!tt.ptr<f32>, #blocked>, %mem: !ttg.memdesc<128xf32, #shared, #ttg.shared_memory, mutable>) -> !ttg.async.token {
+  %false = arith.constant dense<false> : tensor<128xi1, #blocked>
+  %zero = arith.constant dense<0.0> : tensor<128xf32, #blocked>
+  %token = ttg.async_copy_global_to_local %ptr, %mem mask %false other %zero : tensor<128x!tt.ptr<f32>, #blocked> -> !ttg.memdesc<128xf32, #shared, #ttg.shared_memory, mutable>
+  tt.return %token : !ttg.async.token
+}
+}
+
+// -----
+
 
 // CHECK-LABEL: @test_canonicalize_convert_view
 // CHECK-SAME: (%[[ARG:.+]]: tensor<64x64xf32

--- a/test/TritonNvidiaGPU/canonicalize.mlir
+++ b/test/TritonNvidiaGPU/canonicalize.mlir
@@ -46,3 +46,71 @@ tt.func @canonicalize_fromCTA(%barrier: !ttg.memdesc<8xi64, #barrier, #smem, mut
   tt.return
 }
 }
+
+#local_barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared_a = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
+#shared_tma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#offsets_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#offsets = #ttg.slice<{dim = 0, parent = #offsets_parent}>
+#data = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+// BARRIER-LABEL: @false_barrier_predicates
+// BARRIER-NEXT: %[[FALSE_WAIT:.*]] = arith.constant false
+// BARRIER-NEXT: %[[PHASE:.*]] = arith.constant 0 : i32
+// BARRIER-NEXT: ttng.wait_barrier %arg0, %[[PHASE]], %[[FALSE_WAIT]] deps %arg2 :
+// BARRIER-NEXT: ttng.wait_barrier %arg0, %[[PHASE]], %arg1 :
+// BARRIER-NEXT: ttng.tc_gen5_commit %arg0, %arg1 :
+// BARRIER-NEXT: tt.return
+tt.func @false_barrier_predicates(%bar: !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>, %pred: i1, %mem: !ttg.memdesc<16x64xf16, #shared_tma, #smem, mutable>) {
+  %false = arith.constant false
+  %phase = arith.constant 0 : i32
+  ttng.barrier_expect %bar, 1048576, %false : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
+  ttng.arrive_barrier %bar, 1, %false : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
+  ttng.wait_barrier %bar, %phase, %false : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
+  ttng.tc_gen5_commit %bar, %false : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
+  ttng.wait_barrier %bar, %phase, %false deps %mem : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>, !ttg.memdesc<16x64xf16, #shared_tma, #smem, mutable>
+  ttng.wait_barrier %bar, %phase, %pred : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
+  ttng.tc_gen5_commit %bar, %pred : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
+  tt.return
+}
+
+// BARRIER-LABEL: @false_tma_predicates
+// BARRIER-NEXT: tt.return
+tt.func @false_tma_predicates(%desc: !tt.tensordesc<16x64xf16, #shared_tma>, %gather: !tt.tensordesc<1x64xf16, #shared_tma>, %mem: !ttg.memdesc<16x64xf16, #shared_tma, #smem, mutable>, %bar: !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>, %rows: tensor<16xi32, #offsets>) {
+  %false = arith.constant false
+  %zero = arith.constant 0 : i32
+  ttng.async_tma_copy_global_to_local %desc[%zero, %zero] %mem, %bar, %false : !tt.tensordesc<16x64xf16, #shared_tma>, !ttg.memdesc<1xi64, #local_barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared_tma, #smem, mutable>
+  ttng.async_tma_gather %gather[%rows, %zero] %mem, %bar, %false : !tt.tensordesc<1x64xf16, #shared_tma>, tensor<16xi32, #offsets>, i32, !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>, !ttg.memdesc<16x64xf16, #shared_tma, #smem, mutable>, i1
+  tt.return
+}
+
+// BARRIER-LABEL: @false_tmem_store
+// BARRIER-NEXT: tt.return
+tt.func @false_tmem_store(%value: tensor<128x128xf32, #data>, %mem: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+  %false = arith.constant false
+  ttng.tmem_store %value, %mem, %false : tensor<128x128xf32, #data> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  tt.return
+}
+
+// The predicate disables MMA, while the independent completion predicate stays true.
+// BARRIER-LABEL: @false_mma_keeps_completion
+// BARRIER: %[[FALSE:.*]] = arith.constant false
+// BARRIER: ttng.tc_gen5_mma %arg0, %arg1, %arg2, %[[FALSE]], %[[FALSE]], %arg3[
+// BARRIER-NEXT: tt.return
+tt.func @false_mma_keeps_completion(%a: !ttg.memdesc<128x128xf16, #shared_a, #smem>, %b: !ttg.memdesc<128x128xf16, #shared_b, #smem>, %d: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %bar: !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>) {
+  %false = arith.constant false
+  %true = arith.constant true
+  ttng.tc_gen5_mma %a, %b, %d, %false, %false, %bar[%true] {is_async} : !ttg.memdesc<128x128xf16, #shared_a, #smem>, !ttg.memdesc<128x128xf16, #shared_b, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
+  tt.return
+}
+
+// BARRIER-LABEL: @false_tmem_store_keeps_token
+// BARRIER: %[[TOKEN:.*]] = ttng.tmem_store
+// BARRIER-NEXT: tt.return %[[TOKEN]] : !ttg.async.token
+tt.func @false_tmem_store_keeps_token(%value: tensor<128x128xf32, #data>, %mem: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dep: !ttg.async.token) -> !ttg.async.token {
+  %false = arith.constant false
+  %token = ttng.tmem_store %value, %mem[%dep], %false : tensor<128x128xf32, #data> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  tt.return %token : !ttg.async.token
+}
+}

--- a/test/TritonNvidiaGPU/canonicalize.mlir
+++ b/test/TritonNvidiaGPU/canonicalize.mlir
@@ -69,6 +69,7 @@ tt.func @false_barrier_predicates(%bar: !ttg.memdesc<1xi64, #local_barrier, #sme
   ttng.arrive_barrier %bar, 1, %false : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
   ttng.wait_barrier %bar, %phase, %false : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
   ttng.tc_gen5_commit %bar, %false : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
+  // Keep the dependency-bearing wait so %mem stays live until the wait.
   ttng.wait_barrier %bar, %phase, %false deps %mem : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>, !ttg.memdesc<16x64xf16, #shared_tma, #smem, mutable>
   ttng.wait_barrier %bar, %phase, %pred : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>
   ttng.tc_gen5_commit %bar, %pred : !ttg.memdesc<1xi64, #local_barrier, #smem, mutable>


### PR DESCRIPTION
Fold constant-false predicates for stores and NVIDIA barrier, TMA, and tensor-memory operations when they suppress all effects. Preserve dependency-carrying waits and operations with independent effects or results, and enable the folds in Gluon canonicalization.