### PR TITLE
[Python] Avoid symbolic subtraction in cdiv

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -441,6 +441,15 @@ def test_constexpr_function_from_jit():
     tl.arange(0, x)
 
 
+@filecheck_test
+@triton.jit
+def test_cdiv_constexpr():
+    # CHECK-LABEL: test_cdiv_constexpr
+    x: tl.constexpr = triton.cdiv(33, 32)
+    # CHECK: make_range {end = 2 : i32, start = 0 : i32}
+    tl.arange(0, x)
+
+
 def test_constexpr_function_from_python():
     assert constexpr_function(7) == 8
 

--- a/python/test/unit/test_utils.py
+++ b/python/test/unit/test_utils.py
@@ -1,6 +1,38 @@
 import pytest
 
+import triton
 from triton._utils import is_power_of_two, validate_block_shape
+
+
+@pytest.mark.parametrize("y", [1, 32])
+def test_cdiv_symbolic_numerator(y):
+
+    class Expr:
+
+        def __init__(self, evaluate):
+            self.evaluate = evaluate
+
+        def __add__(self, other):
+            return Expr(lambda x: self.evaluate(x) + other)
+
+        def __floordiv__(self, other):
+            return Expr(lambda x: self.evaluate(x) // other)
+
+    result = triton.cdiv(Expr(lambda x: x), y)
+    assert isinstance(result, Expr)
+    for x in [0, 1, 31, 32, 33, 64, 65]:
+        assert result.evaluate(x) == -(-x // y)
+
+
+@pytest.mark.parametrize("x", [-33, -1, 0, 1, 31, 32, 33, 2**100, 2**100 + 1])
+@pytest.mark.parametrize("y", [1, 2, 32, 2**64])
+def test_cdiv_integers(x, y):
+    assert triton.cdiv(x, y) == -(-x // y)
+
+
+def test_cdiv_zero_divisor():
+    with pytest.raises(ZeroDivisionError):
+        triton.cdiv(1, 0)
 
 
 def test_is_power_of_two():

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -67,7 +67,7 @@ __all__ = [
 
 @constexpr_function
 def cdiv(x: int, y: int):
-    return (x + y - 1) // y
+    return (x + (y - 1)) // y
 
 
 @constexpr_function


### PR DESCRIPTION
`triton.cdiv(N, 32)` currently subtracts from `N + 32`, which fails for symbolic numerators that support addition and floor division only. Compute the concrete divisor offset first so the result stays symbolic as `(N + 31) // 32`.

Python-integer results and `@constexpr_function` behavior are preserved. Symbolic support is scoped to numerators with concrete integer divisors; reassociation can change floating-point rounding.

CPU validation: 43 checks passed, covering lazy symbolic expressions, integer boundaries and large integers, division by zero, and a compiled constexpr call. Both symbolic cases fail with `TypeError` on the original implementation. The before/after runs used the exact changed Python module with a prebuilt Linux Triton runtime.

```sh
pytest -s --tb=short python/test/unit/test_utils.py python/test/unit/language/test_frontend.py::test_cdiv_constexpr
```

| Files | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Test | +41 | -0 | +41 |
| Non-test | +1 | -1 | +0 |
| All | +42 | -1 | +41 |

## Reviewer's guide

- `python/triton/`: compute `y - 1` before involving the symbolic numerator.
- `python/test/unit/`: add CPU symbolic/integer coverage and a frontend FileCheck for constexpr compilation.

<!-- codex-thread: 01a0927e-10a4-7aa3-9c4c-d8c138374b42 -->
