### PR TITLE
[OPT] Scalarize loads from splatted pointers

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -74,34 +74,33 @@ public:
   LogicalResult matchAndRewrite(LoadOp op,
                                 PatternRewriter &rewriter) const override {
     auto type = dyn_cast<RankedTensorType>(op.getType());
-    if (!type || type.getEncoding() || op.getIsVolatile())
-      return failure();
-    if (!op.getPtr().getDefiningOp<SplatOp>())
+    auto ptr = op.getPtr().getDefiningOp<SplatOp>();
+    if (!type || type.getEncoding() || !ptr || op.getIsVolatile())
       return failure();
 
-    for (Value operand : op->getOperands()) {
-      DenseElementsAttr constant;
+    for (Value operand : op->getOperands().drop_front()) {
+      SplatElementsAttr constant;
       if (!operand.getDefiningOp<SplatOp>() &&
-          !(matchPattern(operand, m_Constant(&constant)) && constant.isSplat()))
+          !matchPattern(operand, m_Constant(&constant)))
         return failure();
     }
 
-    auto scalar = [&](Value value) -> Value {
+    auto getScalar = [&](Value value) -> Value {
       if (!value)
         return {};
       if (auto splat = value.getDefiningOp<SplatOp>())
         return splat.getSrc();
-      DenseElementsAttr constant;
+      SplatElementsAttr constant;
       bool matched = matchPattern(value, m_Constant(&constant));
-      assert(matched && constant.isSplat());
+      assert(matched);
       return arith::ConstantOp::materialize(
           rewriter, constant.getSplatValue<Attribute>(),
           constant.getElementType(), op.getLoc());
     };
-    auto load =
-        LoadOp::create(rewriter, op.getLoc(), type.getElementType(),
-                       scalar(op.getPtr()), scalar(op.getMask()),
-                       scalar(op.getOther()), op.getCachePolicyAttr(), false);
+    auto load = LoadOp::create(rewriter, op.getLoc(), type.getElementType(),
+                               ptr.getSrc(), getScalar(op.getMask()),
+                               getScalar(op.getOther()),
+                               op.getCachePolicyAttr(), false);
     rewriter.replaceOpWithNewOp<SplatOp>(op, type, load);
     return success();
   }

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -78,10 +78,13 @@ public:
     if (!type || !ptr || op.getIsVolatile())
       return failure();
 
-    for (Value operand : op->getOperands().drop_front()) {
+    for (Value operand : op->getOperands()) {
+      auto splat = operand.getDefiningOp<SplatOp>();
+      // A one-element tensor is not a scalar load operand.
+      if (splat && isa<TensorType>(splat.getSrc().getType()))
+        return failure();
       SplatElementsAttr constant;
-      if (!operand.getDefiningOp<SplatOp>() &&
-          !matchPattern(operand, m_Constant(&constant)))
+      if (!splat && !matchPattern(operand, m_Constant(&constant)))
         return failure();
     }
 

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -75,7 +75,7 @@ public:
                                 PatternRewriter &rewriter) const override {
     auto type = dyn_cast<RankedTensorType>(op.getType());
     auto ptr = op.getPtr().getDefiningOp<SplatOp>();
-    if (!type || type.getEncoding() || !ptr || op.getIsVolatile())
+    if (!type || !ptr || op.getIsVolatile())
       return failure();
 
     for (Value operand : op->getOperands().drop_front()) {

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -66,6 +66,47 @@ using FastMathFlags = arith::FastMathFlags;
 
 #include "TritonCombine.inc"
 
+// Keep uniform loads scalar before assigning distributed tensor layouts.
+class CombineSplatLoadPattern : public OpRewritePattern<LoadOp> {
+public:
+  using OpRewritePattern<LoadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LoadOp op,
+                                PatternRewriter &rewriter) const override {
+    auto type = dyn_cast<RankedTensorType>(op.getType());
+    if (!type || type.getEncoding() || op.getIsVolatile())
+      return failure();
+    if (!op.getPtr().getDefiningOp<SplatOp>())
+      return failure();
+
+    for (Value operand : op->getOperands()) {
+      DenseElementsAttr constant;
+      if (!operand.getDefiningOp<SplatOp>() &&
+          !(matchPattern(operand, m_Constant(&constant)) && constant.isSplat()))
+        return failure();
+    }
+
+    auto scalar = [&](Value value) -> Value {
+      if (!value)
+        return {};
+      if (auto splat = value.getDefiningOp<SplatOp>())
+        return splat.getSrc();
+      DenseElementsAttr constant;
+      bool matched = matchPattern(value, m_Constant(&constant));
+      assert(matched && constant.isSplat());
+      return arith::ConstantOp::materialize(
+          rewriter, constant.getSplatValue<Attribute>(),
+          constant.getElementType(), op.getLoc());
+    };
+    auto load =
+        LoadOp::create(rewriter, op.getLoc(), type.getElementType(),
+                       scalar(op.getPtr()), scalar(op.getMask()),
+                       scalar(op.getOther()), op.getCachePolicyAttr(), false);
+    rewriter.replaceOpWithNewOp<SplatOp>(op, type, load);
+    return success();
+  }
+};
+
 // select(cond, load(ptrs, splat(cond), ???), other)
 //   => load(ptrs, splat(cond), other)
 class CombineSelectMaskedLoadPattern : public RewritePattern {
@@ -301,6 +342,7 @@ public:
     patterns.add<CombineDotAddFPattern>(context);
     patterns.add<CombineDotScaledAddFPattern>(context);
     patterns.add<CombineSelectMaskedLoadPattern>(context);
+    patterns.add<CombineSplatLoadPattern>(context);
     patterns.add<CombineAddPtrPattern>(context);
     patterns.add<CombineBroadcastMulReducePattern>(context);
     patterns.add<CombineReshapeReducePatterns>(context);

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -653,25 +653,6 @@ tt.func @splat_load_volatile(%p: !tt.ptr<f32>) -> tensor<4xf32> {
 }
 
 // A rank-zero tensor source is still a tensor, not a scalar load operand.
-// CHECK-LABEL: @splat_load_tensor_pointer(
-// CHECK: %[[V:.*]] = tt.load %{{.*}} : tensor<4x!tt.ptr<f32>>
-// CHECK-NEXT: tt.return %[[V]]
-tt.func @splat_load_tensor_pointer(%p: tensor<!tt.ptr<f32>>) -> tensor<4xf32> {
-  %ptrs = tt.splat %p : tensor<!tt.ptr<f32>> -> tensor<4x!tt.ptr<f32>>
-  %v = tt.load %ptrs : tensor<4x!tt.ptr<f32>>
-  tt.return %v : tensor<4xf32>
-}
-
-// CHECK-LABEL: @splat_load_tensor_mask(
-// CHECK: %[[V:.*]] = tt.load %{{.*}}, %{{.*}} : tensor<4x!tt.ptr<f32>>
-// CHECK-NEXT: tt.return %[[V]]
-tt.func @splat_load_tensor_mask(%p: !tt.ptr<f32>, %pred: tensor<i1>) -> tensor<4xf32> {
-  %ptrs = tt.splat %p : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
-  %mask = tt.splat %pred : tensor<i1> -> tensor<4xi1>
-  %v = tt.load %ptrs, %mask : tensor<4x!tt.ptr<f32>>
-  tt.return %v : tensor<4xf32>
-}
-
 // CHECK-LABEL: @splat_load_tensor_other(
 // CHECK: %[[V:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<4x!tt.ptr<f32>>
 // CHECK-NEXT: tt.return %[[V]]

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -585,3 +585,69 @@ tt.func @test_combine_broadcast_mul_reduce_multiple_results(%arg0: tensor<32x16x
     }) : (tensor<32x16x32xf32>, tensor<32x16x32xf32>) -> (tensor<32x32xf32>, tensor<32x32xf32>)
     tt.return %5#0 : tensor<32x32xf32>
 }
+
+// CHECK-LABEL: @splat_load
+// CHECK-SAME: %[[P:.*]]: !tt.ptr<f32>
+// CHECK: %[[V:.*]] = tt.load %[[P]] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_first>} : !tt.ptr<f32>
+// CHECK: %[[S:.*]] = tt.splat %[[V]] : f32 -> tensor<128xf32>
+// CHECK: tt.return %[[S]]
+tt.func @splat_load(%p: !tt.ptr<f32>) -> tensor<128xf32> {
+  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+  %v = tt.load %ps {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_first>} : tensor<128x!tt.ptr<f32>>
+  tt.return %v : tensor<128xf32>
+}
+
+// CHECK-LABEL: @splat_load_uniform_mask
+// CHECK-SAME: %[[P:.*]]: !tt.ptr<f32>, %[[PRED:.*]]: i1
+// CHECK: %[[ZERO:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK: %[[V:.*]] = tt.load %[[P]], %[[PRED]], %[[ZERO]] : !tt.ptr<f32>
+// CHECK: %[[S:.*]] = tt.splat %[[V]] : f32 -> tensor<8x16xf32>
+// CHECK: tt.return %[[S]]
+tt.func @splat_load_uniform_mask(%p: !tt.ptr<f32>, %pred: i1) -> tensor<8x16xf32> {
+  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<8x16x!tt.ptr<f32>>
+  %mask = tt.splat %pred : i1 -> tensor<8x16xi1>
+  %zero = arith.constant dense<0.0> : tensor<8x16xf32>
+  %v = tt.load %ps, %mask, %zero : tensor<8x16x!tt.ptr<f32>>
+  tt.return %v : tensor<8x16xf32>
+}
+
+// CHECK-LABEL: @splat_load_varying_mask
+// CHECK: tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<128x!tt.ptr<f32>>
+tt.func @splat_load_varying_mask(%p: !tt.ptr<f32>, %mask: tensor<128xi1>) -> tensor<128xf32> {
+  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+  %zero = arith.constant dense<0.0> : tensor<128xf32>
+  %v = tt.load %ps, %mask, %zero : tensor<128x!tt.ptr<f32>>
+  tt.return %v : tensor<128xf32>
+}
+
+// CHECK-LABEL: @splat_load_varying_other
+// CHECK: tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<128x!tt.ptr<f32>>
+tt.func @splat_load_varying_other(%p: !tt.ptr<f32>, %pred: i1, %other: tensor<128xf32>) -> tensor<128xf32> {
+  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+  %mask = tt.splat %pred : i1 -> tensor<128xi1>
+  %v = tt.load %ps, %mask, %other : tensor<128x!tt.ptr<f32>>
+  tt.return %v : tensor<128xf32>
+}
+
+// CHECK-LABEL: @splat_load_volatile
+// CHECK: tt.load %{{.*}} {isVolatile = true} : tensor<128x!tt.ptr<f32>>
+tt.func @splat_load_volatile(%p: !tt.ptr<f32>) -> tensor<128xf32> {
+  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+  %v = tt.load %ps {isVolatile = true} : tensor<128x!tt.ptr<f32>>
+  tt.return %v : tensor<128xf32>
+}
+
+// CHECK-LABEL: @splat_load_preserves_store_order
+// CHECK: %[[V0:.*]] = tt.load %[[P:.*]] : !tt.ptr<f32>
+// CHECK: %[[S0:.*]] = tt.splat %[[V0]] : f32 -> tensor<128xf32>
+// CHECK: tt.store %[[P]], %{{.*}} : !tt.ptr<f32>
+// CHECK: %[[V1:.*]] = tt.load %[[P]] : !tt.ptr<f32>
+// CHECK: %[[S1:.*]] = tt.splat %[[V1]] : f32 -> tensor<128xf32>
+// CHECK: tt.return %[[S0]], %[[S1]]
+tt.func @splat_load_preserves_store_order(%p: !tt.ptr<f32>, %new: f32) -> (tensor<128xf32>, tensor<128xf32>) {
+  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+  %v0 = tt.load %ps : tensor<128x!tt.ptr<f32>>
+  tt.store %p, %new : !tt.ptr<f32>
+  %v1 = tt.load %ps : tensor<128x!tt.ptr<f32>>
+  tt.return %v0, %v1 : tensor<128xf32>, tensor<128xf32>
+}

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -611,43 +611,17 @@ tt.func @splat_load_uniform_mask(%p: !tt.ptr<f32>, %pred: i1) -> tensor<8x16xf32
   tt.return %v : tensor<8x16xf32>
 }
 
-// CHECK-LABEL: @splat_load_varying_mask
-// CHECK: tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<128x!tt.ptr<f32>>
-tt.func @splat_load_varying_mask(%p: !tt.ptr<f32>, %mask: tensor<128xi1>) -> tensor<128xf32> {
+// CHECK-LABEL: @splat_load_preserves_nonuniform_and_volatile
+// CHECK: %[[A:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<128x!tt.ptr<f32>>
+// CHECK: %[[B:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<128x!tt.ptr<f32>>
+// CHECK: %[[C:.*]] = tt.load %{{.*}} {isVolatile = true} : tensor<128x!tt.ptr<f32>>
+// CHECK: tt.return %[[A]], %[[B]], %[[C]]
+tt.func @splat_load_preserves_nonuniform_and_volatile(%p: !tt.ptr<f32>, %pred: i1, %mask: tensor<128xi1>, %other: tensor<128xf32>) -> (tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) {
   %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
+  %uniform_mask = tt.splat %pred : i1 -> tensor<128xi1>
   %zero = arith.constant dense<0.0> : tensor<128xf32>
-  %v = tt.load %ps, %mask, %zero : tensor<128x!tt.ptr<f32>>
-  tt.return %v : tensor<128xf32>
-}
-
-// CHECK-LABEL: @splat_load_varying_other
-// CHECK: tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<128x!tt.ptr<f32>>
-tt.func @splat_load_varying_other(%p: !tt.ptr<f32>, %pred: i1, %other: tensor<128xf32>) -> tensor<128xf32> {
-  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
-  %mask = tt.splat %pred : i1 -> tensor<128xi1>
-  %v = tt.load %ps, %mask, %other : tensor<128x!tt.ptr<f32>>
-  tt.return %v : tensor<128xf32>
-}
-
-// CHECK-LABEL: @splat_load_volatile
-// CHECK: tt.load %{{.*}} {isVolatile = true} : tensor<128x!tt.ptr<f32>>
-tt.func @splat_load_volatile(%p: !tt.ptr<f32>) -> tensor<128xf32> {
-  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
-  %v = tt.load %ps {isVolatile = true} : tensor<128x!tt.ptr<f32>>
-  tt.return %v : tensor<128xf32>
-}
-
-// CHECK-LABEL: @splat_load_preserves_store_order
-// CHECK: %[[V0:.*]] = tt.load %[[P:.*]] : !tt.ptr<f32>
-// CHECK: %[[S0:.*]] = tt.splat %[[V0]] : f32 -> tensor<128xf32>
-// CHECK: tt.store %[[P]], %{{.*}} : !tt.ptr<f32>
-// CHECK: %[[V1:.*]] = tt.load %[[P]] : !tt.ptr<f32>
-// CHECK: %[[S1:.*]] = tt.splat %[[V1]] : f32 -> tensor<128xf32>
-// CHECK: tt.return %[[S0]], %[[S1]]
-tt.func @splat_load_preserves_store_order(%p: !tt.ptr<f32>, %new: f32) -> (tensor<128xf32>, tensor<128xf32>) {
-  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
-  %v0 = tt.load %ps : tensor<128x!tt.ptr<f32>>
-  tt.store %p, %new : !tt.ptr<f32>
-  %v1 = tt.load %ps : tensor<128x!tt.ptr<f32>>
-  tt.return %v0, %v1 : tensor<128xf32>, tensor<128xf32>
+  %a = tt.load %ps, %mask, %zero : tensor<128x!tt.ptr<f32>>
+  %b = tt.load %ps, %uniform_mask, %other : tensor<128x!tt.ptr<f32>>
+  %c = tt.load %ps {isVolatile = true} : tensor<128x!tt.ptr<f32>>
+  tt.return %a, %b, %c : tensor<128xf32>, tensor<128xf32>, tensor<128xf32>
 }

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -625,3 +625,21 @@ tt.func @splat_load_preserves_nonuniform_and_volatile(%p: !tt.ptr<f32>, %pred: i
   %c = tt.load %ps {isVolatile = true} : tensor<128x!tt.ptr<f32>>
   tt.return %a, %b, %c : tensor<128xf32>, tensor<128xf32>, tensor<128xf32>
 }
+
+// CHECK-LABEL: @splat_load_preserves_tensor_sources
+// CHECK: %[[A:.*]] = tt.load %{{.*}} : tensor<8x!tt.ptr<f32>>
+// CHECK: %[[B:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<8x!tt.ptr<f32>>
+// CHECK: %[[C:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<8x!tt.ptr<f32>>
+// CHECK: tt.return %[[A]], %[[B]], %[[C]]
+tt.func @splat_load_preserves_tensor_sources(%p: !tt.ptr<f32>, %pred: i1, %tensor_p: tensor<!tt.ptr<f32>>, %tensor_pred: tensor<i1>, %tensor_other: tensor<f32>) -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>) {
+  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+  %tensor_ps = tt.splat %tensor_p : tensor<!tt.ptr<f32>> -> tensor<8x!tt.ptr<f32>>
+  %mask = tt.splat %pred : i1 -> tensor<8xi1>
+  %tensor_mask = tt.splat %tensor_pred : tensor<i1> -> tensor<8xi1>
+  %other = tt.splat %tensor_other : tensor<f32> -> tensor<8xf32>
+  %zero = arith.constant dense<0.0> : tensor<8xf32>
+  %a = tt.load %tensor_ps : tensor<8x!tt.ptr<f32>>
+  %b = tt.load %ps, %tensor_mask, %zero : tensor<8x!tt.ptr<f32>>
+  %c = tt.load %ps, %mask, %other : tensor<8x!tt.ptr<f32>>
+  tt.return %a, %b, %c : tensor<8xf32>, tensor<8xf32>, tensor<8xf32>
+}

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -586,60 +586,99 @@ tt.func @test_combine_broadcast_mul_reduce_multiple_results(%arg0: tensor<32x16x
     tt.return %5#0 : tensor<32x32xf32>
 }
 
-// CHECK-LABEL: @splat_load
+// CHECK-LABEL: @splat_load(
 // CHECK-SAME: %[[P:.*]]: !tt.ptr<f32>
 // CHECK: %[[V:.*]] = tt.load %[[P]] {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_first>} : !tt.ptr<f32>
-// CHECK: %[[S:.*]] = tt.splat %[[V]] : f32 -> tensor<128xf32>
-// CHECK: tt.return %[[S]]
-tt.func @splat_load(%p: !tt.ptr<f32>) -> tensor<128xf32> {
-  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
-  %v = tt.load %ps {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_first>} : tensor<128x!tt.ptr<f32>>
-  tt.return %v : tensor<128xf32>
+// CHECK-NEXT: %[[S:.*]] = tt.splat %[[V]] : f32 -> tensor<4xf32>
+// CHECK-NEXT: tt.return %[[S]]
+tt.func @splat_load(%p: !tt.ptr<f32>) -> tensor<4xf32> {
+  %ptrs = tt.splat %p : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %v = tt.load %ptrs {cachePolicy = #tt.cache_policy<cache_modifier = cg, eviction_policy = evict_first>} : tensor<4x!tt.ptr<f32>>
+  tt.return %v : tensor<4xf32>
 }
 
-// CHECK-LABEL: @splat_load_uniform_mask
+// CHECK-LABEL: @splat_load_uniform_mask(
 // CHECK-SAME: %[[P:.*]]: !tt.ptr<f32>, %[[PRED:.*]]: i1
 // CHECK: %[[ZERO:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK: %[[V:.*]] = tt.load %[[P]], %[[PRED]], %[[ZERO]] : !tt.ptr<f32>
-// CHECK: %[[S:.*]] = tt.splat %[[V]] : f32 -> tensor<8x16xf32>
-// CHECK: tt.return %[[S]]
-tt.func @splat_load_uniform_mask(%p: !tt.ptr<f32>, %pred: i1) -> tensor<8x16xf32> {
-  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<8x16x!tt.ptr<f32>>
-  %mask = tt.splat %pred : i1 -> tensor<8x16xi1>
-  %zero = arith.constant dense<0.0> : tensor<8x16xf32>
-  %v = tt.load %ps, %mask, %zero : tensor<8x16x!tt.ptr<f32>>
-  tt.return %v : tensor<8x16xf32>
+// CHECK-NEXT: %[[S:.*]] = tt.splat %[[V]] : f32 -> tensor<2x2xf32>
+// CHECK-NEXT: tt.return %[[S]]
+tt.func @splat_load_uniform_mask(%p: !tt.ptr<f32>, %pred: i1) -> tensor<2x2xf32> {
+  %ptrs = tt.splat %p : !tt.ptr<f32> -> tensor<2x2x!tt.ptr<f32>>
+  %mask = tt.splat %pred : i1 -> tensor<2x2xi1>
+  %zero = arith.constant dense<0.0> : tensor<2x2xf32>
+  %v = tt.load %ptrs, %mask, %zero : tensor<2x2x!tt.ptr<f32>>
+  tt.return %v : tensor<2x2xf32>
 }
 
-// CHECK-LABEL: @splat_load_preserves_nonuniform_and_volatile
-// CHECK: %[[A:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<128x!tt.ptr<f32>>
-// CHECK: %[[B:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<128x!tt.ptr<f32>>
-// CHECK: %[[C:.*]] = tt.load %{{.*}} {isVolatile = true} : tensor<128x!tt.ptr<f32>>
-// CHECK: tt.return %[[A]], %[[B]], %[[C]]
-tt.func @splat_load_preserves_nonuniform_and_volatile(%p: !tt.ptr<f32>, %pred: i1, %mask: tensor<128xi1>, %other: tensor<128xf32>) -> (tensor<128xf32>, tensor<128xf32>, tensor<128xf32>) {
-  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>>
-  %uniform_mask = tt.splat %pred : i1 -> tensor<128xi1>
-  %zero = arith.constant dense<0.0> : tensor<128xf32>
-  %a = tt.load %ps, %mask, %zero : tensor<128x!tt.ptr<f32>>
-  %b = tt.load %ps, %uniform_mask, %other : tensor<128x!tt.ptr<f32>>
-  %c = tt.load %ps {isVolatile = true} : tensor<128x!tt.ptr<f32>>
-  tt.return %a, %b, %c : tensor<128xf32>, tensor<128xf32>, tensor<128xf32>
+// CHECK-LABEL: @splat_load_uniform_other(
+// CHECK-SAME: %[[P:.*]]: !tt.ptr<f32>, %[[PRED:.*]]: i1, %[[OTHER:.*]]: f32
+// CHECK: %[[V:.*]] = tt.load %[[P]], %[[PRED]], %[[OTHER]] : !tt.ptr<f32>
+// CHECK-NEXT: %[[S:.*]] = tt.splat %[[V]] : f32 -> tensor<4xf32>
+// CHECK-NEXT: tt.return %[[S]]
+tt.func @splat_load_uniform_other(%p: !tt.ptr<f32>, %pred: i1, %other: f32) -> tensor<4xf32> {
+  %ptrs = tt.splat %p : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %mask = tt.splat %pred : i1 -> tensor<4xi1>
+  %fallback = tt.splat %other : f32 -> tensor<4xf32>
+  %v = tt.load %ptrs, %mask, %fallback : tensor<4x!tt.ptr<f32>>
+  tt.return %v : tensor<4xf32>
 }
 
-// CHECK-LABEL: @splat_load_preserves_tensor_sources
-// CHECK: %[[A:.*]] = tt.load %{{.*}} : tensor<8x!tt.ptr<f32>>
-// CHECK: %[[B:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<8x!tt.ptr<f32>>
-// CHECK: %[[C:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<8x!tt.ptr<f32>>
-// CHECK: tt.return %[[A]], %[[B]], %[[C]]
-tt.func @splat_load_preserves_tensor_sources(%p: !tt.ptr<f32>, %pred: i1, %tensor_p: tensor<!tt.ptr<f32>>, %tensor_pred: tensor<i1>, %tensor_other: tensor<f32>) -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>) {
-  %ps = tt.splat %p : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
-  %tensor_ps = tt.splat %tensor_p : tensor<!tt.ptr<f32>> -> tensor<8x!tt.ptr<f32>>
-  %mask = tt.splat %pred : i1 -> tensor<8xi1>
-  %tensor_mask = tt.splat %tensor_pred : tensor<i1> -> tensor<8xi1>
-  %other = tt.splat %tensor_other : tensor<f32> -> tensor<8xf32>
-  %zero = arith.constant dense<0.0> : tensor<8xf32>
-  %a = tt.load %tensor_ps : tensor<8x!tt.ptr<f32>>
-  %b = tt.load %ps, %tensor_mask, %zero : tensor<8x!tt.ptr<f32>>
-  %c = tt.load %ps, %mask, %other : tensor<8x!tt.ptr<f32>>
-  tt.return %a, %b, %c : tensor<8xf32>, tensor<8xf32>, tensor<8xf32>
+// CHECK-LABEL: @splat_load_nonuniform_mask(
+// CHECK: %[[V:.*]] = tt.load %{{.*}}, %{{.*}} : tensor<4x!tt.ptr<f32>>
+// CHECK-NEXT: tt.return %[[V]]
+tt.func @splat_load_nonuniform_mask(%p: !tt.ptr<f32>, %mask: tensor<4xi1>) -> tensor<4xf32> {
+  %ptrs = tt.splat %p : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %v = tt.load %ptrs, %mask : tensor<4x!tt.ptr<f32>>
+  tt.return %v : tensor<4xf32>
+}
+
+// CHECK-LABEL: @splat_load_nonuniform_other(
+// CHECK: %[[V:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<4x!tt.ptr<f32>>
+// CHECK-NEXT: tt.return %[[V]]
+tt.func @splat_load_nonuniform_other(%p: !tt.ptr<f32>, %pred: i1, %other: tensor<4xf32>) -> tensor<4xf32> {
+  %ptrs = tt.splat %p : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %mask = tt.splat %pred : i1 -> tensor<4xi1>
+  %v = tt.load %ptrs, %mask, %other : tensor<4x!tt.ptr<f32>>
+  tt.return %v : tensor<4xf32>
+}
+
+// CHECK-LABEL: @splat_load_volatile(
+// CHECK: %[[V:.*]] = tt.load %{{.*}} {isVolatile = true} : tensor<4x!tt.ptr<f32>>
+// CHECK-NEXT: tt.return %[[V]]
+tt.func @splat_load_volatile(%p: !tt.ptr<f32>) -> tensor<4xf32> {
+  %ptrs = tt.splat %p : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %v = tt.load %ptrs {isVolatile = true} : tensor<4x!tt.ptr<f32>>
+  tt.return %v : tensor<4xf32>
+}
+
+// A rank-zero tensor source is still a tensor, not a scalar load operand.
+// CHECK-LABEL: @splat_load_tensor_pointer(
+// CHECK: %[[V:.*]] = tt.load %{{.*}} : tensor<4x!tt.ptr<f32>>
+// CHECK-NEXT: tt.return %[[V]]
+tt.func @splat_load_tensor_pointer(%p: tensor<!tt.ptr<f32>>) -> tensor<4xf32> {
+  %ptrs = tt.splat %p : tensor<!tt.ptr<f32>> -> tensor<4x!tt.ptr<f32>>
+  %v = tt.load %ptrs : tensor<4x!tt.ptr<f32>>
+  tt.return %v : tensor<4xf32>
+}
+
+// CHECK-LABEL: @splat_load_tensor_mask(
+// CHECK: %[[V:.*]] = tt.load %{{.*}}, %{{.*}} : tensor<4x!tt.ptr<f32>>
+// CHECK-NEXT: tt.return %[[V]]
+tt.func @splat_load_tensor_mask(%p: !tt.ptr<f32>, %pred: tensor<i1>) -> tensor<4xf32> {
+  %ptrs = tt.splat %p : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %mask = tt.splat %pred : tensor<i1> -> tensor<4xi1>
+  %v = tt.load %ptrs, %mask : tensor<4x!tt.ptr<f32>>
+  tt.return %v : tensor<4xf32>
+}
+
+// CHECK-LABEL: @splat_load_tensor_other(
+// CHECK: %[[V:.*]] = tt.load %{{.*}}, %{{.*}}, %{{.*}} : tensor<4x!tt.ptr<f32>>
+// CHECK-NEXT: tt.return %[[V]]
+tt.func @splat_load_tensor_other(%p: !tt.ptr<f32>, %pred: i1, %other: tensor<f32>) -> tensor<4xf32> {
+  %ptrs = tt.splat %p : !tt.ptr<f32> -> tensor<4x!tt.ptr<f32>>
+  %mask = tt.splat %pred : i1 -> tensor<4xi1>
+  %fallback = tt.splat %other : tensor<f32> -> tensor<4xf32>
+  %v = tt.load %ptrs, %mask, %fallback : tensor<4x!tt.ptr<f32>>
+  tt.return %v : tensor<4xf32>
 }


### PR DESCRIPTION
## Summary

Rewrite `load(splat(p))` as `splat(load(p))` before assigning distributed layouts. Keeping the loaded value scalar lets existing folds remove unnecessary tensor and layout work.

The rewrite applies only to nonvolatile tensor loads whose pointer is a splat and whose optional mask and fallback are also splats or splat constants. Every splat must have a scalar source; tensor-valued sources are left unchanged. It preserves cache policy and the load's position relative to other memory operations.

## Validation

Rebuilt with `make` on macOS; `lit -v test/Triton/combine.mlir` passed. The seven focused cases cover ordinary loads and cache policy, constant and runtime fallbacks, and rejection of varying masks/fallbacks, volatile loads, and tensor-valued splat sources. The focused suite also fails as expected when the combine optimization is omitted.

### Benchmark results

The repeated five-case gather/permutation sweep found three clear speedups, one case within 1%, and one regression. All five cases are shown below alongside the matmul reproducer; the regression row uses the later focused confirmation run.

Kernel-only measurements on NVIDIA GB300. These are constructed compiler reproducers with splatted load pointers, not unmodified application benchmarks or end-to-end model measurements. These are retained results from the compiler investigation, not new performance runs of the latest test-only revision.

| Kernel | Parameters | Before | After | Speedup |
|---|---|---:|---:|---:|
| BF16 matmul with scalar tile scaling | M=8192, N=4096, K=512; 4 warps, 3 stages | 38.85 µs | 30.75 µs | +26.3% |
| FP32 gather with a broadcast index | 256×128; index strides (0, 0); one block, 4 warps, 1 stage | 4.194 µs | 4.169 µs | +0.6% |
| FP16 gather with a broadcast index | 256×256; index strides (0, 0); one block, 4 warps, 1 stage | 9.51 µs | 7.22 µs | +31.7% |
| FP32 permutation of a broadcast input | 256×256; input strides (0, 0); one block, 4 warps, 1 stage | 11.47 µs | 5.07 µs | +126.1% |
| FP16 permutation of a broadcast input | 512×512; input strides (0, 0); one block, 4 warps, 1 stage | 149.377 µs | 9.015 µs | +1557.0% |
| FP32 gather with a broadcast index | 512×128; index=42; one block, 4 warps, 1 stage | 34.08 µs | 35.30 µs | −3.4% |

Speedup is `(before / after - 1) × 100%`, computed from unrounded timings; negative means slower. Correctness checks passed for all listed cases.

- **Matmul:** earlier native compiler prototype on a pinned downstream compiler (`5198bceaf9`), with two timing rounds per arm. Allocated local memory fell from 456 to 0 bytes/thread.
- **Gather/permutation sweep:** medians across five independent process runs, each with eight rounds alternating the before/after order. Index/input strides were specialized to zero to exercise splatted loads. Both permutation cases have fully broadcast inputs, so their gains reflect eliminating redundant tensor work rather than ordinary dense-transpose speedups. The FP16 gather used 203 → 170 registers/thread. Both permutation cases eliminated 32 KiB of shared memory; local-memory allocation fell from 1,016 → 0 bytes/thread for FP32 and 10,448 → 0 bytes/thread for FP16. The smaller FP32 gather was essentially flat.
- **FP32 gather regression:** six alternating-order rounds using CUDA graphs of 200 launches. Saved before/after PTX was assembled with the same Blackwell assembler, version 13.3.69. All 128 indices and three in-place aliasing cases passed correctness checks. Nsight measured local-memory requests increasing from 8,708 to 10,636 per launch, despite both binaries using 32 registers/thread. The observed regression comes from downstream scheduling and register-allocation heuristics. Reordering instructions removes it while retaining the optimization.

Clocks were not locked; all sampled clocks in the six-round FP32 gather run were 2070 MHz SM / 3996 MHz memory. These examples demonstrate both a benefit and a regression: the rewrite is not guaranteed to improve runtime.

## Lines Changed

| Type | Added | Removed | Net |
|---|---:|---:|---:|
| Tests | 78 | 0 | +78 |
| Core Logic | 44 | 0 | +44 |
| AutoGenerated | 0 | 0 | 0 |
| Total | 122 | 0 | +122 |

## Reviewers Guide

- `lib/Dialect/Triton/Transforms/Combine.cpp`: the match and rewrite.
- `test/Triton/combine.mlir`: seven focused cases, each with one load and one expected behavior. No file movements.
