### PR TITLE
[Release] Update Triton release cadence for PyTorch 2.15

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,6 +35,8 @@ Starting with PyTorch 2.14, Triton feature releases (`X.Y.0`) follow the PyTorch
 
 Each Triton target date is one week before the corresponding PyTorch release date. Dates are tentative and follow the [PyTorch release cadence](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence).
 
+At the release decision date, validation results determine whether to publish a patch or the next feature release.
+
 | PyTorch version | Triton release options | Release decision date | Target release date |
 | --- | --- | --- | --- |
 | 2.15 | 3.9 | --- | Oct 21, 2026 |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,12 +31,14 @@ The following compatibility matrix reflects the CPython wheels published on PyPI
 
 ## Release Cadence
 
-Starting with PyTorch 2.14, Triton feature releases (`X.Y.0`) follow the PyTorch minor release cadence, typically coinciding with every one or two PyTorch minor releases depending on the scope of new features. Each Triton target date is one week before the corresponding PyTorch release date. Dates are tentative and follow the [PyTorch release cadence](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence).
+Starting with PyTorch 2.14, Triton feature releases (`X.Y.0`) follow the PyTorch minor release cadence, typically coinciding with every one or two PyTorch minor releases depending on the scope of new features. After each Triton release, evaluation of the next feature release begins immediately. At a designated release decision date, maintainers use Triton and downstream validation results to choose between a patch of the current release and the next feature release.
 
-| Triton version | PyTorch version | Release branch opened | Release date |
+Each Triton target date is one week before the corresponding PyTorch release date. Dates are tentative and follow the [PyTorch release cadence](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence).
+
+| PyTorch version | Triton release options | Release decision date | Target release date |
 | --- | --- | --- | --- |
-| 3.9 | 2.15 | Sep 2026 | Oct 21, 2026 |
-| 3.10 | 2.16 | Nov 2026 | Dec 15, 2026 |
+| 2.15 | 3.9 | --- | Oct 21, 2026 |
+| 2.16 | 3.9.1 or 3.10 | Nov 2026 | Dec 15, 2026 |
 
 Patch releases (`X.Y.1`) are optional and are only published if major regressions are found in the corresponding minor release.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,7 +40,7 @@ At the release decision date, validation results determine whether to publish a 
 | PyTorch version | Triton release options | Release decision date | Target release date |
 | --- | --- | --- | --- |
 | 2.15 | 3.9 | --- | Oct 21, 2026 |
-| 2.16 | 3.9.1 or 3.10 | Nov 2026 | Dec 15, 2026 |
+| 2.16 | 3.9.1 or 3.10 | Nov 10, 2026 | Dec 15, 2026 |
 
 Patch releases (`X.Y.1`) are optional and are only published if major regressions are found in the corresponding minor release.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,9 +33,9 @@ The following compatibility matrix reflects the CPython wheels published on PyPI
 
 Starting with PyTorch 2.14, Triton feature releases (`X.Y.0`) follow the PyTorch minor release cadence, typically coinciding with every one or two PyTorch minor releases depending on the scope of new features.
 
-Each Triton target date is one week before the corresponding PyTorch release date. Dates are tentative and follow the [PyTorch release cadence](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence).
-
 At the release decision date, validation results determine whether to publish a patch or the next feature release.
+
+Each Triton target date is one week before the corresponding PyTorch release date. Dates are tentative and follow the [PyTorch release cadence](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence).
 
 | PyTorch version | Triton release options | Release decision date | Target release date |
 | --- | --- | --- | --- |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,7 +31,7 @@ The following compatibility matrix reflects the CPython wheels published on PyPI
 
 ## Release Cadence
 
-Starting with PyTorch 2.14, Triton feature releases (`X.Y.0`) are scheduled for every PyTorch minor release. Each Triton target date is one week before the corresponding PyTorch release date. Dates are tentative and follow the [PyTorch release cadence](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence).
+Starting with PyTorch 2.14, Triton feature releases (`X.Y.0`) follow the PyTorch minor release cadence, typically coinciding with every one or two PyTorch minor releases depending on the scope of new features. Each Triton target date is one week before the corresponding PyTorch release date. Dates are tentative and follow the [PyTorch release cadence](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence).
 
 | Triton version | PyTorch version | Release branch opened | Release date |
 | --- | --- | --- | --- |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@ The following compatibility matrix reflects the CPython wheels published on PyPI
 
 | Triton version | Python version | Manylinux version |
 | --- | --- | --- |
+| 3.8.0 | >=3.10, <=3.14 | glibc 2.27+ x86-64, AArch64 |
 | 3.7.1 | >=3.10, <=3.14 | glibc 2.27+ x86-64, AArch64 |
 | 3.7.0 | >=3.10, <=3.14 | glibc 2.27+ x86-64, AArch64 |
 | 3.6.0 | >=3.10, <=3.14 | glibc 2.27+ x86-64, AArch64 |
@@ -30,12 +31,12 @@ The following compatibility matrix reflects the CPython wheels published on PyPI
 
 ## Release Cadence
 
-Starting with PyTorch 2.14, Triton feature releases (`X.Y.0`) are scheduled for even-numbered PyTorch minor releases. Odd-numbered PyTorch minor releases receive a Triton patch update (`X.Y.1`) from the same release branch. Each Triton target date is one week before the corresponding PyTorch release date. Dates are tentative and follow the [PyTorch release cadence](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence).
+Starting with PyTorch 2.14, Triton feature releases (`X.Y.0`) are scheduled for every PyTorch minor release. Each Triton target date is one week before the corresponding PyTorch release date. Dates are tentative and follow the [PyTorch release cadence](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence).
 
-| Minor Version | Release branch opened | Release date | Patch release date (if needed) |
+| Triton version | PyTorch version | Release branch opened | Release date |
 | --- | --- | --- | --- |
-| 3.8 | Jun 2026 | Aug 26, 2026 | Oct 21, 2026 |
-| 3.9 | Oct 2026 | Dec 15, 2026 | TBD |
+| 3.9 | 2.15 | Sep 2026 | Oct 21, 2026 |
+| 3.10 | 2.16 | Nov 2026 | Dec 15, 2026 |
 
 Patch releases (`X.Y.1`) are optional and are only published if major regressions are found in the corresponding minor release.
 
@@ -45,6 +46,7 @@ The following timeline records release branch cuts and the first publication of 
 
 | Minor Version | Release branch cut | Release date | Patch Release date |
 | --- | --- | --- | --- |
+| 3.8.0 | Jun 2026 | Aug 28, 2026 | --- |
 | 3.7.0 | Feb 2026 | May 7, 2026 | Jun 17, 2026 (3.7.1) |
 | 3.6.0 | Nov 2025 | Jan 20, 2026 | --- |
 | 3.5.0 | Aug 2025 | Oct 13, 2025 | Nov 11, 2025 (3.5.1) |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,7 +31,7 @@ The following compatibility matrix reflects the CPython wheels published on PyPI
 
 ## Release Cadence
 
-Starting with PyTorch 2.14, Triton feature releases (`X.Y.0`) follow the PyTorch minor release cadence, typically coinciding with every one or two PyTorch minor releases depending on the scope of new features. After each Triton release, evaluation of the next feature release begins immediately. At a designated release decision date, maintainers use Triton and downstream validation results to choose between a patch of the current release and the next feature release.
+Starting with PyTorch 2.14, Triton feature releases (`X.Y.0`) follow the PyTorch minor release cadence, typically coinciding with every one or two PyTorch minor releases depending on the scope of new features.
 
 Each Triton target date is one week before the corresponding PyTorch release date. Dates are tentative and follow the [PyTorch release cadence](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence).
 


### PR DESCRIPTION
## Summary

- document a flexible Triton release cadence aligned with PyTorch minor releases
- schedule Triton 3.9 and a future decision between Triton 3.9.1 and 3.10
- add Triton 3.8.0 to the compatibility matrix and release history