### PR TITLE
[AMD] Fix XF32 MFMA lowering for small K

### DIFF
--- a/python/test/regression/test_cast_matmul.py
+++ b/python/test/regression/test_cast_matmul.py
@@ -86,9 +86,8 @@ def matmul_kernel(A, B, C, M, N, K,  #
                           for (M, K, N) in [(768, 768, 1024)]  #
                           for w in input_dtypes
                           for x in input_dtypes  #
-                          for o in out_dtypes] +
-                         ([(16, 8, 16, 8, 16, 16, "int8", "float32", "float32"),
-                           (16, 8, 16, 8, 16, 16, "float32", "int8", "float32")] if is_cuda() else []))
+                          for o in out_dtypes] + [(16, 8, 16, 8, 16, 16, "int8", "float32", "float32"),
+                                                  (16, 8, 16, 8, 16, 16, "float32", "int8", "float32")])
 def test_cast_matmul(M, K, N, BLOCK_K, BLOCK_M, BLOCK_N, w_dtype, x_dtype, out_dtype, device):
     if is_hip() and (BLOCK_K, BLOCK_M, BLOCK_N) in ((64, 64, 128), (64, 16, 128)):
         pytest.skip("skip as they run out of shared memory")

--- a/test/TritonGPU/amd/mfma-xf32.mlir
+++ b/test/TritonGPU/amd/mfma-xf32.mlir
@@ -54,3 +54,39 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
     tt.return
   }
 }
+
+// -----
+
+#mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [4, 1], instrShape = [16, 16, 8], isTransposed = true}>
+#a = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
+#b = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>
+module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // The layout already supplies the two values per lane needed by XF32.
+  // CHECK-LABEL: @mfma_xf32_small_k(
+  tt.func @mfma_xf32_small_k(%a: tensor<16x8xf32, #a>, %b: tensor<8x16xf32, #b>) -> tensor<16x16xf32, #mma> {
+    %zero = arith.constant dense<0.0> : tensor<16x16xf32, #mma>
+    // CHECK: rocdl.mfma.f32.16x16x8.xf32 {{.*}} : (vector<2xf32>, vector<2xf32>, vector<4xf32>) -> vector<4xf32>
+    // CHECK-NOT: rocdl.mfma
+    // CHECK: llvm.return
+    %dot = tt.dot %a, %b, %zero, inputPrecision = tf32 : tensor<16x8xf32, #a> * tensor<8x16xf32, #b> -> tensor<16x16xf32, #mma>
+    tt.return %dot : tensor<16x16xf32, #mma>
+  }
+}
+
+// -----
+
+#mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [4, 1], instrShape = [16, 16, 8], isTransposed = true}>
+#a = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>
+#b = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>
+module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // A packed layout supplies four values per lane for two XF32 instructions.
+  // CHECK-LABEL: @mfma_xf32_packed_k(
+  tt.func @mfma_xf32_packed_k(%a: tensor<16x16xf32, #a>, %b: tensor<16x16xf32, #b>) -> tensor<16x16xf32, #mma> {
+    %zero = arith.constant dense<0.0> : tensor<16x16xf32, #mma>
+    // CHECK-COUNT-2: rocdl.mfma.f32.16x16x8.xf32 {{.*}} : (vector<2xf32>, vector<2xf32>, vector<4xf32>) -> vector<4xf32>
+    // CHECK-NOT: rocdl.mfma
+    // CHECK: llvm.return
+    %dot = tt.dot %a, %b, %zero, inputPrecision = tf32 : tensor<16x16xf32, #a> * tensor<16x16xf32, #b> -> tensor<16x16xf32, #mma>
+    tt.return %dot : tensor<16x16xf32, #mma>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -300,10 +300,6 @@ struct DotOpMFMAConversionHelper {
 
     intrinsicName = maybeMfmaIntrinsic->name;
 
-    // If we are using XF32, the kWidth (and kBase) is double that of F32.
-    if (aTensorTy.getElementType().isF32() && allowXF32)
-      kWidth *= 2;
-
     const auto kDimInstrSize = mfmaLayout.getInstrShapeForOperand(kWidth, 0)[1];
 
     auto repA = mfmaLayout.getRepForOperand(aTensorTy.getShape(), kWidth, 0);


### PR DESCRIPTION
XF32 MFMA lowering doubles the operand's already-correct `kWidth`, causing out-of-bounds access for small K. Preserve the encoded width, cover widths 2 and 4, and enable both small-K mixed-precision matmul cases on AMD.