### PR TITLE
Fix alignment of warp-specialized NVIDIA barriers

### DIFF
--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -14,16 +14,16 @@ llvm.func @rewrite_barriers() attributes {allocation.offset = 32 : i32} {
   // CHECK-DAG: [[C64:%.*]] = llvm.mlir.constant(64 : i32)
   // CHECK-DAG: [[C128:%.*]] = llvm.mlir.constant(128 : i32)
 
-  // CHECK: nvvm.barrier id = [[C2]] number_of_threads = [[C128]]
-  // CHECK: nvvm.barrier id = [[C3]] number_of_threads = [[C64]]
+  // CHECK: nvvm.barrier id = [[C2]] number_of_threads = [[C128]] {aligned = false}
+  // CHECK: nvvm.barrier id = [[C3]] number_of_threads = [[C64]] {aligned = false}
   // CHECK: bar.warp.sync
 
   // CHECK: bb{{[0-9]+}}:
-  // CHECK-NEXT: nvvm.barrier id = [[C0]] number_of_threads = [[C128]]
+  // CHECK-NEXT: nvvm.barrier id = [[C0]] number_of_threads = [[C128]] {aligned = false}
   nvvm.barrier
   ttg.warp_specialize() attributes {allocation.offset = 0 : i32, warpGroupStartIds = array<i32: 4, 8, 10>}
   default {
-    // CHECK: nvvm.barrier id = [[C0]] number_of_threads = [[C128]]
+    // CHECK: nvvm.barrier id = [[C0]] number_of_threads = [[C128]] {aligned = false}
     nvvm.barrier
     ttg.warp_yield
   }
@@ -39,7 +39,7 @@ llvm.func @rewrite_barriers() attributes {allocation.offset = 32 : i32} {
     nvvm.barrier
     ttg.warp_return
   } : () -> ()
-  // CHECK: nvvm.barrier id = [[C0]] number_of_threads = [[C128]]
+  // CHECK: nvvm.barrier id = [[C0]] number_of_threads = [[C128]] {aligned = false}
   nvvm.barrier
   llvm.return
 }
@@ -105,7 +105,7 @@ llvm.func internal @inner_func_nw4() attributes {"ws_num_warps" = 4 : i32} {
   // CHECK: "use.barrier_id"(%arg0) : (i32) -> ()
   %barrier_id = nvg.warp_group_barrier_id
   "use.barrier_id"(%barrier_id) : (i32) -> ()
-  // CHECK: nvvm.barrier id = %arg0 number_of_threads = [[C128]]
+  // CHECK: nvvm.barrier id = %arg0 number_of_threads = [[C128]] {aligned = false}
   // CHECK: llvm.call @inner_func_nw4_ws(%arg0) : (i32) -> ()
   nvvm.barrier
   llvm.call @inner_func_nw4() : () -> ()
@@ -115,7 +115,7 @@ llvm.func internal @inner_func_nw4() attributes {"ws_num_warps" = 4 : i32} {
 // CHECK: llvm.func internal @inner_func_nw2_ws(%arg0: f32 {some.attr = "some_value"}, %arg1: i32)
 llvm.func internal @inner_func_nw2(%arg0: f32 {some.attr = "some_value"}) attributes {"ws_num_warps" = 2 : i32} {
   // CHECK: [[C64:%.*]] = llvm.mlir.constant(64 : i32)
-  // CHECK: nvvm.barrier id = %arg1 number_of_threads = [[C64]]
+  // CHECK: nvvm.barrier id = %arg1 number_of_threads = [[C64]] {aligned = false}
   nvvm.barrier
   llvm.return
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -81,7 +81,9 @@ public:
     if (numThreads == 32) {
       LLVM::NVIDIA::createSyncWarp(b.getLoc(), b);
     } else {
-      NVVM::BarrierOp::create(b, b.getLoc(), handle, b.i32_val(numThreads));
+      // Only this warp partition participates, so the barrier is not CTA-aligned.
+      NVVM::BarrierOp::create(b, b.getLoc(), handle, b.i32_val(numThreads),
+                              /*aligned=*/false);
     }
   }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -81,7 +81,8 @@ public:
     if (numThreads == 32) {
       LLVM::NVIDIA::createSyncWarp(b.getLoc(), b);
     } else {
-      // Only this warp partition participates, so the barrier is not CTA-aligned.
+      // Only this warp partition participates, so the barrier is not
+      // CTA-aligned.
       NVVM::BarrierOp::create(b, b.getLoc(), handle, b.i32_val(numThreads),
                               /*aligned=*/false);
     }


### PR DESCRIPTION
Warp partitions execute on only part of a CTA, but their NVVM barriers
default to `.aligned`, which requires CTA-uniform execution. Emit
non-aligned barriers to avoid violating that requirement.

Extend the existing warp-specialization conversion regression to require
`aligned=false`.

# New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests by extending the existing `lit` regression in
  `/test/Conversion/warp_specialize_to_llvm.mlir`.
- [x] The `lit` checks follow these
  [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
  including the "tests should be minimal" section.