### PR TITLE
[CI] Remove compile warmup step timeout

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -135,7 +135,6 @@ jobs:
       - name: Run C++ unittests
         run: make test-cpp
       - name: Warm Triton compile cache
-        timeout-minutes: 10
         shell: bash
         run: |
           trace_dir="$RUNNER_TEMP/triton-ci-compile-trace"

--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -101,7 +101,6 @@ jobs:
           PYTEST_ADDOPTS: ""
         run: python3 -m pytest -n 0 -s -vv python/test/microbenchmark/consan_performance.py
       - name: Warm Triton compile cache
-        timeout-minutes: 10
         run: |
           trace_dir="$RUNNER_TEMP/triton-ci-compile-trace"
           echo "TRITON_CI_COMPILE_TRACE_DIR=$trace_dir" >> "$GITHUB_ENV"


### PR DESCRIPTION
Remove the 10-minute timeout from the Triton compile cache warmup steps in both NVIDIA and AMD integration CI so warmup can finish when compilation takes longer. The existing overall job timeouts still apply.

Validation: `git diff --check origin/main...HEAD` passed. Workflow-only change; no build or runtime tests run.
