### PR TITLE
[Build] Refresh Ninja path for cached AMD bootstrap builds

### DIFF
--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -585,6 +585,10 @@ def download_codegen_llvm(backend: str, llvm_info: dict, helper_args: BuildHelpe
 
 
 def build_amd_codegen(amd_llvm_info: dict, helper_args: BuildHelperArgs):
+    ninja_path = shutil.which("ninja")
+    if ninja_path is None:
+        raise RuntimeError("Cannot find ninja on PATH")
+
     llvm_path = download_codegen_llvm("amd", amd_llvm_info, helper_args)
     revision = f'{amd_llvm_info["llvm_hash"]}-{amd_llvm_info["build_number"]}'
     system_suffix = get_llvm_system_suffix(helper_args)
@@ -598,6 +602,7 @@ def build_amd_codegen(amd_llvm_info: dict, helper_args: BuildHelperArgs):
         "cmake",
         "-G",
         "Ninja",
+        f"-DCMAKE_MAKE_PROGRAM={ninja_path}",
         "-S",
         source_path,
         "-B",

--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -585,10 +585,6 @@ def download_codegen_llvm(backend: str, llvm_info: dict, helper_args: BuildHelpe
 
 
 def build_amd_codegen(amd_llvm_info: dict, helper_args: BuildHelperArgs):
-    ninja_path = shutil.which("ninja")
-    if ninja_path is None:
-        raise RuntimeError("Cannot find ninja on PATH")
-
     llvm_path = download_codegen_llvm("amd", amd_llvm_info, helper_args)
     revision = f'{amd_llvm_info["llvm_hash"]}-{amd_llvm_info["build_number"]}'
     system_suffix = get_llvm_system_suffix(helper_args)
@@ -602,7 +598,6 @@ def build_amd_codegen(amd_llvm_info: dict, helper_args: BuildHelperArgs):
         "cmake",
         "-G",
         "Ninja",
-        f"-DCMAKE_MAKE_PROGRAM={ninja_path}",
         "-S",
         source_path,
         "-B",
@@ -612,6 +607,9 @@ def build_amd_codegen(amd_llvm_info: dict, helper_args: BuildHelperArgs):
         f"-DTRITON_AMD_LLVM_REVISION={revision}",
         "-DCMAKE_BUILD_TYPE=Release",
     ]
+    ninja_path = shutil.which("ninja")
+    if ninja_path is not None:
+        command.append(f"-DCMAKE_MAKE_PROGRAM={ninja_path}")
     if sys.platform != "win32":
         clang = os.path.join(llvm_path, "bin", "clang")
         clangxx = os.path.join(llvm_path, "bin", "clang++")


### PR DESCRIPTION
Reusing the AMD codegen bootstrap cache across Python environments can leave CMake pointing at a missing Ninja executable, as in this [main CI failure](https://github.com/triton-lang/triton/actions/runs/34629811449/job/103363663242). When Ninja is available on the current `PATH`, pass its resolved path as `CMAKE_MAKE_PROGRAM` when configuring the bootstrap. Otherwise, preserve CMake's existing lookup and error handling.

Validated by relocating Ninja after a real AMD bootstrap build: the original code fails; the fix reconfigures successfully without recompiling. Also checked that a valid cached Ninja works when Ninja is absent from `PATH`.

| Files | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Test | +0 | -0 | +0 |
| Non-test | +3 | -0 | +3 |
| All | +3 | -0 | +3 |

### Reviewer's guide

- `python/build_helpers.py`: refresh the bootstrap's Ninja path when available, preserving CMake's fallback otherwise.
