### PR TITLE
[release/3.8] [BACKEND] Disable unaligned descriptor -> TMA conversion (#10898)

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -128,6 +128,10 @@ inline bool isTMALoad(Operation *op) {
   return isa<DescriptorLoadLikeOpInterface>(op);
 }
 
+// Return true if Tensor Descriptor load can satisfy TMA's
+// shared-memory address alignment requirement.
+bool canPipelineTMALoad(Operation *op);
+
 // Determine if the operation can be lowered to an async load.
 bool canBeAsyncLoad(Operation *op);
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -107,8 +107,16 @@ public:
         return false;
       }
     }
-    if (isa<tt::DescriptorLoadLikeOpInterface>(op))
+    if (auto loadOp = dyn_cast<tt::DescriptorLoadLikeOpInterface>(op)) {
+      auto descTy = cast<tt::TensorDescType>(loadOp.getDesc().getType());
+      if (descTy.getSharedLayout() && !canPipelineTMALoad(op)) {
+        LDBG("TMA load " << *op
+                         << " has a per-stage allocation that is not aligned "
+                            "for pipelining");
+        return false;
+      }
       return true;
+    }
     if (!canHaveSharedEncoding(cast<tt::LoadOp>(op))) {
       LDBG("Load " << *op << " cannot have shared encoding");
       return false;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -479,7 +479,8 @@ scf::ForOp lowerLoads(scf::ForOp forOp, CoarseSchedule &schedule,
           contiguity = vec;
         }
       }
-      if (canUseAsyncCp || isTMALoad(&op)) {
+      bool canUseTMA = isTMALoad(&op) && canPipelineTMALoad(&op);
+      if (canUseAsyncCp || canUseTMA) {
         if (loadRequiresAdditionalBuffer(&op)) {
           // Allocate additional buffer required by the wgmma pipelining.
           stageDiff += 1;
@@ -489,15 +490,22 @@ scf::ForOp lowerLoads(scf::ForOp forOp, CoarseSchedule &schedule,
         asyncLoad.contiguity = contiguity;
         asyncLoad.sharedEncoding = sharedEncoding;
       } else if (stageDiff > 1) {
-        // Distance-1 loads can in most cases be pipelined in registers without
-        // any performance degradation, as the schedule will usually reorder the
-        // user and the producer so there is no liverange overlap, and no copy
-        // needed.
-        op.emitRemark() << "Pipelining load that cannot use vectorized "
-                           "copy. This will likely "
-                           "lead to pipelining in registers and severe "
-                           "performance degradation.";
+        if (isTMALoad(&op)) {
+          op.emitRemark()
+              << "Not pipelining TMA load because the per-stage shared-memory "
+                 "allocation size is not a multiple of the 128-byte TMA "
+                 "alignment.";
+        } else {
+          op.emitRemark() << "Pipelining load that cannot use vectorized "
+                             "copy. This will likely "
+                             "lead to pipelining in registers and severe "
+                             "performance degradation.";
+        }
       }
+      // Otherwise, stageDiff == 1. Distance-1 loads can generally be pipelined
+      // in registers without any performance degradation because the schedule
+      // will usually reorder the producer and user so that their live ranges do
+      // not overlap and no copy is needed.
     }
   }
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -405,9 +405,18 @@ Value mlir::triton::createAlloc(Operation *insertBefore, RankedTensorType ty,
   return alloc;
 }
 
+bool mlir::triton::canPipelineTMALoad(Operation *op) {
+  auto tensorTy = cast<RankedTensorType>(op->getResultTypes()[0]);
+  auto sharedEncoding = getSharedEncoding(op);
+  int64_t stageSizeInBits = product(ttg::getAllocationShapePerCTA(
+                                sharedEncoding, tensorTy.getShape())) *
+                            tensorTy.getElementTypeBitWidth();
+  return stageSizeInBits % (ttng::TMA_ALIGN * 8) == 0;
+}
+
 bool mlir::triton::canBeAsyncLoad(Operation *op) {
   if (mlir::triton::isTMALoad(op)) {
-    return true;
+    return canPipelineTMALoad(op);
   }
   assert(isa<tt::LoadOp>(op));
   ttg::SharedEncodingTrait sharedEncoding = mlir::triton::getSharedEncoding(op);

--- a/python/test/unit/language/test_pipeliner.py
+++ b/python/test/unit/language/test_pipeliner.py
@@ -112,6 +112,14 @@ def vecadd_kernel(a_ptr, b_ptr, output_ptr, n_elements, num_blocks, BLOCK_SIZE: 
 
 
 @triton.jit
+def small_tma_load_kernel(input_desc, output_ptr, N: tl.constexpr):
+    offsets = tl.arange(0, 4)
+    for block_start in tl.range(0, N, 4, num_stages=3):
+        value = input_desc.load([block_start])
+        tl.store(output_ptr + block_start + offsets, value)
+
+
+@triton.jit
 def mxfp_to_bf16_kernel(
     x_ptr,
     scale_ptr,
@@ -316,6 +324,24 @@ def test_pipeline_matmul(scale, device):
                 assert ttgir.count("ttng.warp_group_dot") != 0, "warp_group_dot not found"
             elif cc[0] < 9:
                 assert ttgir.count("ttg.dot") != 0, "dot not found"
+
+
+def test_tma_load_unaligned_stage_size(device):
+    if not is_cuda() or not is_hopper_or_newer():
+        pytest.skip("TMA requires Hopper or newer")
+
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    inp = torch.arange(12, dtype=torch.float32, device=device)
+    output = torch.empty_like(inp)
+    desc = TensorDescriptor.from_tensor(inp, block_shape=[4])
+    kernel = small_tma_load_kernel[(1, )](desc, output, inp.numel())
+
+    torch.testing.assert_close(output, inp)
+    ttgir = kernel.asm["ttgir"]
+    assert "ttng.async_tma_copy_global_to_local" in ttgir
+    assert "ttg.local_alloc : () -> !ttg.memdesc<4xf32" in ttgir
+    assert "ttg.local_alloc : () -> !ttg.memdesc<3x4xf32" not in ttgir
 
 
 def test_pipeline_vecadd(device):

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -381,6 +381,28 @@ tt.func @intermediate_use_cust_stages(%lb : index, %ub : index, %step : index,
 
 // -----
 
+#tiny_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#tiny_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: @unaligned_tma_stage_size
+  // CHECK: scf.for
+  // CHECK: tt.descriptor_load
+  // CHECK-NOT: tt.latency
+  // CHECK: "use"
+  tt.func @unaligned_tma_stage_size(%desc: !tt.tensordesc<4xf32, #tiny_shared>,
+                                    %lb: index, %ub: index, %step: index) {
+    %c0 = arith.constant 0 : i32
+    scf.for %iv = %lb to %ub step %step {
+      %load = tt.descriptor_load %desc[%c0] : !tt.tensordesc<4xf32, #tiny_shared> -> tensor<4xf32, #tiny_blocked>
+      "use"(%load) : (tensor<4xf32, #tiny_blocked>) -> ()
+    } {tt.num_stages = 3 : i32}
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-test-pipeline-lower-loop -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-test-pipeline-lower-loop -triton-nvidia-tma-lowering -canonicalize | FileCheck %s --check-prefix=TMA-LOWERING
 #nvmma_128 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 
 #A = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -16,6 +17,39 @@ tt.func @unscheduled_loop(%lb : index, %ub : index, %step : index,
   }
   tt.return
 }
+}
+
+// -----
+
+#tiny_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#tiny_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: @unaligned_tma_stage_size
+  // CHECK-NOT: ttg.local_alloc
+  // CHECK: scf.for
+  // CHECK-NOT: ttng.async_tma_copy_global_to_local
+  // CHECK: tt.descriptor_load
+  // CHECK-NOT: ttng.async_tma_copy_global_to_local
+  // CHECK: "use"
+  // CHECK-NOT: ttng.async_tma_copy_global_to_local
+  // CHECK: tt.return
+  // TMA-LOWERING-LABEL: @unaligned_tma_stage_size
+  // TMA-LOWERING-NOT: ttg.local_alloc : () -> !ttg.memdesc<3x4xf32
+  // TMA-LOWERING: scf.for
+  // TMA-LOWERING: ttg.local_alloc : () -> !ttg.memdesc<4xf32
+  // TMA-LOWERING: ttng.async_tma_copy_global_to_local
+  // TMA-LOWERING: ttng.wait_barrier
+  // TMA-LOWERING: ttg.local_load
+  tt.func @unaligned_tma_stage_size(%desc: !tt.tensordesc<4xf32, #tiny_shared>,
+                                    %lb: index, %ub: index, %step: index) {
+    %c0 = arith.constant 0 : i32
+    scf.for %iv = %lb to %ub step %step {
+      %load = tt.descriptor_load %desc[%c0] {loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<4xf32, #tiny_shared> -> tensor<4xf32, #tiny_blocked>
+      "use"(%load) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<4xf32, #tiny_blocked>) -> ()
+    } {tt.scheduled_max_stage = 2 : i32}
+    tt.return
+  }
 }
 
 // -----


### PR DESCRIPTION
Cherry-pick of #10898 (aeef4e77e) onto `release/3.8.x`, for #11735.

On 3.8.0 a pipelined load whose descriptor stage size is not 16-byte aligned is still converted to TMA and faults on the device: main's `test_tma_load_unaligned_stage_size` ends in `CUDA error: misaligned address` on the wheel, and the error is sticky for the process. #10898 stops the conversion for unaligned descriptors.

Applies cleanly (7 files). Built on `release/3.8.x` with the branch's LLVM (5f07f818) on an RTX PRO 6000 (sm_120): the test passes.
