### PR TITLE
[MEMBAR] Distribute TMA expectations across producer warps

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.td
@@ -38,6 +38,11 @@ def TMALoadLikeOpInterface : OpInterface<"TMALoadLikeOpInterface", [TMAOpInterfa
       /*methodName=*/"getBarrier",
       /*args=*/(ins)>,
     InterfaceMethod<
+      /*desc=*/"Get the completion barrier operand",
+      /*retType=*/"::mlir::OpOperand&",
+      /*methodName=*/"getBarrierMutable",
+      /*args=*/(ins)>,
+    InterfaceMethod<
       /*desc=*/"Get the predicate",
       /*retType=*/"::mlir::Value",
       /*methodName=*/"getPred",

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -320,7 +320,7 @@ def TTNG_InvalBarrierOp : TTNG_Op<"inval_barrier", [
 }
 
 def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [
-    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier", "isPerWarp"]>,
     DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
   let summary = "Signal a barrier of an expected number of bytes to be copied.";
 
@@ -330,6 +330,12 @@ def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [
     been copied. The optional `fromCTA` attribute is a CTA-ID
     basis-selection mask: set bits are preserved and unset bits are zeroed
     when selecting the CTA that routes the arrival to each per-CTA barrier.
+
+    The compiler-owned `per_warp` flag distributes the expectation
+    across the execution region's warps in a one-CTA kernel. Each warp publishes
+    its prior effects and contributes one arrival and an equal share of the
+    expected bytes. The barrier's initialization count must be scaled to match;
+    `size` remains the total byte count.
   }];
 
   let hasVerifier = 1;
@@ -338,13 +344,14 @@ def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [
     Arg<TTG_MemDescType, "", BarrierSharedWrite>:$alloc,
     I32Attr:$size,
     I1:$pred,
-    OptionalAttr<I32Attr>:$fromCTA
+    OptionalAttr<I32Attr>:$fromCTA,
+    UnitAttr:$per_warp
   );
 
   let builders = [
     OpBuilder<(ins "Value":$alloc, "uint32_t":$size, "Value":$pred), [{
-      build($_builder, $_state, alloc, $_builder.getI32IntegerAttr(size), pred,
-            /*fromCTA=*/IntegerAttr());
+      build($_builder, $_state, alloc, size, pred, /*fromCTA=*/IntegerAttr(),
+            /*per_warp=*/false);
     }]>
   ];
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -425,6 +425,14 @@ static LogicalResult canonicalizeBarrierFromCTA(BarrierOp op,
 LogicalResult BarrierExpectOp::verify() {
   if (failed(verifyBarrierFromCTA(*this, getAlloc(), getFromCTA())))
     return failure();
+  if (getPerWarp()) {
+    int numWarps = gpu::lookupNumWarps(*this);
+    if (numWarps <= 1 || getSize() % numWarps != 0)
+      return emitOpError("per_warp requires multiple warps and size divisible "
+                         "by the warp count");
+    if (gpu::lookupNumCTAs(*this) != 1)
+      return emitOpError("distributed expectation requires one CTA");
+  }
   return success();
 }
 
@@ -436,6 +444,8 @@ LogicalResult BarrierExpectOp::canonicalize(BarrierExpectOp op,
 }
 
 TypedValue<MemDescType> BarrierExpectOp::getBarrier() { return getAlloc(); }
+
+bool BarrierExpectOp::isPerWarp() { return getPerWarp(); }
 
 Value BarrierExpectOp::getPredicateOperand() { return getPred(); }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -174,7 +174,8 @@ public:
       info->pred = expectOp.getPred();
       info->barriers.push_back(
           {expectOp.getBarrier(), nullptr,
-           /*count=*/1, MemEffectsOpInfo::BarrierTrackingMode::Frontier,
+           expectOp.getPerWarp() ? ttg::lookupNumWarps(expectOp) : 1,
+           MemEffectsOpInfo::BarrierTrackingMode::Frontier,
            /*txCount=*/static_cast<int>(expectOp.getSize())});
     }
     if (auto copyOp = dyn_cast<ttng::TMEMCopyOp>(op)) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeMBarrierArrivals.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeMBarrierArrivals.cpp
@@ -59,6 +59,8 @@ static DescriptorForwarding collectDescriptorForwarding(ModuleOp mod) {
 struct BarrierUses {
   SmallVector<InitBarrierOp> inits;
   SmallVector<ArriveBarrierOp> arrivals;
+  SmallVector<BarrierExpectOp> expects;
+  bool hasTMA = false;
 };
 
 // Follow views and forwarded descriptors without accepting escapes or joins
@@ -96,10 +98,19 @@ static LogicalResult collectBarrierUses(gpu::LocalAllocOp alloc,
       // Wait dependencies only keep their allocations live.
       if (isa<WaitBarrierOp>(user))
         continue;
+      if (auto tma = dyn_cast<TMALoadLikeOpInterface>(user)) {
+        // The same allocation used as a TMA payload is not a closed barrier.
+        if (&use != &tma.getBarrierMutable())
+          return failure();
+        uses.hasTMA = true;
+        continue;
+      }
       if (auto init = dyn_cast<InitBarrierOp>(user)) {
         uses.inits.push_back(init);
       } else if (auto arrive = dyn_cast<ArriveBarrierOp>(user)) {
         uses.arrivals.push_back(arrive);
+      } else if (auto expect = dyn_cast<BarrierExpectOp>(user)) {
+        uses.expects.push_back(expect);
       } else if (!isa<InvalBarrierOp, gpu::LocalDeallocOp>(user)) {
         return failure();
       }
@@ -112,25 +123,48 @@ static LogicalResult collectBarrierUses(gpu::LocalAllocOp alloc,
 static uint64_t
 getDistributionScale(const BarrierUses &uses,
                      llvm::function_ref<bool(Operation *)> usePerWarp) {
-  if (uses.inits.empty() || !llvm::any_of(uses.arrivals, usePerWarp))
+  if (uses.inits.empty() || (!llvm::any_of(uses.arrivals, usePerWarp) &&
+                             !llvm::any_of(uses.expects, usePerWarp)))
     return 0;
   constexpr uint64_t maxCount = (1 << 20) - 1;
   uint64_t scale = 1;
-  for (ArriveBarrierOp arrive : uses.arrivals) {
-    if (!usePerWarp(arrive))
-      continue;
-    uint64_t numWarps = gpu::lookupNumWarps(arrive);
-    // The smallest scale making each count divisible by its warp count.
-    scale = std::lcm(
-        scale, numWarps / std::gcd(numWarps, uint64_t(arrive.getCount())));
-  }
-  for (ArriveBarrierOp arrive : uses.arrivals)
-    if (arrive.getCount() > maxCount / scale)
+  if (!uses.expects.empty()) {
+    scale = gpu::lookupNumWarps(uses.expects.front());
+    if (!uses.arrivals.empty() || scale == 1 ||
+        gpu::lookupNumCTAs(uses.expects.front()) != 1)
       return 0;
+    uint64_t maxInitCount = 0;
+    for (InitBarrierOp init : uses.inits)
+      maxInitCount = std::max(maxInitCount, uint64_t(init.getCount()));
+    for (BarrierExpectOp expect : uses.expects) {
+      // A phase has at most maxInitCount expectations. Bound the transaction
+      // balance even when copies complete before other warps add their shares.
+      if (gpu::lookupNumWarps(expect) != scale ||
+          expect.getSize() > maxCount / maxInitCount ||
+          expect.getSize() % scale != 0)
+        return 0;
+    }
+  } else {
+    if (uses.hasTMA)
+      return 0;
+    for (ArriveBarrierOp arrive : uses.arrivals) {
+      if (!usePerWarp(arrive))
+        continue;
+      uint64_t numWarps = gpu::lookupNumWarps(arrive);
+      // The smallest scale making each count divisible by its warp count.
+      scale = std::lcm(
+          scale, numWarps / std::gcd(numWarps, uint64_t(arrive.getCount())));
+    }
+    for (ArriveBarrierOp arrive : uses.arrivals)
+      if (arrive.getCount() > maxCount / scale)
+        return 0;
+  }
   for (InitBarrierOp init : uses.inits) {
     // Lowering counts all CTAs that contribute to the same physical barrier.
     uint64_t ctasPerBarrier =
-        gpu::lookupNumCTAs(init) / init.getAlloc().getType().getNumElements();
+        uses.expects.empty() ? gpu::lookupNumCTAs(init) /
+                                   init.getAlloc().getType().getNumElements()
+                             : 1;
     if (init.getCount() > maxCount / scale / ctasPerBarrier)
       return 0;
   }
@@ -244,6 +278,9 @@ struct OptimizeMBarrierArrivalsPass
       for (ArriveBarrierOp arrive : uses.arrivals)
         if (scalarOps.contains(arrive))
           arrive.setPerWarp(false);
+      for (BarrierExpectOp expect : uses.expects)
+        if (scalarOps.contains(expect))
+          expect.setPerWarp(false);
 
       uint64_t scale = getDistributionScale(uses, isPerWarp);
       if (!scale)
@@ -255,6 +292,16 @@ struct OptimizeMBarrierArrivalsPass
       for (ArriveBarrierOp arrive : uses.arrivals)
         arrive.setCountAttr(
             builder.getI32IntegerAttr(arrive.getCount() * scale));
+      for (BarrierExpectOp expect : uses.expects) {
+        if (expect.getPerWarp())
+          continue;
+        builder.setInsertionPointAfter(expect);
+        // Register all bytes before supplying the remaining arrivals.
+        auto arrive =
+            ArriveBarrierOp::create(builder, expect.getLoc(), expect.getAlloc(),
+                                    scale - 1, expect.getPred());
+        arrive.setFromCTAAttr(expect.getFromCTAAttr());
+      }
     });
   }
 };
@@ -292,6 +339,8 @@ void prepareMBarrierArrivals(ModuleOp mod, BufferRegionAnalysis &regions,
     if (failed(collectBarrierUses(alloc, forwarding, regions, uses)) ||
         !getDistributionScale(uses, [](Operation *) { return true; }))
       return;
+    for (BarrierExpectOp expect : uses.expects)
+      expect.setPerWarp(true);
     for (ArriveBarrierOp arrive : uses.arrivals)
       if (gpu::lookupNumWarps(arrive) > 1)
         arrive.setPerWarp(true);

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -546,6 +546,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
+  // The helper's two warps split the bytes and preserve identity routing.
+  // CHECK-LABEL: expect_barrier_distributed
+  // CHECK: nvvm.elect.sync
+  // CHECK-NOT: nvvm.read.ptx.sreg.tid.x
+  // CHECK: @$0 mbarrier.arrive.expect_tx.shared::cta.b64 _, [$1], 8192;
+  tt.func private @expect_barrier_distributed(%barrier: !ttg.memdesc<1xi64, #shared0, #smem, mutable>, %pred: i1) attributes {noinline = true, "ttg.num-warps" = 2 : i32} {
+    ttng.barrier_expect %barrier, 16384 {fromCTA = 0 : i32, per_warp}, %pred : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
+    tt.return
+  }
 }
 
 // -----

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1,6 +1,33 @@
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritoninstrument-prepare-consan-captures="target=nvidia" -tritoninstrument-concurrency-sanitizer | FileCheck %s --implicit-check-not=cluster_waiting --implicit-check-not=always_use_warp_shuffle
 // RUN: env TRITON_CONSAN_INIT_ALLOCATIONS=0 triton-opt %s -split-input-file -allow-unregistered-dialect -tritoninstrument-prepare-consan-captures="target=nvidia" -tritoninstrument-concurrency-sanitizer | FileCheck %s --check-prefix=NO-INIT
 
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 2056 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // Track four total arrivals and the original total bytes, not per-warp bytes.
+  // CHECK-LABEL: @distributed_expect
+  // CHECK: ttng.init_barrier
+  // CHECK: %[[COUNT:.*]] = arith.constant 4 : i32
+  // CHECK-NEXT: %[[BYTES:.*]] = arith.constant 2048 : i64
+  // CHECK: tt.call @__triton_consan_verify_and_update_barrier_state{{.*}}({{[^,]+}}, {{[^,]+}}, %[[COUNT]], %[[BYTES]],
+  // CHECK: ttng.barrier_expect {{.*}}, 2048 {per_warp},
+  tt.func public @distributed_expect(%desc: !tt.tensordesc<16x64xf16, #shared>) {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %mem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 2048 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.init_barrier %bar, 4 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %bar, 2048 {per_warp}, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %mem, %bar, %true : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory

--- a/test/TritonNvidiaGPU/membar.mlir
+++ b/test/TritonNvidiaGPU/membar.mlir
@@ -412,6 +412,106 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
+  // Scalar and distributed expectations contribute to the same phase.
+  // FOLD-LABEL: @multiple_expectations_per_phase
+  // FOLD: ttng.init_barrier {{.*}}, 8 :
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: ttng.barrier_expect %[[BAR:.*]], 0 {fromCTA = 0 : i32}, %[[PRED:.*]] :
+  // FOLD-NEXT: ttng.arrive_barrier %[[BAR]], 3, %[[PRED]] {fromCTA = 0 : i32} :
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: tt.store
+  // FOLD-NEXT: ttg.barrier warp local
+  // FOLD-NEXT: ttng.barrier_expect %[[BAR]], 0 {per_warp}, %[[PRED]] :
+  tt.func @multiple_expectations_per_phase(%pred: i1, %out: !tt.ptr<i32>, %value: i32) {
+    %phase = arith.constant 0 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.barrier_expect %bar, 0 {fromCTA = 0 : i32}, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.barrier local
+    tt.store %out, %value : !tt.ptr<i32>
+    ttng.barrier_expect %bar, 0, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %phase, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // A later predecessor adds loop-entry synchronization. Replay must discard
+  // the store effects propagated to the exit before that barrier was inserted.
+  // FOLD-LABEL: @expectation_after_converged_loop_entry_barrier
+  // FOLD: ttng.init_barrier %[[BAR:.*]], 1 :
+  // FOLD: tt.store
+  // FOLD-NEXT: cf.cond_br %{{.*}}, ^[[PREHEADER:bb[0-9]+]], ^[[SLOW:bb[0-9]+]]
+  // FOLD: ^[[SLOW]]:
+  // FOLD-NEXT: ttng.async_tma_store_wait
+  // FOLD-NEXT: cf.br ^[[PREHEADER]]
+  // FOLD: ^[[PREHEADER]]:
+  // FOLD-NEXT: %[[MORE:.*]] = arith.cmpi
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: cf.cond_br %[[MORE]], ^{{bb[0-9]+}}(%{{.*}} : i32), ^[[DONE:bb[0-9]+]]
+  // FOLD-NOT: ttg.barrier warp
+  // FOLD: ^[[DONE]]:
+  // FOLD-NEXT: ttng.barrier_expect %[[BAR]], 0, %{{.*}} :
+  // FOLD-NEXT: ttng.wait_barrier
+  // FOLD-NOT: ttng.arrive_barrier
+  // FOLD: tt.return
+  tt.func @expectation_after_converged_loop_entry_barrier(%out: !tt.ptr<i32>, %value: i32, %condition: i1, %iterations: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.barrier local
+    tt.store %out, %value : !tt.ptr<i32>
+    cf.cond_br %condition, ^preheader, ^slow
+  ^slow:
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    cf.br ^preheader
+  ^preheader:
+    %more = arith.cmpi slt, %c0, %iterations : i32
+    cf.cond_br %more, ^loop(%c0 : i32), ^done
+  ^loop(%i: i32):
+    %next = arith.addi %i, %c1 : i32
+    %again = arith.cmpi slt, %next, %iterations : i32
+    cf.cond_br %again, ^loop(%next : i32), ^done
+  ^done:
+    ttng.barrier_expect %bar, 0, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // Bound both physical arrivals and total bytes across a phase. These
+  // barriers have no asynchronous users and can be invalidated while pending.
+  // FOLD-LABEL: @expectation_count_limits
+  // FOLD: ttng.init_barrier {{.*}}, 1048572 :
+  // FOLD: ttng.init_barrier {{.*}}, 262144 :
+  // FOLD: ttng.init_barrier {{.*}}, 8 :
+  // FOLD: ttng.init_barrier {{.*}}, 2 :
+  // FOLD: ttng.barrier_expect {{.*}}, 0 {per_warp},
+  // FOLD: ttng.barrier_expect {{.*}}, 524284 {per_warp},
+  // FOLD: ttng.barrier_expect {{.*}}, 0,
+  // FOLD: ttng.barrier_expect {{.*}}, 524288,
+  tt.func @expectation_count_limits(%pred: i1, %out: !tt.ptr<i32>, %value: i32) {
+    %a = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %a, 262143 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %b, 262144 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %c = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %c, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %d = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %d, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.barrier local
+    tt.store %out, %value : !tt.ptr<i32>
+    ttng.barrier_expect %a, 0, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.barrier_expect %c, 524284, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.barrier_expect %b, 0, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.barrier_expect %d, 524288, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.inval_barrier %a : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.inval_barrier %b : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.inval_barrier %c : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.inval_barrier %d : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
 
   // Descriptor joins are rejected as a whole, including their direct users.
   // FOLD-LABEL: @arrival_with_selected_barrier
@@ -525,8 +625,64 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // Expectations follow captured and loop-carried views of one allocation.
+  // PREP-LABEL: @distributed_expect_loop_carried_view
+  // PREP: ttng.init_barrier {{.*}}, 1 :
+  // PREP: ttng.barrier_expect {{.*}}, 0 {per_warp},
+  // PREP: ttng.inval_barrier
+  tt.func @distributed_expect_loop_carried_view(%n: i32, %index: i32) {
+    %bars = ttg.local_alloc : () -> !ttg.memdesc<2x1xi64, #shared, #smem, mutable>
+    %bar = ttg.memdesc_index %bars[%index] : !ttg.memdesc<2x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.warp_specialize(%n, %index, %bars, %bar)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%limit: i32, %idx: i32, %storage: !ttg.memdesc<2x1xi64, #shared, #smem, mutable>, %initial: !ttg.memdesc<1xi64, #shared, #smem, mutable>) num_warps(4) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %true = arith.constant true
+      %result:2 = scf.for %i = %c0 to %limit step %c1 iter_args(%iter = %initial, %phase = %c0) -> (!ttg.memdesc<1xi64, #shared, #smem, mutable>, i32) : i32 {
+        ttng.barrier_expect %iter, 0, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+        ttng.wait_barrier %iter, %phase : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+        %next = ttg.memdesc_index %storage[%idx] : !ttg.memdesc<2x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+        %next_phase = arith.xori %phase, %c1 : i32
+        scf.yield %next, %next_phase : !ttg.memdesc<1xi64, #shared, #smem, mutable>, i32
+      }
+      ttng.inval_barrier %result#0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttg.warp_return
+    } : (i32, i32, !ttg.memdesc<2x1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>) -> ()
+    tt.return
+  }
 
-
+  // Different-width producers can own successive phases of the same barrier.
+  // FOLD-LABEL: @expectations_with_different_warp_counts
+  // FOLD: ttng.init_barrier {{.*}}, 1 :
+  // FOLD: ttng.barrier_expect {{.*}}, 0,
+  // FOLD: ttng.barrier_expect {{.*}}, 0,
+  tt.func @expectations_with_different_warp_counts(%out: !tt.ptr<i32>, %value: i32) {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.barrier local
+    tt.store %out, %value : !tt.ptr<i32>
+    ttng.barrier_expect %bar, 0, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.warp_specialize(%bar)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%captured: !ttg.memdesc<1xi64, #shared, #smem, mutable>) num_warps(2) {
+      %c1 = arith.constant 1 : i32
+      %pred = arith.constant true
+      ttng.barrier_expect %captured, 0, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttng.wait_barrier %captured, %c1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<1xi64, #shared, #smem, mutable>) -> ()
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
 
   // Descriptor forwarding preserves the common software count scale.
   // FOLD-LABEL: @software_arrival_same_allocation_join
@@ -555,4 +711,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Per-warp publication does not order another warp's old payload read.
+  // FOLD-LABEL: @distributed_expect_keeps_payload_war
+  // FOLD: ttg.local_load
+  // FOLD-NEXT: ttg.barrier warp local
+  // FOLD-NEXT: ttng.barrier_expect {{.*}}, 2048 {per_warp},
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: ttng.async_tma_copy_global_to_local
+  // FOLD-NEXT: ttng.wait_barrier
+  // FOLD-NEXT: ttg.barrier local
+  // FOLD-NEXT: ttng.inval_barrier
+  tt.func @distributed_expect_keeps_payload_war(%desc: !tt.tensordesc<16x64xf16, #shared>, %data: tensor<16x64xf16, #blocked>) -> tensor<16x64xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    %mem = ttg.local_alloc %data : (tensor<16x64xf16, #blocked>) -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttg.barrier local
+    %old = ttg.local_load %mem : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
+    ttng.barrier_expect %bar, 2048, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %mem, %bar, %true : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.inval_barrier %bar : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return %old : tensor<16x64xf16, #blocked>
+  }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -266,23 +266,32 @@ struct BarrierExpectConversion
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
         loc, adaptor.getAlloc(),
         typeConverter->convertType(barrierTy.getElementType()), rewriter);
-    // The partition-relative thread ID lowers the same or marginally better
-    // than an elect: LOP3.LUT vs. ELECT + ISETP.EQ.U32.AND.
-    Value id = getThreadId(rewriter, loc);
-    Value pred = b.icmp_eq(id, b.i32_val(0));
+    Value pred;
+    unsigned size = op.getSize();
     bool isCrossClusterBarrier =
         LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;
     Value barrierPtr = LLVM::NVIDIA::getLeaderAddress(
         loc, rewriter, smemObj.getBase(), barrierTy);
     Value multicastMask;
-    if (std::optional<uint32_t> fromCTA = op.getFromCTA()) {
-      FromCTALowering lowering =
-          getFromCTALowering(loc, rewriter, smemObj.getBase(), id, *fromCTA,
-                             supportsMBarrierMulticast);
-      pred = lowering.pred;
-      barrierPtr = lowering.barrierPtr;
-      multicastMask = lowering.multicastMask;
-      isCrossClusterBarrier = true;
+    if (op.getPerWarp()) {
+      // Match the fixed full-mask leader used by each warp's TMA copies.
+      // One-CTA expectations have only identity routing.
+      pred = LLVM::NVIDIA::createElectPredicate(loc, rewriter);
+      size /= ttg::lookupNumWarps(op);
+    } else {
+      // The partition-relative thread ID lowers the same or marginally better
+      // than a warp-zero elect: LOP3.LUT vs. ELECT + ISETP.EQ.U32.AND.
+      Value id = getThreadId(rewriter, loc);
+      pred = b.icmp_eq(id, b.i32_val(0));
+      if (std::optional<uint32_t> fromCTA = op.getFromCTA()) {
+        FromCTALowering lowering =
+            getFromCTALowering(loc, rewriter, smemObj.getBase(), id, *fromCTA,
+                               supportsMBarrierMulticast);
+        pred = lowering.pred;
+        barrierPtr = lowering.barrierPtr;
+        multicastMask = lowering.multicastMask;
+        isCrossClusterBarrier = true;
+      }
     }
     pred = b.and_(pred, adaptor.getPred());
 
@@ -291,7 +300,7 @@ struct BarrierExpectConversion
         "@$0 mbarrier.arrive.expect_tx." +
         std::string(isCrossClusterBarrier ? "shared::cluster" : "shared::cta") +
         std::string(multicastMask ? ".multicast::cluster::32b" : "") +
-        ".b64 _, [$1], " + std::to_string(op.getSize()) +
+        ".b64 _, [$1], " + std::to_string(size) +
         std::string(multicastMask ? ", $2" : "") + ";";
     auto &expectOp = *expectPtxBuilder.create(expectPtx);
     SmallVector<PTXBuilder::Operand *, 3> operands = {


### PR DESCRIPTION
Distribute TMA expectations across producer warps using the same delayed finalization as software arrivals. Fully scalar groups keep their original counts; mixed groups receive compensating arrivals.

Stacked on #11573.
