### PR TITLE
[TEST] Run the scalar multi-CTA atomic_cas test on sm12x again

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -30,7 +30,6 @@ from triton._internal_testing import (
     is_compile_warmup,
     is_interpreter,
     is_hopper,
-    is_sm12x,
     is_hip,
     is_hip_cdna,
     is_hip_cdna2,
@@ -2138,7 +2137,6 @@ def test_atomic_cas(sem, num_ctas, dtype_str, device):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
                     reason="num_ctas > 1 requires NVIDIA SM90+ (Hopper)")
-@pytest.mark.skipif(is_sm12x(), reason="scalar multi-CTA atomic_cas is not supported on sm12x (consumer Blackwell)")
 def test_scalar_atomic_cas_multicta_result(device):
 
     @triton.jit


### PR DESCRIPTION
#10825 skipped this test on sm120 because the launch failed there with a sticky `unspecified launch failure`. That failure is the missing cluster barrier at kernel exit, which #10656 added three hours after the skip landed (CTA 0 returned while the other CTAs still read its shared memory through `mapa.shared::cluster`), so main has been fine on sm120 since July.

On an RTX PRO 6000 (sm_120) at 42c5e89c3 the test passes with the skip removed, its tensor siblings pass with it (6/6), and the 768 `test_bin_op` cases that follow them in the same process are unaffected. The 3.8.0 wheel still has the failure; that is #11730, with the backport in #11731.
