### PR TITLE
[AMD] Bypass the epilogue relayout for FMA

### DIFF
--- a/test/TritonGPU/amd/amd-optimize-epilogue.mlir
+++ b/test/TritonGPU/amd/amd-optimize-epilogue.mlir
@@ -167,3 +167,141 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32}
     tt.return
   }
 }
+
+// -----
+
+// FMA dot layout cases.
+
+// Both contiguous sizePerThread are identical: bypass is profitable.
+// CHECK-LABEL: fma_blocked_equal_contig
+// CHECK-NOT:   ttg.convert_layout %{{.*}} : tensor<64x128xf32, #blocked> -> tensor<64x128xf32, #blocked1>
+// CHECK:       %[[PTR:.+]] = ttg.convert_layout %{{.*}} : tensor<64x128x!tt.ptr<f32>, #blocked1> -> tensor<64x128x!tt.ptr<f32>, #blocked>
+// CHECK:       tt.store %[[PTR]], %{{.*}} : tensor<64x128x!tt.ptr<f32>, #blocked>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1101", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fma_blocked_equal_contig(%arg0: !tt.ptr<f32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked>
+    %cst_0 = arith.constant dense<1.230000e+02> : tensor<64x16xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
+    %cst_1 = arith.constant dense<1.230000e+02> : tensor<16x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
+    %0 = tt.dot %cst_0, %cst_1, %cst : tensor<64x16xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x128xf32, #blocked>
+    %1 = ttg.convert_layout %0 : tensor<64x128xf32, #blocked> -> tensor<64x128xf32, #blocked1>
+    %2 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>, #blocked1>
+    tt.store %2, %1 : tensor<64x128x!tt.ptr<f32>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+// Source sizePerThread is bigger than the store layout's: bypass is profitable.
+// CHECK-LABEL: fma_blocked_wider_contig
+// CHECK-NOT:   ttg.convert_layout %{{.*}} : tensor<64x128xf32, #blocked> -> tensor<64x128xf32, #blocked1>
+// CHECK:       tt.store %{{.*}}, %{{.*}} : tensor<64x128x!tt.ptr<f32>, #blocked>
+#blocked = #ttg.blocked<{sizePerThread = [4, 8], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1101", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fma_blocked_wider_contig(%arg0: !tt.ptr<f32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked>
+    %0 = ttg.convert_layout %cst : tensor<64x128xf32, #blocked> -> tensor<64x128xf32, #blocked1>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>, #blocked1>
+    tt.store %1, %0 : tensor<64x128x!tt.ptr<f32>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+// Source sizePerThread is smaller than the store layout's: bypass is not profitable.
+// CHECK-LABEL: fma_blocked_narrower_contig
+// CHECK:       %[[VAL:.+]] = ttg.convert_layout %{{.*}} : tensor<64x128xf32, #blocked> -> tensor<64x128xf32, #blocked1>
+// CHECK:       tt.store %{{.*}}, %[[VAL]] : tensor<64x128x!tt.ptr<f32>, #blocked1>
+#blocked = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1101", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fma_blocked_narrower_contig(%arg0: !tt.ptr<f32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked>
+    %0 = ttg.convert_layout %cst : tensor<64x128xf32, #blocked> -> tensor<64x128xf32, #blocked1>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>, #blocked1>
+    tt.store %1, %0 : tensor<64x128x!tt.ptr<f32>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+// The two layouts disagree on the order, so bypass is not profitable.
+// CHECK-LABEL: fma_blocked_order_mismatch
+// CHECK:       %[[VAL:.+]] = ttg.convert_layout %{{.*}} : tensor<64x128xf32, #blocked> -> tensor<64x128xf32, #blocked1>
+// CHECK:       tt.store %{{.*}}, %[[VAL]] : tensor<64x128x!tt.ptr<f32>, #blocked1>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1101", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fma_blocked_order_mismatch(%arg0: !tt.ptr<f32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked>
+    %0 = ttg.convert_layout %cst : tensor<64x128xf32, #blocked> -> tensor<64x128xf32, #blocked1>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>, #blocked1>
+    tt.store %1, %0 : tensor<64x128x!tt.ptr<f32>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+// The source keeps a single lane on the contiguous dimension, so consecutive
+// lanes do not continue each other's run and the store would not be coalesced,
+// even though the contiguous sizePerThread match.
+// CHECK-LABEL: fma_blocked_lanes_not_contig
+// CHECK:       %[[VAL:.+]] = ttg.convert_layout %{{.*}} : tensor<64x128xf32, #blocked> -> tensor<64x128xf32, #blocked1>
+// CHECK:       tt.store %{{.*}}, %[[VAL]] : tensor<64x128x!tt.ptr<f32>, #blocked1>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1101", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fma_blocked_lanes_not_contig(%arg0: !tt.ptr<f32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked>
+    %0 = ttg.convert_layout %cst : tensor<64x128xf32, #blocked> -> tensor<64x128xf32, #blocked1>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x128x!tt.ptr<f32>, #blocked1>
+    tt.store %1, %0 : tensor<64x128x!tt.ptr<f32>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+// The source sizePerThread is smaller than the store layout's, but both already
+// fill the 128 bit store width, so neither needs more stores than the other and
+// the bypass is still profitable.
+// CHECK-LABEL: fma_blocked_narrower_but_store_width_bound
+// CHECK-NOT:   ttg.convert_layout %{{.*}} : tensor<64x128xf16, #blocked> -> tensor<64x128xf16, #blocked1>
+// CHECK:       tt.store %{{.*}}, %{{.*}} : tensor<64x128x!tt.ptr<f16>, #blocked>
+#blocked = #ttg.blocked<{sizePerThread = [4, 8], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1101", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fma_blocked_narrower_but_store_width_bound(%arg0: !tt.ptr<f16>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf16, #blocked>
+    %0 = ttg.convert_layout %cst : tensor<64x128xf16, #blocked> -> tensor<64x128xf16, #blocked1>
+    %1 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x128x!tt.ptr<f16>, #blocked1>
+    tt.store %1, %0 : tensor<64x128x!tt.ptr<f16>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+// A tensor whose store dimension holds a single element cannot deliver the
+// contiguous run its sizePerThread advertises, so the bypass must be rejected
+// even though looking at sizePerThread alone would allow it.
+// CHECK-LABEL: fma_blocked_tensor_narrower_than_tile
+// CHECK:       %[[VAL:.+]] = ttg.convert_layout %{{.*}} : tensor<128x1xf32, #blocked> -> tensor<128x1xf32, #blocked1>
+// CHECK:       tt.store %{{.*}}, %[[VAL]] : tensor<128x1x!tt.ptr<f32>, #blocked1>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1101", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fma_blocked_tensor_narrower_than_tile(%arg0: !tt.ptr<f32>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x1xf32, #blocked>
+    %0 = ttg.convert_layout %cst : tensor<128x1xf32, #blocked> -> tensor<128x1xf32, #blocked1>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<128x1x!tt.ptr<f32>, #blocked1>
+    tt.store %1, %0 : tensor<128x1x!tt.ptr<f32>, #blocked1>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
@@ -97,6 +97,63 @@ usePermlaneSwapToOptimizeStore(PatternRewriter &rewriter, Value ptr, Value val,
   return newStore;
 }
 
+// Whether issuing the store directly in the layout of `srcType` is worth
+// skipping the relayout into the coalesced layout of `dstType`, the type the
+// original store used.
+//
+// For an MMA source it always is: the relayout is a pure LDS round trip and
+// the MFMA/WMMA layouts store acceptably.
+//
+// For a blocked source it is profitable when the store stays as wide and as
+// coalesced as it would be in the layout of `dstType`. Both layouts hold the
+// same number of elements per thread, so a shorter contiguous run means that
+// each store would cover fewer elements, thus needing more store instructions,
+// which would harm performance.
+static bool isProfitableBypassSource(RankedTensorType srcType,
+                                     RankedTensorType dstType) {
+  Attribute srcEncoding = srcType.getEncoding();
+  Attribute dstEncoding = dstType.getEncoding();
+  if (!srcEncoding || !dstEncoding)
+    return false;
+
+  // If the source is MMA, it is always profitable. If not (FMA), we check
+  // several things like contiguity, number of stores, etc.
+  if (isa<triton::gpu::MmaEncodingTrait>(srcEncoding))
+    return true;
+
+  auto srcBlocked = dyn_cast<triton::gpu::BlockedEncodingAttr>(srcEncoding);
+  auto dstBlocked = dyn_cast<triton::gpu::BlockedEncodingAttr>(dstEncoding);
+  if (!srcBlocked || !dstBlocked)
+    return false;
+
+  // A differing fastest-varying dimension would make the store run in a
+  // different axis, so the contiguous runs are not comparable.
+  const unsigned contigDim = srcBlocked.getOrder()[0];
+  if (contigDim != dstBlocked.getOrder()[0])
+    return false;
+
+  // Since we are considering using the src layout, make sure that
+  // lanes in that layout write to consecutive addresses.
+  if (triton::gpu::getThreadOrder(srcType)[0] != contigDim)
+    return false;
+
+  // Make sure that using the src layout would not increase the store count.
+  // A store is at most 128 bits wide, so we cap both runs at the number of
+  // elements that fit in it (4 for f32, 8 for f16): a src run of 8 f16 against
+  // a dst run of 16 needs no more stores, since neither can write more than 8
+  // elements at a time, and rejecting it would keep the LDS round trip for a
+  // penalty the hardware does not have.
+  Type elemType = dstType.getElementType();
+  const unsigned elemBitWidth =
+      elemType.isIntOrFloat() ? elemType.getIntOrFloatBitWidth() : 0;
+  const unsigned maxElems =
+      elemBitWidth ? std::max(128u / elemBitWidth, 1u) : ~0u;
+  return std::min(triton::gpu::getContigPerThread(srcType)[contigDim],
+                  maxElems) >=
+         std::min(triton::gpu::getContigPerThread(dstType)[contigDim],
+                  maxElems);
+}
+
 // convert(val) : xmma -> blocked
 // elementWiseOp(val) : blocked
 // ...
@@ -112,7 +169,8 @@ usePermlaneSwapToOptimizeStore(PatternRewriter &rewriter, Value ptr, Value val,
 //
 // Store with xmma layout directly
 //
-// xmma layout is either MFMA or WMMA
+// xmma layout is either MFMA or WMMA, or the blocked layout of an FMA dot when
+// that keeps the store as wide as the coalesced layout would.
 class BypassEpilogueSMEM : public mlir::OpRewritePattern<triton::StoreOp> {
 
 public:
@@ -151,8 +209,7 @@ public:
     if (!cvtOp)
       return mlir::failure();
 
-    auto encoding = cvtOp.getSrc().getType().getEncoding();
-    if (!isa<triton::gpu::MmaEncodingTrait>(encoding))
+    if (!isProfitableBypassSource(cvtOp.getSrc().getType(), valType))
       return mlir::failure();
 
     if (!cvtOp.getResult().hasOneUse())


### PR DESCRIPTION
`BypassEpilogueSMEM` only rewrites a store when the `convert_layout` feeding it is MMA (MFMA/WMMA), so FMA is silently skipped. That means that the expensive relayout stays, with its LDS round trip, which hurts performance. This PR replaces that bail-out with a profitability check, so the relayout can also be bypassed on FMA kernels when it is profitable. With this PR, we measured ~10% speedup on several FMA kernels.

Two layouts are involved in the decision:
1. The *candidate* layout is the `convert_layout` source (the one the store would pivot to if the relayout is dropped, **srcType in the code**)
2. The *current* layout is the coalesced one the store uses today (**dstType** in the code)

The heuristic for when the relayout is profitable for FMA is simple:
- Both layouts have the same contiguity? Bail out if not (we cannot compare those 2 layouts)
- Consecutive lanes of the candidate layout goes along that dimension? If not, the store would not be coalesced, so bail out
- Would skipping the relayout increase the store instruction? If yes, it will be bad for performance, so bail out

If all of those guards pass, then we conclude it's profitable to skip the relayout.

This PR also adds several testcases to exercise those situations.
