### PR TITLE
[BAKCEND] Use native FP16/BF16 conversions on SM90+

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -41,28 +41,6 @@ def launch_type_convert_triton(src, src_dtype, dst_dtype, device, rounding=None,
     return dst
 
 
-@pytest.mark.parametrize("block_size", [32, 256, 1024])
-def test_bf16_to_fp16_exhaustive(block_size, device):
-    # Cover every BF16 bit pattern, including signed zeros, subnormals,
-    # overflow, infinities, and NaNs. Compute the reference on the CPU.
-    src_cpu = torch.arange(65536, dtype=torch.int32).to(torch.int16).view(torch.bfloat16)
-    expected = src_cpu.to(torch.float16).to(device)
-    src = src_cpu.to(device)
-    dst = torch.empty_like(src, dtype=torch.float16)
-    kernel = type_convert_triton[(src.numel() // block_size,)](src, dst, None, block_size)
-
-    nan = torch.isnan(expected)
-    assert torch.equal(torch.isnan(dst), nan)
-    assert torch.equal(dst.view(torch.int16)[~nan], expected.view(torch.int16)[~nan])
-    if is_cuda():
-        if torch.cuda.get_device_capability()[0] >= 9:
-            assert "cvt.rn.f16.bf16" in kernel.asm["ptx"]
-            assert "cvt.f32.bf16" not in kernel.asm["ptx"]
-            assert "cvt.rn.f16.f32" not in kernel.asm["ptx"]
-        else:
-            assert "cvt.rn.f16.bf16" not in kernel.asm["ptx"]
-
-
 @triton.jit
 def exhaustive_populate(dst, offset, BLOCK_SIZE : tl.constexpr, force_odd : tl.constexpr, output_bits : tl.constexpr, max_repr : tl.constexpr):
 

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -41,6 +41,28 @@ def launch_type_convert_triton(src, src_dtype, dst_dtype, device, rounding=None,
     return dst
 
 
+@pytest.mark.parametrize("block_size", [32, 256, 1024])
+def test_bf16_to_fp16_exhaustive(block_size, device):
+    # Cover every BF16 bit pattern, including signed zeros, subnormals,
+    # overflow, infinities, and NaNs. Compute the reference on the CPU.
+    src_cpu = torch.arange(65536, dtype=torch.int32).to(torch.int16).view(torch.bfloat16)
+    expected = src_cpu.to(torch.float16).to(device)
+    src = src_cpu.to(device)
+    dst = torch.empty_like(src, dtype=torch.float16)
+    kernel = type_convert_triton[(src.numel() // block_size,)](src, dst, None, block_size)
+
+    nan = torch.isnan(expected)
+    assert torch.equal(torch.isnan(dst), nan)
+    assert torch.equal(dst.view(torch.int16)[~nan], expected.view(torch.int16)[~nan])
+    if is_cuda():
+        if torch.cuda.get_device_capability()[0] >= 9:
+            assert "cvt.rn.f16.bf16" in kernel.asm["ptx"]
+            assert "cvt.f32.bf16" not in kernel.asm["ptx"]
+            assert "cvt.rn.f16.f32" not in kernel.asm["ptx"]
+        else:
+            assert "cvt.rn.f16.bf16" not in kernel.asm["ptx"]
+
+
 @triton.jit
 def exhaustive_populate(dst, offset, BLOCK_SIZE : tl.constexpr, force_odd : tl.constexpr, output_bits : tl.constexpr, max_repr : tl.constexpr):
 

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -41,20 +41,21 @@ def anchor(v):
 
 
 @pytest.mark.parametrize("scalar", [True, False])
-def test_bf16_to_fp16_cast(scalar):
+@pytest.mark.parametrize("src_dtype, dst_dtype", [(tl.bfloat16, tl.float16), (tl.float16, tl.bfloat16)])
+def test_fp16_bf16_cast(scalar, src_dtype, dst_dtype):
 
     @triton.jit
-    def kernel(X, SCALAR: tl.constexpr):
+    def kernel(X, SCALAR: tl.constexpr, DTYPE: tl.constexpr):
         if not SCALAR:
             X = X + tl.arange(0, 32)
         # CHECK: [[X:%.*]] = tt.load
         x = tl.load(X)
         # CHECK-NEXT: [[Y:%.*]] = tt.fp_to_fp [[X]], rounding = rtne
-        y = x.to(tl.float16)
+        y = x.to(DTYPE)
         # CHECK-NEXT: tt.call {{.*}}([[Y]])
         anchor(y)
 
-    run_filecheck_test(kernel, args=(MockTensor(tl.bfloat16), scalar))
+    run_filecheck_test(kernel, args=(MockTensor(src_dtype), scalar, dst_dtype))
 
 
 @pytest.mark.parametrize("dtype",

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -40,6 +40,23 @@ def anchor(v):
     pass
 
 
+@pytest.mark.parametrize("scalar", [True, False])
+def test_bf16_to_fp16_cast(scalar):
+
+    @triton.jit
+    def kernel(X, SCALAR: tl.constexpr):
+        if not SCALAR:
+            X = X + tl.arange(0, 32)
+        # CHECK: [[X:%.*]] = tt.load
+        x = tl.load(X)
+        # CHECK-NEXT: [[Y:%.*]] = tt.fp_to_fp [[X]], rounding = rtne
+        y = x.to(tl.float16)
+        # CHECK-NEXT: tt.call {{.*}}([[Y]])
+        anchor(y)
+
+    run_filecheck_test(kernel, args=(MockTensor(tl.bfloat16), scalar))
+
+
 @pytest.mark.parametrize("dtype",
                          [tl.float16, tl.bfloat16, tl.float32, tl.float64, tl.float8e4nv, tl.float8e5, tl.float8e4b15],
                          ids=str)

--- a/python/test/unit/runtime/test_interpreter.py
+++ b/python/test/unit/runtime/test_interpreter.py
@@ -27,6 +27,14 @@ def test_bf16_to_fp16_rounding_and_overflow():
     np.testing.assert_array_equal(result.data.view(np.uint16), expected)
 
 
+def test_fp16_to_bf16_exact_values():
+    bits = np.array([0x0000, 0x8000, 0x3C00, 0xBC00, 0x3C08, 0x0001, 0x7C00, 0xFC00, 0x7E00], dtype=np.uint16)
+    expected = np.array([0x0000, 0x8000, 0x3F80, 0xBF80, 0x3F81, 0x3380, 0x7F80, 0xFF80, 0x7FC0], dtype=np.uint16)
+    src = interpreter.TensorHandle(bits.view(np.float16), tl.float16)
+    result = interpreter.InterpreterBuilder().create_fp_to_fp(src, tl.bfloat16, ir.ROUNDING_MODE.RTNE)
+    np.testing.assert_array_equal(result.data, expected)
+
+
 def test_atomic_poll_tensor_shares_timeout(monkeypatch) -> None:
     builder = interpreter.InterpreterBuilder()
     data = np.array([0, 0, 1], dtype=np.int32)

--- a/python/test/unit/runtime/test_interpreter.py
+++ b/python/test/unit/runtime/test_interpreter.py
@@ -14,6 +14,19 @@ def _element_ptrs(array: np.ndarray) -> np.ndarray:
     return (base + offsets).reshape(array.shape)
 
 
+def test_bf16_to_fp16_rounding_and_overflow():
+    # Signed zeros, finite values, overflow, subnormal rounding, and infinities.
+    bits = np.array([0x0000, 0x8000, 0x3F80, 0xBF80, 0x4781, 0xC781, 0x3300, 0x3301, 0x33C0, 0xB3C0, 0x7F80, 0xFF80],
+                    dtype=np.uint16)
+    expected = np.array(
+        [0x0000, 0x8000, 0x3C00, 0xBC00, 0x7C00, 0xFC00, 0x0000, 0x0001, 0x0002, 0x8002, 0x7C00, 0xFC00],
+        dtype=np.uint16)
+    src = interpreter.TensorHandle(bits, tl.bfloat16)
+    with np.errstate(over="ignore"):
+        result = interpreter.InterpreterBuilder().create_fp_to_fp(src, tl.float16, ir.ROUNDING_MODE.RTNE)
+    np.testing.assert_array_equal(result.data.view(np.uint16), expected)
+
+
 def test_atomic_poll_tensor_shares_timeout(monkeypatch) -> None:
     builder = interpreter.InterpreterBuilder()
     data = np.array([0, 0, 1], dtype=np.int32)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -830,8 +830,8 @@ class TritonSemantic(Generic[TensorTy]):
                                  "Source scalar type is " + str(src_sca_ty) + " and destination type is " +
                                  str(dst_sca_ty))
 
-        # Keep BF16 -> FP16 intact so backends can select a native conversion.
-        if src_sca_ty.is_bf16() and dst_sca_ty.is_fp16():
+        # Keep FP16 <-> BF16 intact so backends can select a native conversion.
+        if (src_sca_ty.is_bf16() and dst_sca_ty.is_fp16()) or (src_sca_ty.is_fp16() and dst_sca_ty.is_bf16()):
             return self.tensor(
                 self.builder.create_fp_to_fp(input.handle, dst_ty.to_ir(self.builder), ir.ROUNDING_MODE.RTNE), dst_ty)
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -830,6 +830,11 @@ class TritonSemantic(Generic[TensorTy]):
                                  "Source scalar type is " + str(src_sca_ty) + " and destination type is " +
                                  str(dst_sca_ty))
 
+        # Keep BF16 -> FP16 intact so backends can select a native conversion.
+        if src_sca_ty.is_bf16() and dst_sca_ty.is_fp16():
+            return self.tensor(
+                self.builder.create_fp_to_fp(input.handle, dst_ty.to_ir(self.builder), ir.ROUNDING_MODE.RTNE), dst_ty)
+
         if (src_sca_ty.is_fp8e4b15() or dst_sca_ty.is_fp8e4b15()):
             assert self.builder.codegen_fns.get(
                 "convert_custom_types") is not None, "target doesn't provide conversion for this type."

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -564,6 +564,8 @@ class InterpreterBuilder:
     def create_fp_to_fp(self, src, dst_type, rounding_mode):
         src_element_type = src.dtype.scalar
         dst_element_type = dst_type.scalar
+        if src_element_type == tl.bfloat16 and dst_element_type == tl.float16:
+            return self.cast_impl(self.cast_impl(src, tl.float32), dst_type)
         data = _convert_float(src.data, src_element_type, dst_element_type, rounding_mode).view(_get_np_dtype(dst_type))
         return TensorHandle(data, dst_type.scalar)
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -564,7 +564,8 @@ class InterpreterBuilder:
     def create_fp_to_fp(self, src, dst_type, rounding_mode):
         src_element_type = src.dtype.scalar
         dst_element_type = dst_type.scalar
-        if src_element_type == tl.bfloat16 and dst_element_type == tl.float16:
+        if (src_element_type == tl.bfloat16 and dst_element_type == tl.float16) or \
+           (src_element_type == tl.float16 and dst_element_type == tl.bfloat16):
             return self.cast_impl(self.cast_impl(src, tl.float32), dst_type)
         data = _convert_float(src.data, src_element_type, dst_element_type, rounding_mode).view(_get_np_dtype(dst_type))
         return TensorHandle(data, dst_type.scalar)

--- a/test/Conversion/amd/fp_to_fp.mlir
+++ b/test/Conversion/amd/fp_to_fp.mlir
@@ -254,3 +254,17 @@ tt.func @test_scalar_conversion(%arg0: f32) -> f8E4M3FN {
   %0 = tt.fp_to_fp %arg0, rounding = rtne : f32 -> f8E4M3FN
   tt.return %0 : f8E4M3FN
 }
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // COMMON-LABEL: @bf16_to_fp16
+  // GFX942: llvm.fptrunc {{.*}} : f32 to f16
+  // GFX950: llvm.fptrunc {{.*}} : vector<2xf32> to vector<2xf16>
+  // COMMON: rocdl.cvt.pkrtz
+  tt.func private @bf16_to_fp16(%arg: bf16) -> (f16, f16) {
+    %rn = tt.fp_to_fp %arg : bf16 -> f16
+    %rz = tt.fp_to_fp %arg, rounding = rtz : bf16 -> f16
+    tt.return %rn, %rz : f16, f16
+  }
+}

--- a/test/Conversion/amd/fp_to_fp.mlir
+++ b/test/Conversion/amd/fp_to_fp.mlir
@@ -267,4 +267,18 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
     %rz = tt.fp_to_fp %arg, rounding = rtz : bf16 -> f16
     tt.return %rn, %rz : f16, f16
   }
+
+  // COMMON-LABEL: @fp16_to_bf16
+  // COMMON: llvm.fpext {{.*}} : f16 to f32
+  // GFX942: llvm.add
+  // GFX942: llvm.trunc {{.*}} : i32 to i16
+  // GFX950: llvm.fptrunc {{.*}} : vector<2xf32> to vector<2xbf16>
+  // COMMON: llvm.fpext {{.*}} : f16 to f32
+  // COMMON: llvm.lshr
+  // COMMON: llvm.trunc {{.*}} : i32 to i16
+  tt.func private @fp16_to_bf16(%arg: f16) -> (bf16, bf16) {
+    %rn = tt.fp_to_fp %arg : f16 -> bf16
+    %rz = tt.fp_to_fp %arg, rounding = rtz : f16 -> bf16
+    tt.return %rn, %rz : bf16, bf16
+  }
 }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -3578,3 +3578,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @bf16_to_fp16_fallback
+  // CHECK: llvm.fpext {{.*}} : bf16 to f32
+  // CHECK: llvm.inline_asm {{.*}} "cvt.rn.f16.f32 $0, $1;", "=h,r"
+  // CHECK: llvm.fpext {{.*}} : bf16 to f32
+  // CHECK: llvm.inline_asm {{.*}} "cvt.rz.f16.f32 $0, $1;", "=h,r"
+  tt.func private @bf16_to_fp16_fallback(%arg: bf16) -> (f16, f16) {
+    %rn = tt.fp_to_fp %arg : bf16 -> f16
+    %rz = tt.fp_to_fp %arg, rounding = rtz : bf16 -> f16
+    tt.return %rn, %rz : f16, f16
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -3592,4 +3592,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %rz = tt.fp_to_fp %arg, rounding = rtz : bf16 -> f16
     tt.return %rn, %rz : f16, f16
   }
+
+  // CHECK-LABEL: @fp16_to_bf16_fallback
+  // CHECK: llvm.fpext {{.*}} : f16 to f32
+  // CHECK: llvm.call_intrinsic "llvm.nvvm.f2bf16.rn"
+  // CHECK: llvm.fpext {{.*}} : f16 to f32
+  // CHECK: llvm.call_intrinsic "llvm.nvvm.f2bf16.rz"
+  tt.func private @fp16_to_bf16_fallback(%arg: f16) -> (bf16, bf16) {
+    %rn = tt.fp_to_fp %arg : f16 -> bf16
+    %rz = tt.fp_to_fp %arg, rounding = rtz : f16 -> bf16
+    tt.return %rn, %rz : bf16, bf16
+  }
 }

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv='compute-capability=90 ptx-version=81' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=81' | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv='compute-capability=90 ptx-version=77' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=77' | FileCheck %s --check-prefix=OLD-PTX
 
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @test_cluster_attr
@@ -713,4 +714,27 @@ tt.func @warpgroup_dot_wait_local_does_not_synchronize_warpgroups(%arg0: tensor<
   tt.return
 }
 
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @bf16_to_fp16
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.inline_asm {{.*}} "cvt.rn.f16.bf16 $0, $1;", "=h,h"
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.inline_asm {{.*}} "cvt.rz.f16.bf16 $0, $1;", "=h,h"
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.return
+  // OLD-PTX-LABEL: @bf16_to_fp16
+  // OLD-PTX: llvm.fpext {{.*}} : bf16 to f32
+  // OLD-PTX: llvm.inline_asm {{.*}} "cvt.rn.f16.f32 $0, $1;", "=h,r"
+  // OLD-PTX: llvm.fpext {{.*}} : bf16 to f32
+  // OLD-PTX: llvm.inline_asm {{.*}} "cvt.rz.f16.f32 $0, $1;", "=h,r"
+  tt.func private @bf16_to_fp16(%arg: tensor<128xbf16, #blocked>) -> (tensor<128xf16, #blocked>, tensor<128xf16, #blocked>) {
+    %rn = tt.fp_to_fp %arg : tensor<128xbf16, #blocked> -> tensor<128xf16, #blocked>
+    %rz = tt.fp_to_fp %arg, rounding = rtz : tensor<128xbf16, #blocked> -> tensor<128xf16, #blocked>
+    tt.return %rn, %rz : tensor<128xf16, #blocked>, tensor<128xf16, #blocked>
+  }
 }

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -1,5 +1,4 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv='compute-capability=90 ptx-version=81' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=81' | FileCheck %s
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv='compute-capability=90 ptx-version=77' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=77' | FileCheck %s --check-prefix=OLD-PTX
 
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @test_cluster_attr
@@ -727,11 +726,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: llvm.inline_asm {{.*}} "cvt.rz.f16.bf16 $0, $1;", "=h,h"
   // CHECK-NOT: llvm.fpext
   // CHECK: llvm.return
-  // OLD-PTX-LABEL: @bf16_to_fp16
-  // OLD-PTX: llvm.fpext {{.*}} : bf16 to f32
-  // OLD-PTX: llvm.inline_asm {{.*}} "cvt.rn.f16.f32 $0, $1;", "=h,r"
-  // OLD-PTX: llvm.fpext {{.*}} : bf16 to f32
-  // OLD-PTX: llvm.inline_asm {{.*}} "cvt.rz.f16.f32 $0, $1;", "=h,r"
   tt.func private @bf16_to_fp16(%arg: tensor<128xbf16, #blocked>) -> (tensor<128xf16, #blocked>, tensor<128xf16, #blocked>) {
     %rn = tt.fp_to_fp %arg : tensor<128xbf16, #blocked> -> tensor<128xf16, #blocked>
     %rz = tt.fp_to_fp %arg, rounding = rtz : tensor<128xbf16, #blocked> -> tensor<128xf16, #blocked>

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -731,4 +731,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %rz = tt.fp_to_fp %arg, rounding = rtz : tensor<128xbf16, #blocked> -> tensor<128xf16, #blocked>
     tt.return %rn, %rz : tensor<128xf16, #blocked>, tensor<128xf16, #blocked>
   }
+
+  // CHECK-LABEL: @fp16_to_bf16
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.inline_asm {{.*}} "cvt.rn.bf16.f16 $0, $1;", "=h,h"
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.inline_asm {{.*}} "cvt.rz.bf16.f16 $0, $1;", "=h,h"
+  // CHECK-NOT: llvm.fpext
+  // CHECK: llvm.return
+  tt.func private @fp16_to_bf16(%arg: tensor<128xf16, #blocked>) -> (tensor<128xbf16, #blocked>, tensor<128xbf16, #blocked>) {
+    %rn = tt.fp_to_fp %arg : tensor<128xf16, #blocked> -> tensor<128xbf16, #blocked>
+    %rz = tt.fp_to_fp %arg, rounding = rtz : tensor<128xf16, #blocked> -> tensor<128xbf16, #blocked>
+    tt.return %rn, %rz : tensor<128xbf16, #blocked>, tensor<128xbf16, #blocked>
+  }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
@@ -2451,7 +2451,8 @@ struct FpToFpOpConversion
     const size_t maxElementsPerThread = maybeMaxElementsPerThread.value();
 
     bool useFp32Intermediate =
-        srcElementType.isBF16() && dstElementType.isF16();
+        (srcElementType.isBF16() && dstElementType.isF16()) ||
+        (srcElementType.isF16() && dstElementType.isBF16());
     if (useFp32Intermediate)
       roundingMode = roundingMode.value_or(RoundingMode::RTNE);
     auto converter =
@@ -2485,7 +2486,8 @@ struct FpToFpOpConversion
 
     if (useFp32Intermediate)
       for (Value &v : inVals)
-        v = AMD::convertBf16ToFp32(loc, rewriter, v);
+        v = srcElementType.isBF16() ? AMD::convertBf16ToFp32(loc, rewriter, v)
+                                    : Fp16ToFp32OneValue(loc, rewriter, v);
 
     auto maybeOutVals = converter->convert(loc, rewriter, inVals);
     assert(maybeOutVals.has_value());

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertFpCastOpToLLVM.cpp
@@ -2450,8 +2450,13 @@ struct FpToFpOpConversion
     }
     const size_t maxElementsPerThread = maybeMaxElementsPerThread.value();
 
-    auto converter = getConverter(srcElementType, dstElementType,
-                                  maxElementsPerThread, roundingMode);
+    bool useFp32Intermediate =
+        srcElementType.isBF16() && dstElementType.isF16();
+    if (useFp32Intermediate)
+      roundingMode = roundingMode.value_or(RoundingMode::RTNE);
+    auto converter =
+        getConverter(useFp32Intermediate ? f32_ty : srcElementType,
+                     dstElementType, maxElementsPerThread, roundingMode);
     if (converter == nullptr) {
       std::string rmError;
       if (roundingMode.has_value())
@@ -2477,6 +2482,10 @@ struct FpToFpOpConversion
     }
     inVals.resize(numElements,
                   b.undef(typeConverter->convertType(srcElementType)));
+
+    if (useFp32Intermediate)
+      for (Value &v : inVals)
+        v = AMD::convertBf16ToFp32(loc, rewriter, v);
 
     auto maybeOutVals = converter->convert(loc, rewriter, inVals);
     assert(maybeOutVals.has_value());

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -381,28 +381,27 @@ struct FpToFpOpConversion
         .getResult(0);
   }
 
-  static Value convertFp32ToFp16(Location loc,
-                                 ConversionPatternRewriter &rewriter,
-                                 const Value &v, const RoundingMode rounding) {
+  static Value convertToFp16(Location loc, ConversionPatternRewriter &rewriter,
+                             const Value &v, const RoundingMode rounding) {
     PTXBuilder builder;
     StringRef ptx;
     switch (rounding) {
     case RoundingMode::RTNE:
-      ptx = "cvt.rn.f16.f32";
+      ptx = v.getType().isBF16() ? "cvt.rn.f16.bf16" : "cvt.rn.f16.f32";
       break;
     case RoundingMode::RTZ:
-      ptx = "cvt.rz.f16.f32";
+      ptx = v.getType().isBF16() ? "cvt.rz.f16.bf16" : "cvt.rz.f16.f32";
       break;
     default:
-      emitError(loc) << "unsupported rounding mode for f32->f16 conversion: "
+      emitError(loc) << "unsupported rounding mode for conversion to f16: "
                      << stringifyRoundingMode(rounding) << "\n";
       llvm::report_fatal_error(
-          "unsupported rounding mode for f32->f16 conversion: " +
+          "unsupported rounding mode for conversion to f16: " +
           stringifyRoundingMode(rounding) + "\n");
     }
     auto &cvt = *builder.create(ptx.str());
     auto res = builder.newOperand("=h");
-    auto operand = builder.newOperand(v, "r");
+    auto operand = builder.newOperand(v, v.getType().isBF16() ? "h" : "r");
     cvt(res, operand);
     return builder.launch(rewriter, loc, f16_ty, false);
   }
@@ -509,13 +508,20 @@ struct FpToFpOpConversion
       }));
     }
 
-    if (srcElementType.isF32() && dstElementType.isF16()) {
+    if ((srcElementType.isF32() || srcElementType.isBF16()) &&
+        dstElementType.isF16()) {
+      if (srcElementType.isBF16())
+        roundingMode = roundingMode.value_or(RoundingMode::RTNE);
       assert(roundingMode.has_value() &&
-             "rounding mode must be specified for fp32->fp16 conversion");
+             "rounding mode must be specified for conversion to fp16");
       SmallVector<Value> outVals;
       for (Value v : operands[0]) {
+        // Direct BF16 -> FP16 conversion requires SM90 and PTX 7.8.
+        if (srcElementType.isBF16() &&
+            (computeCapability < 90 || ptxVersion < 78))
+          v = LLVM::FPExtOp::create(rewriter, loc, f32_ty, v);
         outVals.push_back(
-            convertFp32ToFp16(loc, rewriter, v, roundingMode.value()));
+            convertToFp16(loc, rewriter, v, roundingMode.value()));
       }
       return outVals;
     }
@@ -547,7 +553,7 @@ struct FpToFpOpConversion
     }
     if (useFP16IntermediateSrc)
       for (Value &v : inVals)
-        v = convertFp32ToFp16(loc, rewriter, v, RoundingMode::RTZ);
+        v = convertToFp16(loc, rewriter, v, RoundingMode::RTZ);
     inVals.resize(numElements, b.undef(typeConverter->convertType(srcType)));
     SmallVector<Value> outVals = cvtFunc(loc, rewriter, inVals);
     assert(outVals.size() == inVals.size());

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -509,21 +509,24 @@ struct FpToFpOpConversion
       }));
     }
 
-    if (srcElementType.isBF16() && dstElementType.isF16()) {
+    if ((srcElementType.isBF16() && dstElementType.isF16()) ||
+        (srcElementType.isF16() && dstElementType.isBF16())) {
       Value v = operands[0][0];
       if (computeCapability < 90) {
         v = LLVM::FPExtOp::create(rewriter, loc, f32_ty, v);
-        return {convertFp32ToFp16(loc, rewriter, v,
-                                  roundingMode.value_or(RoundingMode::RTNE))};
+        auto rounding = roundingMode.value_or(RoundingMode::RTNE);
+        return {dstElementType.isBF16()
+                    ? convertFp32ToBf16(loc, rewriter, v, rounding)
+                    : convertFp32ToFp16(loc, rewriter, v, rounding)};
       }
       PTXBuilder builder;
       auto *result = builder.newOperand("=h");
       auto *input = builder.newOperand(v, "h");
       auto &cvt = *builder.create("cvt");
       cvt.o(roundingMode == RoundingMode::RTZ ? "rz" : "rn")
-          .o("f16")
-          .o("bf16")(result, input);
-      return {builder.launch(rewriter, loc, f16_ty, false)};
+          .o(dstElementType.isBF16() ? "bf16" : "f16")
+          .o(srcElementType.isBF16() ? "bf16" : "f16")(result, input);
+      return {builder.launch(rewriter, loc, dstElementType, false)};
     }
 
     if (srcElementType.isF32() && dstElementType.isF16()) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -511,7 +511,7 @@ struct FpToFpOpConversion
 
     if (srcElementType.isBF16() && dstElementType.isF16()) {
       Value v = operands[0][0];
-      if (computeCapability < 90 || ptxVersion < 78) {
+      if (computeCapability < 90) {
         v = LLVM::FPExtOp::create(rewriter, loc, f32_ty, v);
         return {convertFp32ToFp16(loc, rewriter, v,
                                   roundingMode.value_or(RoundingMode::RTNE))};

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -381,27 +381,28 @@ struct FpToFpOpConversion
         .getResult(0);
   }
 
-  static Value convertToFp16(Location loc, ConversionPatternRewriter &rewriter,
-                             const Value &v, const RoundingMode rounding) {
+  static Value convertFp32ToFp16(Location loc,
+                                 ConversionPatternRewriter &rewriter,
+                                 const Value &v, const RoundingMode rounding) {
     PTXBuilder builder;
     StringRef ptx;
     switch (rounding) {
     case RoundingMode::RTNE:
-      ptx = v.getType().isBF16() ? "cvt.rn.f16.bf16" : "cvt.rn.f16.f32";
+      ptx = "cvt.rn.f16.f32";
       break;
     case RoundingMode::RTZ:
-      ptx = v.getType().isBF16() ? "cvt.rz.f16.bf16" : "cvt.rz.f16.f32";
+      ptx = "cvt.rz.f16.f32";
       break;
     default:
-      emitError(loc) << "unsupported rounding mode for conversion to f16: "
+      emitError(loc) << "unsupported rounding mode for f32->f16 conversion: "
                      << stringifyRoundingMode(rounding) << "\n";
       llvm::report_fatal_error(
-          "unsupported rounding mode for conversion to f16: " +
+          "unsupported rounding mode for f32->f16 conversion: " +
           stringifyRoundingMode(rounding) + "\n");
     }
     auto &cvt = *builder.create(ptx.str());
     auto res = builder.newOperand("=h");
-    auto operand = builder.newOperand(v, v.getType().isBF16() ? "h" : "r");
+    auto operand = builder.newOperand(v, "r");
     cvt(res, operand);
     return builder.launch(rewriter, loc, f16_ty, false);
   }
@@ -508,20 +509,30 @@ struct FpToFpOpConversion
       }));
     }
 
-    if ((srcElementType.isF32() || srcElementType.isBF16()) &&
-        dstElementType.isF16()) {
-      if (srcElementType.isBF16())
-        roundingMode = roundingMode.value_or(RoundingMode::RTNE);
+    if (srcElementType.isBF16() && dstElementType.isF16()) {
+      Value v = operands[0][0];
+      if (computeCapability < 90 || ptxVersion < 78) {
+        v = LLVM::FPExtOp::create(rewriter, loc, f32_ty, v);
+        return {convertFp32ToFp16(loc, rewriter, v,
+                                  roundingMode.value_or(RoundingMode::RTNE))};
+      }
+      PTXBuilder builder;
+      auto *result = builder.newOperand("=h");
+      auto *input = builder.newOperand(v, "h");
+      auto &cvt = *builder.create("cvt");
+      cvt.o(roundingMode == RoundingMode::RTZ ? "rz" : "rn")
+          .o("f16")
+          .o("bf16")(result, input);
+      return {builder.launch(rewriter, loc, f16_ty, false)};
+    }
+
+    if (srcElementType.isF32() && dstElementType.isF16()) {
       assert(roundingMode.has_value() &&
-             "rounding mode must be specified for conversion to fp16");
+             "rounding mode must be specified for fp32->fp16 conversion");
       SmallVector<Value> outVals;
       for (Value v : operands[0]) {
-        // Direct BF16 -> FP16 conversion requires SM90 and PTX 7.8.
-        if (srcElementType.isBF16() &&
-            (computeCapability < 90 || ptxVersion < 78))
-          v = LLVM::FPExtOp::create(rewriter, loc, f32_ty, v);
         outVals.push_back(
-            convertToFp16(loc, rewriter, v, roundingMode.value()));
+            convertFp32ToFp16(loc, rewriter, v, roundingMode.value()));
       }
       return outVals;
     }
@@ -553,7 +564,7 @@ struct FpToFpOpConversion
     }
     if (useFP16IntermediateSrc)
       for (Value &v : inVals)
-        v = convertToFp16(loc, rewriter, v, RoundingMode::RTZ);
+        v = convertFp32ToFp16(loc, rewriter, v, RoundingMode::RTZ);
     inVals.resize(numElements, b.undef(typeConverter->convertType(srcType)));
     SmallVector<Value> outVals = cvtFunc(loc, rewriter, inVals);
     assert(outVals.size() == inVals.size());


### PR DESCRIPTION
Preserve casts between FP16 and BF16 as `tt.fp_to_fp` and emit native `cvt.rn.bf16.f16` and `cvt.rn.f16.bf16` instructions on SM90+. Keep the FP32 intermediate for older NVIDIA targets, AMD, and the interpreter.

Validated with a rebuilt compiler, the three affected lit files, 168 frontend and interpreter unit tests, 11 existing GPU cast tests, and pre-commit checks. Validation also covered the full CI interpreter selection (6,162 passed), all 65,536 input bit patterns in both directions on GB300, and PTX assembly for SM80, SM89, SM90, SM100, and SM103.