### PR TITLE
[CI] Remove compile cache warmup step timeouts

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -135,7 +135,6 @@ jobs:
       - name: Run C++ unittests
         run: make test-cpp
       - name: Warm Triton compile cache
-        timeout-minutes: 10
         shell: bash
         run: |
           trace_dir="$RUNNER_TEMP/triton-ci-compile-trace"

--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -101,7 +101,6 @@ jobs:
           PYTEST_ADDOPTS: ""
         run: python3 -m pytest -n 0 -s -vv python/test/microbenchmark/consan_performance.py
       - name: Warm Triton compile cache
-        timeout-minutes: 10
         run: |
           trace_dir="$RUNNER_TEMP/triton-ci-compile-trace"
           echo "TRITON_CI_COMPILE_TRACE_DIR=$trace_dir" >> "$GITHUB_ENV"


### PR DESCRIPTION
Remove the 10-minute timeout from the Triton compile cache warming step in both NVIDIA and AMD integration CI so warming can finish when it takes longer than 10 minutes. The steps remain bounded by the existing overall job timeouts (60 minutes for NVIDIA and 45 minutes for AMD).

Validation: parsed both workflows with PyYAML, verified neither warming step has a timeout, ran `git diff --check`, and passed all applicable pre-commit hooks. GPU tests were not run for this workflow-only change.
