### PR TITLE
[Runtime] Validate thread count against the kernel's compiled warp size

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -483,7 +483,7 @@ class CompiledKernel:
         self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = driver.active.utils.load_binary(
             self.name, self.kernel, self.metadata.shared, device)
         self._module_pid = os.getpid()
-        warp_size = driver.active.get_current_target().warp_size
+        warp_size = self.metadata.warp_size
         if self.metadata.num_warps * warp_size > self.n_max_threads:
             raise_(OutOfResources(self.metadata.num_warps * warp_size, self.n_max_threads, "threads"))
         if knobs.runtime.kernel_load_end_hook is not None:


### PR DESCRIPTION
The launch check reads the live device's warp size, which assumes the kernel was compiled for it. 

AMD's launcher already computes the block size as `num_warps * metadata.warp_size` (`third_party/amd/backend/driver.c:668`), the exact product this check bounds.

It also opens the check up for out-of-tree backends whose hardware has more than one warp size - e.g. Intel GPUs run SIMD16 or SIMD32, picked per kernel.