### PR TITLE
[NVGPU] Report an unsupported wgmma form instead of asserting

### DIFF
--- a/test/Conversion/nvgpu_to_llvm_invalid.mlir
+++ b/test/Conversion/nvgpu_to_llvm_invalid.mlir
@@ -1,0 +1,21 @@
+// RUN: triton-opt %s --convert-nv-gpu-to-llvm -split-input-file -verify-diagnostics
+
+!struct_16xi32 = !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+
+// The s8 form of wgmma.mma_async exists only for untransposed operands. This is
+// the form triton-lang/triton#11586 reached, and it used to fire an assertion.
+llvm.func @wgmma_s8_transposed_b(%desc: i64, %in: !struct_16xi32) {
+  %false = llvm.mlir.constant(false) : i1
+  // expected-error @+1 {{unsupported wgmma instruction m64n32k32 with A=s8, B=s8, C=s32, layoutA=row, layoutB=row; this element type combination exists only for untransposed operands}}
+  %acc0 = nvg.wgmma %desc, %desc, %false {
+    eltTypeA = 0 : i32,
+    eltTypeB = 0 : i32,
+    eltTypeC = 1 : i32,
+    layoutA = 0 : i32,
+    layoutB = 0 : i32,
+    m = 64 : i32,
+    n = 32 : i32,
+    k = 32 : i32
+  } : (i64, i64, i1) -> !struct_16xi32
+  llvm.return
+}

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -351,12 +351,93 @@ public:
   }
 };
 
+// Whether wgmma.mma_async has an encoding for these element types, shape and
+// operand layouts (PTX ISA, asynchronous warpgroup level matrix instructions).
+// `needTransArgs` and `floatTypeWGMMA` describe the admitted form.
+static bool isSupportedWGMMA(ttn::WGMMAEltType eltTypeA,
+                             ttn::WGMMAEltType eltTypeB,
+                             ttn::WGMMAEltType eltTypeC, unsigned m, unsigned n,
+                             unsigned k, bool transA, bool transB,
+                             bool &needTransArgs, bool &floatTypeWGMMA) {
+  using namespace ttn;
+  bool supported = false;
+  // Below instructions do support transposing, must pass `trans` arguments
+  supported |=
+      (eltTypeA == WGMMAEltType::f16) && (eltTypeB == WGMMAEltType::f16) &&
+      (eltTypeC == WGMMAEltType::f16 || eltTypeC == WGMMAEltType::f32) &&
+      (m == 64 && 8 <= n && n <= 256 && k == 16);
+  supported |= (eltTypeA == WGMMAEltType::bf16) &&
+               (eltTypeB == WGMMAEltType::bf16) &&
+               (eltTypeC == WGMMAEltType::f32) &&
+               (m == 64 && 8 <= n && n <= 256 && k == 16);
+  needTransArgs = supported;
+  floatTypeWGMMA = supported;
+  // Below instructions do not support transposing
+  if (!supported && !transA && !transB) {
+    supported |= (eltTypeA == WGMMAEltType::tf32) &&
+                 (eltTypeB == WGMMAEltType::tf32) &&
+                 (eltTypeC == WGMMAEltType::f32) &&
+                 (m == 64 && 8 <= n && n <= 256 && k == 8);
+    supported |=
+        (eltTypeA == WGMMAEltType::e4m3 || eltTypeA == WGMMAEltType::e5m2) &&
+        (eltTypeB == WGMMAEltType::e4m3 || eltTypeB == WGMMAEltType::e5m2) &&
+        (eltTypeC == WGMMAEltType::f16 || eltTypeC == WGMMAEltType::f32) &&
+        (m == 64 && 8 <= n && n <= 256 && k == 32);
+    floatTypeWGMMA = supported;
+    // Below instructions are integer-based
+    supported |= (eltTypeA == WGMMAEltType::s8) &&
+                 (eltTypeB == WGMMAEltType::s8) &&
+                 (eltTypeC == WGMMAEltType::s32) &&
+                 (m == 64 && 8 <= n && n <= 224 && k == 32);
+  }
+  return supported;
+}
+
+// Whether `op` has a wgmma.mma_async encoding at all.
+static bool hasWGMMAEncoding(ttn::WGMMAOp op) {
+  using namespace ttn;
+  bool needTransArgs = false, floatTypeWGMMA = false;
+  return isSupportedWGMMA(
+      op.getEltTypeA(), op.getEltTypeB(), op.getEltTypeC(), op.getM(),
+      op.getN(), op.getK(), op.getLayoutA() == WGMMALayout::col,
+      op.getLayoutB() == WGMMALayout::row, needTransArgs, floatTypeWGMMA);
+}
+
+// A form with no wgmma.mma_async encoding is reported on the op instead of
+// tripping the assertion in getPtxAsm, which took the whole process down
+// (triton-lang/triton#11586: an s8 operand B left untransposed by warp
+// specialization). Called once per op after the rewrite, so the greedy driver
+// retrying the pattern does not repeat the diagnostic.
+static InFlightDiagnostic reportUnsupportedWGMMA(ttn::WGMMAOp op) {
+  using namespace ttn;
+  bool transA = op.getLayoutA() == WGMMALayout::col;
+  bool transB = op.getLayoutB() == WGMMALayout::row;
+  bool needTransArgs = false, floatTypeWGMMA = false;
+  InFlightDiagnostic diag =
+      op.emitOpError() << "unsupported wgmma instruction m" << op.getM() << "n"
+                       << op.getN() << "k" << op.getK()
+                       << " with A=" << stringifyWGMMAEltType(op.getEltTypeA())
+                       << ", B=" << stringifyWGMMAEltType(op.getEltTypeB())
+                       << ", C=" << stringifyWGMMAEltType(op.getEltTypeC())
+                       << ", layoutA=" << stringifyWGMMALayout(op.getLayoutA())
+                       << ", layoutB=" << stringifyWGMMALayout(op.getLayoutB());
+  if ((transA || transB) &&
+      isSupportedWGMMA(op.getEltTypeA(), op.getEltTypeB(), op.getEltTypeC(),
+                       op.getM(), op.getN(), op.getK(), false, false,
+                       needTransArgs, floatTypeWGMMA))
+    diag << "; this element type combination exists only for untransposed "
+            "operands";
+  return diag;
+}
+
 class WGMMAOpPattern : public OpRewritePattern<ttn::WGMMAOp> {
 public:
   using OpRewritePattern<ttn::WGMMAOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(ttn::WGMMAOp op,
                                 PatternRewriter &rewriter) const override {
+    if (!hasWGMMAEncoding(op))
+      return rewriter.notifyMatchFailure(op, "no wgmma.mma_async encoding");
     return rewriteAsPtxAsm(op, rewriter, getPtxAsm(op),
                            getOperandsAndConstraints(op),
                            getOutputConstraints(op));
@@ -433,37 +514,11 @@ public:
     // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#asynchronous-warpgroup-level-matrix-instructions-wgmma-mma
     bool transA = layoutA == WGMMALayout::col;
     bool transB = layoutB == WGMMALayout::row;
-    bool supported = false, needTransArgs = false, floatTypeWGMMA = false;
+    bool needTransArgs = false, floatTypeWGMMA = false;
     assert(m % 8 == 0 && n % 8 == 0 && k % 8 == 0);
-    // Below instructions do support transposing, must pass `trans` arguments
-    supported |=
-        (eltTypeA == WGMMAEltType::f16) && (eltTypeB == WGMMAEltType::f16) &&
-        (eltTypeC == WGMMAEltType::f16 || eltTypeC == WGMMAEltType::f32) &&
-        (m == 64 && 8 <= n && n <= 256 && k == 16);
-    supported |= (eltTypeA == WGMMAEltType::bf16) &&
-                 (eltTypeB == WGMMAEltType::bf16) &&
-                 (eltTypeC == WGMMAEltType::f32) &&
-                 (m == 64 && 8 <= n && n <= 256 && k == 16);
-    needTransArgs = supported;
-    floatTypeWGMMA = supported;
-    // Below instructions do not support transposing
-    if (!supported && !transA && !transB) {
-      supported |= (eltTypeA == WGMMAEltType::tf32) &&
-                   (eltTypeB == WGMMAEltType::tf32) &&
-                   (eltTypeC == WGMMAEltType::f32) &&
-                   (m == 64 && 8 <= n && n <= 256 && k == 8);
-      supported |=
-          (eltTypeA == WGMMAEltType::e4m3 || eltTypeA == WGMMAEltType::e5m2) &&
-          (eltTypeB == WGMMAEltType::e4m3 || eltTypeB == WGMMAEltType::e5m2) &&
-          (eltTypeC == WGMMAEltType::f16 || eltTypeC == WGMMAEltType::f32) &&
-          (m == 64 && 8 <= n && n <= 256 && k == 32);
-      floatTypeWGMMA = supported;
-      // Below instructions are integer-based
-      supported |= (eltTypeA == WGMMAEltType::s8) &&
-                   (eltTypeB == WGMMAEltType::s8) &&
-                   (eltTypeC == WGMMAEltType::s32) &&
-                   (m == 64 && 8 <= n && n <= 224 && k == 32);
-    }
+    [[maybe_unused]] bool supported =
+        isSupportedWGMMA(eltTypeA, eltTypeB, eltTypeC, m, n, k, transA, transB,
+                         needTransArgs, floatTypeWGMMA);
     assert(supported && "WGMMA type or shape is not supported");
 
     // Operands
@@ -674,6 +729,15 @@ public:
 
     if (applyPatternsGreedily(mod, std::move(patterns)).failed())
       signalPassFailure();
+    // A wgmma the pattern declined is still in the module: report it and fail
+    // the pass here rather than in the LLVM translation.
+    bool declined = false;
+    mod.walk([&](ttn::WGMMAOp op) {
+      declined = true;
+      (void)reportUnsupportedWGMMA(op);
+    });
+    if (declined)
+      return signalPassFailure();
 
     lowerTensorMemoryAlloc(mod);
     makeAllWarpGroupsIsolatedFromAbove(mod);


### PR DESCRIPTION
`WGMMAOpPattern::getPtxAsm` asserts when the element types, shape and operand layouts have no `wgmma.mma_async` encoding, which takes the whole process down. #11586 reaches it with an s8 operand B that warp specialization leaves untransposed; the layout question itself is being handled separately, as discussed on the issue.

This shares the support predicate between the assembler and a check the pattern runs first. A form without an encoding is left in place and reported once on the op after the rewrite (so the greedy driver retrying the pattern does not repeat it), naming the shape, the element types and the layouts, and saying when the element type combination exists only for untransposed operands. The pass then fails instead of handing the op to the LLVM translation. The assertion in `getPtxAsm` stays as documentation of the invariant.

On the reproducer of #11586 the compile now ends with

```
error: 'nvg.wgmma' op unsupported wgmma instruction m64n32k32 with A=s8, B=s8, C=s32, layoutA=row, layoutB=row; this element type combination exists only for untransposed operands
RuntimeError: PassManager::run failed
```

and exit code 1, where it used to abort with 134. Test: a `-verify-diagnostics` lit case with that form; the Conversion lit suite passes.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
  - [ ] This PR does not need a test because `FILL THIS IN`.
- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices)
