### PR TITLE
[DOCS] Fix broken link to plugins README in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ def inspect_stages(_self, stages, options, language, capability):
     # inspect or modify add_stages here
 triton.knobs.runtime.add_stages_inspection_hook = inspect_stages
 ```
-Examples of how to use this for out of tree plugin passes is [here](lib/Plugins/README.md)
+Examples of how to use this for out of tree plugin passes is [here](examples/plugins/README.md)
 # Changelog
 
 Version 2.0 is out! New features include:


### PR DESCRIPTION
The plugins directory was moved from lib/Plugins/ to examples/plugins/ in commit 70723756e932 (#8523), but the link in the top-level README was not updated, resulting in a 404 error.

Update the link from lib/Plugins/README.md to examples/plugins/README.md.