### PR TITLE
[FPSan] Use generic fingerprints for E8M0 inline assembly

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -3231,22 +3231,6 @@ struct ElementwiseInlineAsmPattern
         !llvm::all_of(op.getResultTypes(), isFloatLike))
       return failure();
 
-    auto srcTy = dyn_cast<RankedTensorType>(op.getOperand(0).getType());
-    auto dstTy = dyn_cast<RankedTensorType>(op->getResult(0).getType());
-    if (op.getAsmString() == "cvt.rn.bf16x2.ue8m0x2 $0, $1;" &&
-        op.getConstraints() == "=r,h" && op.getPackedElement() == 2 &&
-        op.getNumOperands() == 1 && op.getNumResults() == 1 && srcTy && dstTy &&
-        srcTy.getElementType().isInteger(8) &&
-        dstTy.getElementType().isBF16()) {
-      // Preserve the portable E8M0 decoder's payload when using native
-      // conversion.
-      auto loc = op.getLoc();
-      Value payload = scaleI8ToComputePayload(rewriter, loc, op.getOperand(0),
-                                              rewriter.getBF16Type());
-      rewriter.replaceOp(op, unembedToFloat(rewriter, loc, payload, dstTy));
-      return success();
-    }
-
     uint64_t hash = stableStringHash(op.getAsmString());
     SmallVector<Value> results;
     for (auto [resultIdx, resultTy] : llvm::enumerate(op.getResultTypes())) {

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -1466,32 +1466,27 @@ def test_inline_asm_payload_semantics(device, asm, fresh_knobs):
 
 
 @gluon.jit
-def _ue8m0_decode_payload_kernel(scale_ptr, native_ptr, portable_ptr, THREADS_PER_WARP: gl.constexpr):
+def _inline_asm_ue8m0_payload_kernel(scale_ptr, out_ptr, ASM: gl.constexpr, THREADS_PER_WARP: gl.constexpr):
     layout: gl.constexpr = gl.BlockedLayout([2], [THREADS_PER_WARP], [4], [0])
     offsets = gl.arange(0, 256, layout=layout)
     scale = gl.load(scale_ptr + offsets)
-    native = gl.inline_asm_elementwise("cvt.rn.bf16x2.ue8m0x2 $0, $1;", "=r,h", [scale], dtype=gl.bfloat16,
-                                       is_pure=True, pack=2)
-    bits = gl.maximum(scale.to(gl.uint16) << 7, 0x0040).to(gl.uint16)
-    portable = bits.to(gl.bfloat16, bitcast=True)
-    portable = gl.fma(portable, gl.full((256, ), 0, gl.bfloat16, layout), portable)
-    gl.store(native_ptr + offsets, gl.fpsan.embed(native))
-    gl.store(portable_ptr + offsets, gl.fpsan.embed(portable))
+    out = gl.inline_asm_elementwise(ASM, "=r,h", [scale], dtype=gl.bfloat16, is_pure=True, pack=2)
+    gl.store(out_ptr + offsets, gl.fpsan.embed(out))
 
 
-def test_ue8m0_decode_payload_equivalence(device, fresh_knobs):
+@pytest.mark.parametrize("asm", ["cvt.rn.bf16x2.ue8m0x2 $0, $1;", "cvt.rn.bf16x2.ue8m0x2 $0,$1;"])
+def test_inline_asm_ue8m0_payload_semantics(device, asm, fresh_knobs):
     _require_cuda_backend(device)
     fresh_knobs.compilation.instrumentation_mode = "fpsan"
 
     scales = torch.arange(256, device=device, dtype=torch.int32).to(torch.uint8)
-    native = torch.empty(256, device=device, dtype=torch.int16)
-    portable = torch.empty_like(native)
-    _ue8m0_decode_payload_kernel[(1, )](scales, native, portable, THREADS_PER_WARP)
+    out = torch.empty(256, device=device, dtype=torch.int16)
+    _inline_asm_ue8m0_payload_kernel[(1, )](scales, out, asm, THREADS_PER_WARP)
 
-    bits = np.maximum(np.arange(256, dtype=np.uint16) << 7, 0x0040)
-    expected = _mix_float_bits(bits, "bf16").astype(np.uint16)
-    _assert_payload_equal(native, expected)
-    _assert_payload_equal(portable, expected)
+    # Integer operands are sign-extended before applying the assembly's tag.
+    tag = np.uint16(stable_string_hash_u64(asm) & np.uint64(0xFFFF))
+    expected = scales.cpu().numpy().view(np.int8).astype(np.int16).view(np.uint16) ^ tag
+    _assert_payload_equal(out, expected)
 
 
 @gluon.jit

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -853,13 +853,12 @@ tt.func public @inline_asm_unary_different_asm(%a: tensor<4xf32>) -> tensor<4xf3
 
 // CHECK-LABEL: @inline_asm_ue8m0_to_bf16
 tt.func public @inline_asm_ue8m0_to_bf16(%scale: tensor<4xi8>) -> tensor<4xbf16> {
-  // CHECK-DAG: arith.constant dense<7> : tensor<4xi16>
-  // CHECK-DAG: arith.constant dense<64> : tensor<4xi16>
-  // CHECK: arith.extui
-  // CHECK: arith.shli
-  // CHECK: arith.maxui
-  // CHECK: tt.bitcast
+  // CHECK: %[[TAG:.*]] = arith.constant dense<-23530> : tensor<4xi16>
+  // CHECK: %[[SCALE:.*]] = arith.extsi %arg0 : tensor<4xi8> to tensor<4xi16>
+  // CHECK: %[[PAYLOAD:.*]] = arith.xori %[[SCALE]], %[[TAG]] : tensor<4xi16>
+  // CHECK: %[[RESULT:.*]] = tti.experimental_fpsan_unembed %[[PAYLOAD]]
   // CHECK-NOT: tt.elementwise_inline_asm
+  // CHECK: tt.return %[[RESULT]]
   %decoded = tt.elementwise_inline_asm "cvt.rn.bf16x2.ue8m0x2 $0, $1;" {constraints = "=r,h", packed_element = 2 : i32, pure = true} %scale : tensor<4xi8> -> tensor<4xbf16>
   tt.return %decoded : tensor<4xbf16>
 }


### PR DESCRIPTION
FPSan currently treats one exact spelling of `cvt.rn.bf16x2.ue8m0x2` as a numeric E8M0 decoder, while other spellings use the generic inline-assembly fingerprint. Remove this exception so the conversion consistently uses the input payload and assembly-string hash, as documented for pure inline assembly.

Replace the native-versus-portable decoder equivalence test with coverage of both assembly spellings and all 256 input bytes, including signed widening to the BF16 payload width.

Validated on GB300 with ptxas 13.3.33: the new regression fails on the original code, and all 27 selected FPSan GPU cases pass with the fix. `test/TritonGPU/fpsan.mlir` also fails before the fix and passes afterward.

| Files | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Test | +17 | -23 | -6 |
| Non-test | +0 | -16 | -16 |
| All | +17 | -39 | -22 |

### Reviewer's guide

- `lib/Dialect/TritonInstrument/`: remove the assembly-specific rewrite and use existing generic fingerprinting.
- `python/test/gluon/` and `test/TritonGPU/`: check packed integer-to-BF16 fingerprinting instead of numeric decoder equivalence.
