### PR TITLE
[KERNELS] Avoid local output allocation for fused communication

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -2,17 +2,21 @@
 # fmt: off
 from dataclasses import dataclass, fields
 import itertools
+import importlib
+from types import SimpleNamespace
 import pytest
 import torch
 from typing import Union
 import triton
+import triton.language as tl
 from triton._internal_testing import is_compile_warmup, is_hopper
 # matmul utilities
 import triton_kernels.matmul_details.opt_flags as opt_flags
-from triton_kernels.matmul import FlexCtx, PrecisionConfig, FusedActivation, FnSpecs, FnName, Epilogue
+from triton_kernels.matmul import FlexCtx, PrecisionConfig, FusedActivation, FusedComm, FnSpecs, FnName, Epilogue
 from triton_kernels.matmul import apply_precision, matmul_set_idle_sms, matmul, matmul_torch
 # numerics utilities
 from triton_kernels.numerics import InFlexData, OutFlexData
+from triton_kernels.meta import Closure
 from triton_kernels.numerics_details.mxfp import upcast_from_mxfp, quantize_mxfp8_fn, quantize_nvfp4_fn, downcast_to_mxfp_torch, upcast_from_mxfp_torch, MXFP_BLOCK_SIZE, NVFP_BLOCK_SIZE
 # testing utilities
 from triton_kernels.testing import assert_close, make_random_tensor
@@ -837,3 +841,163 @@ def test_set_idle_sms():
             assert flags.idle_sms == num_idle_sms + 1
     finally:
         matmul_set_idle_sms(0)
+
+
+@pytest.fixture
+def matmul_launch_stub(monkeypatch):
+    module = importlib.import_module("triton_kernels.matmul")
+    flags = opt_flags.OptFlags(
+        block_m=32, block_n=64, block_k=32, num_warps=4, num_stages=2,
+        group_m=1, xcd_swizzle=1, w_cache_modifier="", split_k=1,
+        is_persistent=False, idle_sms=0, epilogue_subtile=1, arch=80,
+        occupancy_target=1, target_kernel_kwargs={},
+    )
+    launches = []
+
+    class Kernel:
+        def __getitem__(self, grid):
+            return lambda *args, **kwargs: launches.append((args, kwargs))
+
+    kernels = SimpleNamespace(_matmul=Kernel(), _p_matmul=Kernel())
+    monkeypatch.setattr(module, "make_opt_flags", lambda *args, **kwargs: flags)
+    monkeypatch.setattr(module, "get_swap_xw", lambda *args: False)
+    monkeypatch.setattr(module.specializations, "get", lambda **kwargs: kernels)
+    return flags, launches
+
+
+@pytest.mark.parametrize("fused, output_kind", [(True, "none"), (True, "meta"), (True, "real"),
+                                               (False, "none"), (False, "real")])
+@pytest.mark.parametrize("m, n", [(32, 64), (0, 64), (32, 0)])
+def test_fused_comm_output_metadata(matmul_launch_stub, monkeypatch, fused, output_kind, m, n):
+    _, launches = matmul_launch_stub
+    a = torch.empty((m, 32), dtype=torch.float16)
+    b = torch.empty((32, n), dtype=torch.float16)
+    c = None if output_kind == "none" else torch.empty(
+        (m, n), dtype=torch.float16, device="meta" if output_kind == "meta" else "cpu")
+    comm = FusedComm(torch.empty(1, dtype=torch.uint64), None, None) if fused else None
+    omit_local_output = fused and output_kind != "real"
+    allocations = []
+    original_empty = torch.empty
+
+    def record_empty(*args, **kwargs):
+        tensor = original_empty(*args, **kwargs)
+        allocations.append(tensor)
+        return tensor
+
+    monkeypatch.setattr(torch, "empty", record_empty)
+    result = matmul(a, b, None, c=c, fused_comm=comm)
+    assert result.shape == (m, n)
+    assert result.dtype == a.dtype
+    assert result.is_meta == omit_local_output
+    if output_kind == "real":
+        assert result.data_ptr() == c.data_ptr()
+    if omit_local_output:
+        assert all(t.is_meta or t.untyped_storage().nbytes() == 0 for t in allocations)
+    assert len(launches) == int(m * n != 0)
+    if launches:
+        args, kwargs = launches[0]
+        assert not args[0].is_meta and not args[1].is_meta
+        assert args[0].dtype == result.dtype and args[1].dtype == result.dtype
+        assert kwargs["Y_TMA_MODE"] is None
+        if omit_local_output:
+            assert args[0].numel() == args[1].numel() == 0
+
+
+@pytest.mark.parametrize("output_kind", ["none", "meta"])
+@pytest.mark.parametrize("unsupported", ["split_k", "output_tma", "accumulation", "mx_scale"])
+def test_fused_comm_no_local_output_rejects_unsupported(matmul_launch_stub, output_kind, unsupported):
+    flags, launches = matmul_launch_stub
+    a = torch.empty((32, 32), dtype=torch.float16)
+    b = torch.empty((32, 64), dtype=torch.float16)
+    c = torch.empty((32, 64), dtype=torch.float16, device="meta") if output_kind == "meta" else None
+    comm = FusedComm(torch.empty(1, dtype=torch.uint64), None, None)
+    config = PrecisionConfig()
+    c_acc_in = None
+    if unsupported == "split_k":
+        flags.split_k = 2
+    elif unsupported == "output_tma":
+        flags.use_output_tma = True
+    elif unsupported == "accumulation":
+        c_acc_in = torch.empty((32, 64), dtype=torch.float16)
+    else:
+        config.c_mx_scale = torch.empty((32, 2), dtype=torch.uint8)
+    error = NotImplementedError if unsupported == "mx_scale" else ValueError
+    with pytest.raises(error, match="[Ff]used comm"):
+        matmul(a, b, None, c=c, fused_comm=comm, precision_config=config, c_acc_in=c_acc_in)
+    assert not launches
+
+
+@triton.jit
+def _fused_comm_map_dst(base_m, rows, base_n, cols, rows_per_peer: tl.constexpr):
+    return (rows // rows_per_peer)[:, None], rows % rows_per_peer, cols
+
+
+@triton.jit
+def _fused_comm_writes_issued():
+    pass
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("n_peers", [1, 2])
+@pytest.mark.parametrize("ragged", [False, True])
+@pytest.mark.parametrize("is_persistent", [False, True])
+def test_fused_comm_no_local_output(dtype, n_peers, ragged, is_persistent):
+    if not is_cuda() or torch.cuda.device_count() < n_peers:
+        pytest.skip("Requires CUDA devices for all communication peers")
+    if is_persistent and torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("Persistent matmul requires compute capability >= 9")
+    device = torch.cuda.current_device()
+    peer_devices = [(device + peer) % torch.cuda.device_count() for peer in range(n_peers)]
+    if n_peers > 1 and not torch.cuda.can_device_access_peer(*peer_devices):
+        pytest.skip("Requires CUDA peer access")
+    a = torch.randn((1024, 128), device=device, dtype=dtype)
+    b = torch.randn((2, 128, 256) if ragged else (128, 256), device=device, dtype=dtype)
+    metadata = make_ragged_tensor_metadata(
+        torch.tensor([512, 512], device=device, dtype=torch.int32), 1024) if ragged else None
+    scatter = torch.arange(1023, -1, -1, device=device, dtype=torch.int32) if ragged else None
+    destinations = [torch.empty((1024 // n_peers, 256), device=peer, dtype=dtype) for peer in peer_devices]
+    if n_peers > 1:
+        destinations[1].copy_(destinations[0])
+        torch.cuda.synchronize(peer_devices[1])
+    handles = torch.tensor([d.data_ptr() for d in destinations], device=device, dtype=torch.uint64)
+    comm = FusedComm(handles, Closure(_fused_comm_map_dst, (1024 // n_peers,)),
+                     Closure(_fused_comm_writes_issued, ()))
+    config = PrecisionConfig(out_dtype=dtype)
+
+    def run(c=None):
+        return matmul(a, b, None, a_ragged_metadata=metadata, scatter_indx=scatter,
+                      precision_config=config, fused_comm=comm, c=c)
+
+    def collected():
+        torch.cuda.synchronize(device)
+        return torch.cat([d.to(device) for d in destinations])
+
+    expected = torch.cat([a[:512] @ b[0], a[512:] @ b[1]]).flip(0) if ragged else a @ b
+    with opt_flags.scoped_opt_flags_constraints({"split_k": 1, "is_persistent": is_persistent}):
+        local_output = torch.empty((1024, 256), device=device, dtype=dtype)
+        assert run(local_output).data_ptr() == local_output.data_ptr()
+        reference = collected()
+        torch.testing.assert_close(reference, expected, rtol=0.02, atol=0.1)
+        for c in (None, torch.empty((1024, 256), device="meta", dtype=dtype)):
+            for destination in destinations:
+                destination.zero_()
+                torch.cuda.synchronize(destination.device)
+            result = run(c)
+            assert result.is_meta and result.shape == local_output.shape and result.dtype == dtype
+            torch.testing.assert_close(collected(), reference, rtol=0, atol=0)
+        torch.cuda.synchronize(device)
+        before = torch.cuda.memory_allocated(device)
+        torch.cuda.reset_peak_memory_stats(device)
+        run()
+        torch.cuda.synchronize(device)
+        assert torch.cuda.memory_allocated(device) == before
+        assert torch.cuda.max_memory_allocated(device) == before
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            run()
+        for _ in range(3):
+            for destination in destinations:
+                destination.zero_()
+                torch.cuda.synchronize(destination.device)
+            graph.replay()
+            torch.testing.assert_close(collected(), reference, rtol=0, atol=0)

--- a/python/triton_kernels/tests/test_matmul_metadata.py
+++ b/python/triton_kernels/tests/test_matmul_metadata.py
@@ -359,3 +359,49 @@ def test_matmul_flops_and_bytes_from_slices_handles_large_slice_count():
 
     torch.testing.assert_close(actual[f"flops{nbits}"].cpu(), expected[f"flops{nbits}"].cpu(), rtol=0, atol=0)
     torch.testing.assert_close(actual["bytes"].cpu(), expected["bytes"].to(torch.int64).cpu(), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("ragged_dimension", [None, "M", "K"])
+@pytest.mark.parametrize("n_reduce_shards", [1, 2])
+@pytest.mark.parametrize("activation_reduction", [1, 2])
+@pytest.mark.parametrize("has_local_output", [False, True])
+@pytest.mark.parametrize("allow_sync", [False, True])
+def test_matmul_launch_metadata_fused_comm_output_bytes(ragged_dimension, n_reduce_shards, activation_reduction,
+                                                        has_local_output, allow_sync):
+    if not allow_sync and ragged_dimension is not None and not torch.cuda.is_available():
+        pytest.skip("Asynchronous ragged metadata requires CUDA")
+    device = "cuda" if not allow_sync and ragged_dimension is not None else "cpu"
+    slice_sizes = None if ragged_dimension is None else torch.tensor([3, 0, 5], dtype=torch.int32, device=device)
+    n_tokens, N, K = 8, 16, 8
+    M = 4 if ragged_dimension == "K" else n_tokens
+    batch_size = 3 if ragged_dimension == "K" else 1
+    X = torch.empty((M, K), dtype=torch.float16, device=device)
+    W = torch.empty((3, K, N) if ragged_dimension == "M" else (K, N), dtype=torch.float16, device=device)
+    output_n = N // activation_reduction
+    Y = torch.empty((batch_size, M * n_reduce_shards, output_n) if has_local_output else (0, ), dtype=torch.float16,
+                    device=device)
+    args = _metadata_args(
+        ragged_dimension=ragged_dimension,
+        M=None if ragged_dimension == "M" else M,
+        N=N,
+        K=K,
+        X=X,
+        Y=Y,
+        W=W,
+        slice_sizes=slice_sizes,
+        batch_size=batch_size,
+    )
+    args.update(pYPtrs=torch.empty(n_reduce_shards, dtype=torch.uint64,
+                                   device=device), ACTIVATION_REDUCTION_N=activation_reduction, Y_VALUE_PACK_FACTOR=1,
+                n_reduce_shards=n_reduce_shards, SPLIT_K=1)
+    expected_output_bytes = batch_size * M * n_reduce_shards * output_n * 2
+    expected_weight_bytes = 2 * K * N * 2 if ragged_dimension == "M" else K * N * 2
+    expected_bytes = X.numel() * 2 + expected_weight_bytes + expected_output_bytes
+    previous_allow_sync = launch_metadata_allow_sync()
+    try:
+        set_launch_metadata_allow_sync(allow_sync)
+        actual = matmul_launch_metadata(None, _Kernel(), args)
+    finally:
+        set_launch_metadata_allow_sync(previous_allow_sync)
+    assert actual["bytes"] == expected_bytes
+    assert actual["flops16"] == 2 * M * N * K

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -269,6 +269,10 @@ def matmul(a, b, bias,
     When scatter_shard_indx is specified, the caller should ensure that the indices of different shards do not conflict.
 
     The output buffer for fused comm should be pre-allocated and passed in via fused_comm.out_handles, which contains ipc handles to the output tensors, each with shape (n_rows * n_reduce_shards, n_cols).
+    When fused_comm is provided and c is None or a meta tensor, no local output
+    storage is allocated. The returned tensor contains only shape, stride, and
+    dtype metadata; values must be read from the communication outputs. This
+    requires split_k=1, no output TMA, no c_acc_in, and no output MX scales.
     """
     is_input_batched = a.ndim == 3
     if is_input_batched:
@@ -290,6 +294,9 @@ def matmul(a, b, bias,
         epilogue = Epilogue(FnSpecs.default(), tuple(), tuple(), False)
     if fused_comm is not None and precision_config.c_mx_scale is not None:
         raise NotImplementedError("fused comm with output MX scales is not supported")
+    omit_local_output = fused_comm is not None and (c is None or c.is_meta)
+    if omit_local_output and c_acc_in is not None:
+        raise ValueError("Fused communication without local output does not support accumulation")
     n_slices = max(1, b.shape[0]) if a_ragged_metadata is None else a_ragged_metadata.n_slices
     # unpack b scale
     b_scale = precision_config.b_mx_scale
@@ -485,6 +492,11 @@ def matmul(a, b, bias,
                                  gather_indx, scatter_indx, batch_size,
                                  fused_comm.n_reduce_shards if fused_comm is not None else 1,
                                  opt_flags, intermediate_out_dtype)
+    if omit_local_output:
+        if opt_flags.split_k != 1 or opt_flags.use_output_tma:
+            raise ValueError("Fused communication without local output requires split_k=1 and no output TMA")
+        if c is None:
+            c = torch.empty(allocation.output[0], dtype=dtype_to_torch_dtype(allocation.output[1]), device="meta")
     memory = apply_allocation(allocation, c)
     # early exit
     if batch_size * M * N == 0:
@@ -570,7 +582,12 @@ def matmul(a, b, bias,
     out_tile_n = opt_flags.block_n // matmul_fused_activation.specs.reduction_n
     c_tma_block_size = [1, c_tma_block_n] if has_scatter_tma else [1, opt_flags.block_m, c_tma_block_n]
     c_tma_mode = None if not c_has_tma else "ragged" if is_c_ragged and not has_scatter_tma else "dense"
-    c_tensor_or_tma = make_tma(c, c_tma_block_size, c_tma_mode) if c_has_tma else c.storage.data
+    c_data = c.storage.data
+    if omit_local_output:
+        # Fused stores only dereference out_handles. Supply the output pointer
+        # type without allocating device storage or passing a meta tensor.
+        c_data = out_matmul_flex.reinterpret(torch.empty(0, dtype=out_matmul.dtype, device=a.device))
+    c_tensor_or_tma = make_tma(c, c_tma_block_size, c_tma_mode) if c_has_tma else c_data
     # create tma descriptor for w
     b_has_tma = opt_flags.is_persistent
     b_tensor_or_tma = make_tma(b, [1, opt_flags.block_k, opt_flags.block_n], "dense") if b_has_tma else b.storage.data
@@ -661,7 +678,7 @@ def matmul(a, b, bias,
         extra_kernel_kwargs.update(CLC=True, clc=True)
     n_valid_slices = b_tensor_or_tma.shape[0] if ragged_dimension == "M" else n_slices
     (kernels._p_matmul if opt_flags.is_persistent else kernels._matmul)[(grid,)](
-                   c_tensor_or_tma, c.storage.data, *out_matmul.stride(),
+                   c_tensor_or_tma, c_data, *out_matmul.stride(),
                    *((out_matmul_flex.expected_scale, out_matmul_scale.storage.data, None) if out_matmul_has_mx else out_matmul_flex),
                    *out_matmul_scale_strides[-4:],
                    a_tensor_or_tma, a.storage.data, *a_strides, a_transpose,

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -304,6 +304,19 @@ def _matmul_flops_and_bytes_from_slices_kernel(
     tl.store(Bytes, total_bytes)
 
 
+def _matmul_output_bytes(args, output, n_rows=None):
+    if args.get("pYPtrs") is None:
+        n_elements = output.numel() if n_rows is None else n_rows * output.shape[-1]
+    else:
+        # Fused stores write to communication buffers; the local pointer may
+        # have no storage and does not describe the logical output shape.
+        n_cols = args["N"] // args["ACTIVATION_REDUCTION_N"] // args["Y_VALUE_PACK_FACTOR"]
+        if n_rows is None:
+            n_rows = args["M"] * args["batch_size"]
+        n_elements = n_rows * n_cols * args["n_reduce_shards"] * args["SPLIT_K"]
+    return n_elements * output.element_size()
+
+
 def _matmul_flops_and_bytes_from_slices(
     args,
     M,
@@ -345,12 +358,12 @@ def _matmul_flops_and_bytes_from_slices(
         if w_bytes_per_active_slice is None:
             w_bytes_per_active_slice = 0
         # Here, we're computing dW = X.T@dY, so "W" is actually dY and "Y" is actually dW.
-        static_bytes = Y.numel() * Y.element_size() * (2 if args["OutAcc"] is not None else 1)
+        static_bytes = _matmul_output_bytes(args, Y) * (2 if args["OutAcc"] is not None else 1)
         w_bytes_per_token = W.shape[-1] * W.element_size()
     else:
         if x_bytes_per_token is None:
             x_bytes_per_token = X.shape[-1] * X.element_size()
-        y_bytes_per_token = Y.shape[-1] * Y.element_size()
+        y_bytes_per_token = _matmul_output_bytes(args, Y, n_rows=1)
         if w_bytes_per_active_slice is None:
             w_bytes_per_active_slice = W.numel() * W.element_size() // slice_sizes.numel()
 
@@ -461,7 +474,6 @@ def matmul_launch_metadata(grid, kernel, args):
 
     # sindx = args.get("WriteBackIndx", None)
     n_x_bytes = X.numel() * X.element_size()
-    n_y_bytes = Y.numel() * Y.element_size()
     n_w_bytes = W.numel() * W.element_size()
     if x_bytes_per_token is not None and M is not None:
         # A 2-D X can be shared across batched W.
@@ -475,14 +487,16 @@ def matmul_launch_metadata(grid, kernel, args):
         if args["RAGGED_DIMENSION"] == "K":
             n_x_bytes = n_read_rows * X.shape[-2] * X.element_size()
             # Here, we're computing dW = X.T@dY, so "W" is actually dY and "Y" is actually dW.
-            n_y_bytes = Y.numel() * Y.element_size() * (2 if args["OutAcc"] is not None else 1)
+            n_y_bytes = _matmul_output_bytes(args, Y) * (2 if args["OutAcc"] is not None else 1)
             n_w_bytes = n_read_rows * W.shape[-1] * W.element_size()
         else:
             n_x_bytes = n_read_rows * (x_bytes_per_token if x_bytes_per_token is not None else X.shape[-1] *
                                        X.element_size())
-            n_y_bytes = n_tokens * Y.shape[-1] * Y.element_size()
+            n_y_bytes = _matmul_output_bytes(args, Y, n_rows=n_tokens)
             n_w_bytes = (slice_sizes > 0).sum() * (w_bytes_per_active_slice if w_bytes_per_active_slice is not None else
                                                    W.numel() * W.element_size() // slice_sizes.numel())
+    else:
+        n_y_bytes = _matmul_output_bytes(args, Y)
 
     ret["bytes"] = n_x_bytes + n_y_bytes + n_w_bytes
     return ret


### PR DESCRIPTION
## Summary

Fused matmul communication writes results directly to the buffers in `FusedComm.out_handles`, but the Python wrapper still allocates a local output tensor when `c` is omitted. That allocation is unused by the fused stores.

Skip the local output allocation when fused communication is enabled and `c` is omitted or is a meta tensor. Return a meta tensor describing the logical output; callers consume values from their communication buffers. Supply zero-storage device tensors for the kernel's output-pointer arguments. Calls with a real `c` buffer retain their existing behavior.

This path requires `split_k=1` and rejects output Tensor Memory Accelerator (TMA) stores and accumulation. The existing rejection of output microscaling remains in place.

Keep profiling independent of the dummy pointer's size: derive fused-output bytes from logical dimensions, activation reduction, and replication count in both synchronous and asynchronous metadata paths.

## Validation

- 107 tests passed in validation on two NVIDIA GB300 GPUs: 68 metadata cases and 39 focused fused-communication cases.
- GPU coverage includes FP16/BF16, dense and ragged/scattered output, persistent and nonpersistent kernels, one- and two-GPU writes, numerical comparison, no additional peak CUDA allocation after warmup, and CUDA graph replay.
- Metadata coverage includes dense and ragged outputs, activation reduction, replication, real and dummy output pointers, and synchronous/asynchronous accounting.
- Metadata suite: `python -m pytest python/triton_kernels/tests/test_matmul_metadata.py -s --tb=short`.
- Fused-communication selection: `python -m pytest python/triton_kernels/tests/test_matmul.py -k fused_comm -s --tb=short`.
- Both ran with this checkout's Python sources and the installed native compiler.

## Lines Changed

| Type | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Tests | 211 | 1 | +210 |
| Core Logic | 38 | 7 | +31 |
| AutoGenerated | 0 | 0 | 0 |
| Total | 249 | 8 | +241 |

## Reviewers Guide

- `python/triton_kernels/triton_kernels/matmul.py`: allocation guards, metadata-only output, and zero-storage output-pointer arguments.
- `python/triton_kernels/triton_kernels/matmul_details/_common.py`: logical fused-output byte accounting for profiling.
- `python/triton_kernels/tests/test_matmul.py`: wrapper regression tests and GPU correctness, allocation, and graph tests.
- `python/triton_kernels/tests/test_matmul_metadata.py`: profiling regressions for real and dummy output pointers.
- No file moves or generated changes.
