### PR TITLE
[release/3.8] [NVIDIA] Synchronize multi-CTA kernels at exit (#10656)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -340,18 +340,12 @@ void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
   }
 
   // Any path from distributed shared memory use to kernel exit must include a
-  // cluster barrier.
+  // cluster barrier. Conservatively insert the barrier since we can't analyze
+  // memory effects properly in warp specialized kernels.
   if (op->hasTrait<OpTrait::ReturnLike>() &&
       isa<FunctionOpInterface>(op->getParentOp())) {
-    // During TMEM deallocation lowering we emit a cluster sync for 2CTA
-    // kernels, as we need to sync before the TMA deallocation.
-    // Note that 2CTA kernels must have a tcgen05_mma instruction and thus must
-    // use TensorMemory
-    // According to NVIDIA this is enough, so we don't need an extra
-    // end-of-kernel barrier
     auto funcOp = cast<FunctionOpInterface>(op->getParentOp());
-    if (isKernel(funcOp) && hasUnresolvedCrossClusterDependency(*blockInfo) &&
-        !getModuleTwoCTAs(funcOp)) {
+    if (isKernel(funcOp)) {
       builder->setInsertionPoint(op);
       ttng::ClusterBarrierOp::create(*builder, op->getLoc());
       blockInfo->sync();

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -156,20 +156,29 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @end_cluster_barrier_without_shared_memory
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: tt.return
+  tt.func @end_cluster_barrier_without_shared_memory() {
+    tt.return
+  }
+}
+
+// -----
+
 #sharedA = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
 #sharedB = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CGALayout = [[0, 1]]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  // Negative test: in 2CTA kernels with non-zero tensor memory size, TMEM
-  // teardown sync at kernel exit means we should not add an extra cluster barrier.
-  // CHECK-LABEL: @no_end_cluster_barrier_for_mma_with_tmem_teardown
+  // CHECK-LABEL: @end_cluster_barrier_for_mma_with_tmem_teardown
   // CHECK: ttng.tmem_alloc
   // CHECK: ttng.tc_gen5_mma
-  // CHECK-NOT: ttng.cluster_barrier
-  // CHECK: tt.return
-  tt.func @no_end_cluster_barrier_for_mma_with_tmem_teardown() {
+  // CHECK: ttng.cluster_barrier
+  // CHECK-NEXT: tt.return
+  tt.func @end_cluster_barrier_for_mma_with_tmem_teardown() {
     %true = arith.constant true
     %a = ttg.local_alloc : () -> !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
     %b = ttg.local_alloc : () -> !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>
@@ -353,7 +362,11 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // Negative test: no cluster barrier should be inserted for multiCTA when the layouts don't cross CTAs
   // CHECK-LABEL: @no_cluster_convert_block_trivial
   // CHECK-NOT: ttng.cluster_barrier
-  // CHECK: tt.return
+  // CHECK: ttg.local_load
+
+  // FIXME: Conservatively insert a cluster barrier.
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: tt.return
   tt.func @no_cluster_convert_block_trivial() -> tensor<256x128xf16, #blockedSrc> {
     %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSrc>
     %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedSrc> -> tensor<256x128xf16, #blockedDst>
@@ -409,10 +422,12 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  // Negative test: no cluster barrier should be inserted for multiCTA reduce when the axis is not split
+  // No dependency barrier is needed when the reduction axis is not split.
   // CHECK-LABEL: @no_cluster_reduce_unsplit_axis
   // CHECK-NOT: ttng.cluster_barrier
-  // CHECK: tt.return
+  // CHECK: ttg.local_load
+  // CHECK-NEXT: ttng.cluster_barrier
+  // CHECK-NEXT: tt.return
   tt.func @no_cluster_reduce_unsplit_axis() -> tensor<256xf16, #slice1> {
     %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
     %red = "tt.reduce"(%cst) ({
@@ -583,7 +598,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
   // CHECK: ttng.wait_barrier
   // CHECK: ttng.cluster_barrier
-  // CHECK: tt.return
+  // CHECK-NEXT: tt.return
   tt.func @no_cluster_when_same_allocation(%desc: !tt.tensordesc<64x128xf16, #nvmma>) -> tensor<64x128xf16, #blocked> {
     %c0 = arith.constant 0 : i32
     %true = arith.constant true


### PR DESCRIPTION
Cherry-pick of the `ClusterBarrierInsertion` part of #10656 (8c8f04f642) onto `release/3.8.x`: a cluster barrier before every return of a multi-CTA kernel, unconditionally.

3.8.0 emits no cluster barrier at exit, so a kernel whose lowering reads a peer CTA's shared memory (the scalar atomic broadcast through `mapa.shared::cluster`) lets CTA 0 return while the other CTAs are still reading from it. On sm_120 the launch fails with `unspecified launch failure`, the error is sticky for the process (#11730), and it is the failure #10825 skipped around on main. With the barrier the release's own `test_scalar_atomic_cas_multicta_result` and `test_tensor_atomic_cas_multicta_result` pass on an RTX PRO 6000; I checked that by patching this barrier into the wheel's PTX through `TRITON_KERNEL_OVERRIDE` before building the branch.

Built with the branch's LLVM (5f07f818); `lit test/TritonNvidiaGPU` passes and `membar-cluster.mlir` is updated as in #10656. The box I built on is sm_89, so the built branch itself has not run on sm_120 yet; I'll add that result here when I have it.
