### PR TITLE
[TUTORIALS] Stop the fused-softmax benchmark from accumulating reserved memory

### DIFF
--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -213,9 +213,10 @@ assert torch.allclose(y_triton, y_torch), (y_triton, y_torch)
         args={'M': 4096},  # values for function arguments not in `x_names` and `y_name`
     ))
 def benchmark(M, N, provider):
+    # N grows monotonically, so blocks cached by the previous case are too small to be reused
+    # by this one; release them so reserved memory does not accumulate across the sweep.
+    getattr(torch, DEVICE.type).empty_cache()
     x = torch.randn(M, N, device=DEVICE, dtype=torch.float32)
-    stream = getattr(torch, DEVICE.type).Stream()
-    getattr(torch, DEVICE.type).set_stream(stream)
     if provider == 'torch':
         ms = triton.testing.do_bench(lambda: torch.softmax(x, axis=-1))
     if provider == 'triton':


### PR DESCRIPTION
Fixes #11661

`benchmark()` created a new stream per call. PyTorch's caching allocator keeps a separate block pool per stream, so nothing freed in one case could be reused by the next, and reserved memory grew by every case's working set (the reporter shows 12.5 GiB reserved on a 6 GiB card).
Even on one stream the monotonic N leaves blocks too small for the next case; Linux releases them when `cudaMalloc` fails, but WDDM over-subscribes instead of failing, so the sweep dies with `CUDA error: out of memory`.
Drop the per-call stream and call `empty_cache()` at the start of each case. On an 8 GiB RTX 2000 Ada (Windows): before, idle reserved memory reached 35 GiB and OOM'd at case 217/294; after, worst case 20 MiB and all 294 complete.
