### PR TITLE
[FRONTEND] Diagnose unsupported returns in dynamic loops

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -6,7 +6,7 @@ from triton.experimental import gluon
 from triton._filecheck import filecheck_test, run_filecheck_test, run_parser
 from triton.compiler.code_generator import CodeGenerator
 from triton.runtime.jit import MockTensor
-from triton.compiler.errors import CompilationError
+from triton.compiler.errors import CompilationError, UnsupportedLanguageConstruct
 import pytest
 from typing import NamedTuple
 
@@ -788,6 +788,61 @@ def test_return_in_while():
         run_parser(kernel)
 
     assert "Cannot have `return` statements inside `while` or `for` statements in triton" in str(e.value)
+
+
+@pytest.mark.parametrize("kind", ["while", "for", "tl.range", "nested"])
+def test_direct_return_in_dynamic_loop(kind):
+
+    @triton.jit
+    def helper(KIND: tl.constexpr):
+        pid = tl.program_id(0)
+        if KIND == "while":
+            while pid < 5:
+                pid += 1
+                return pid
+        elif KIND == "for":
+            for i in range(pid):
+                return pid
+        elif KIND == "tl.range":
+            for i in tl.range(pid):
+                return pid
+        else:
+            for i in tl.static_range(2):
+                while pid < 5:
+                    pid += 1
+                    return pid
+        return pid
+
+    @triton.jit
+    def kernel(KIND: tl.constexpr):
+        helper(KIND)
+
+    with pytest.raises(CompilationError) as exc:
+        run_parser(kernel, args=(kind, ))
+    error = exc.value.__cause__
+    assert isinstance(error, UnsupportedLanguageConstruct)
+    assert "Cannot have `return` statements inside `while` or `for` statements in triton" in str(error)
+    assert error.src.splitlines()[error.node.lineno - 1].strip() == "return pid"
+
+
+@pytest.mark.parametrize("static", [False, True])
+def test_returning_helper_in_dynamic_loop(static):
+
+    @triton.jit
+    def helper(value, STATIC: tl.constexpr):
+        if STATIC:
+            for i in tl.static_range(2):
+                if i == 0:
+                    return value
+        return value
+
+    @triton.jit
+    def kernel(STATIC: tl.constexpr):
+        pid = tl.program_id(0)
+        while pid < 5:
+            pid = helper(pid + 1, STATIC)
+
+    assert run_parser(kernel, args=(static, )).verify()
 
 
 class TensorPtr(NamedTuple):

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -567,6 +567,9 @@ class CodeGenerator(ast.NodeVisitor):
 
     # By design, only non-kernel functions can return
     def visit_Return(self, node):
+        if self.scf_stack:
+            raise self._unsupported(node,
+                                    "Cannot have `return` statements inside `while` or `for` statements in triton.")
         ret_value = self.visit(node.value)
         if ret_value is None:
             ret_value = language.constexpr(None)


### PR DESCRIPTION
A direct `return` in a dynamic loop inside a JIT helper currently reaches an internal Python assertion, wrapped as `CompilationError`. Diagnose it at the return statement with the existing `UnsupportedLanguageConstruct` message, consistent with the check for returns inside dynamic conditionals.

The check uses the current function's loop context. It preserves valid calls to returning helpers, static unrolling, and semantic checking after returns; it does not add dynamic-loop early-return support.

Related to #2576. This addresses the missing frontend diagnostic, not general support for early returns.

Validation:
- New diagnostic cases (`while`, `for`, `tl.range`, and a while nested in a static loop) failed before the change; both helper-return compatibility cases passed.
- After the change: `PYTHONPATH=python python -m pytest -s --tb=short python/test/unit/language/test_frontend.py` — 153 passed. A separate run guarded driver creation: zero calls. Tests use the real parser and verify diagnostic type, message, and source position.
- Source-built native extension at baseline `2d4fce94e3c98690bcc3f5c7df73a94d4e423654`; no GPU execution. Main subsequently advanced to `66aa2f8a62912e821dd974ace5697fe19ac90968` with an unrelated scale-decoding change; these two files are unchanged upstream.
- Commit-range pre-commit checks and `git diff --check` passed. Used `SKIP=expand-yaml-anchors` because that workflow-only hook has no matching files here; its tool download failed during environment initialization. All applicable hooks passed.

### New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description explaining the problem and why the change is needed.
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD` (with the non-applicable workflow hook skipped as noted above).
- [x] I have added tests in `python/test`.
- [x] I have not added any `lit` tests.
