### PR TITLE
[release/3.8] [Triton] Fix E8M0 scale decoding (#11624, core) and scaled-dot k_pack forwarding (#11613)

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h
@@ -16,7 +16,8 @@ protected:
                            PatternRewriter &rewriter) const;
   TypedValue<RankedTensorType> scaleTo16(PatternRewriter &rewriter,
                                          TypedValue<RankedTensorType> scale,
-                                         FloatType computeType) const;
+                                         FloatType computeType,
+                                         bool handleNan) const;
   TypedValue<RankedTensorType>
   broadcastScale(PatternRewriter &rewriter, DotScaledOp scaledDotOp,
                  ModuleOp mod, TypedValue<RankedTensorType> scale,
@@ -37,7 +38,7 @@ protected:
   extendAndBroadcastScale(PatternRewriter &rewriter, DotScaledOp scaledDotOp,
                           TypedValue<RankedTensorType> &scale,
                           FloatType computeType, RankedTensorType dstType,
-                          int opIdx) const;
+                          int opIdx, bool handleNan) const;
   static SmallVector<int, 2> getTransposeOrder(int rank);
 };
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -210,7 +210,8 @@ def TritonGPUAccelerateMatmul : Pass<"tritongpu-accelerate-matmul", "mlir::Modul
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
                            "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
-                           "mlir::triton::TritonDialect"];
+                           "mlir::triton::TritonDialect",
+                           "mlir::math::MathDialect"];
 }
 
 def TritonGPUOptimizeDotOperands : Pass<"tritongpu-optimize-dot-operands", "mlir::ModuleOp"> {

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -1,4 +1,5 @@
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -1029,7 +1029,9 @@ static void transposeDotOp(DotScaledOp dotOp) {
   Value result = DotScaledOp::create(
       builder, dotOp.getLoc(), cTransposed.getType(), rhsTransposed,
       lhsTransposed, cTransposed, dotOp.getBScale(), dotOp.getAScale(),
-      dotOp.getBElemType(), dotOp.getAElemType(), dotOp.getFastMath());
+      dotOp.getBElemType(), dotOp.getAElemType(), dotOp.getFastMath(),
+      /*lhs_k_pack=*/dotOp.getRhsKPack(),
+      /*rhs_k_pack=*/dotOp.getLhsKPack());
   Operation *transposedResult =
       TransOp::create(builder, result.getLoc(), result, transOrder);
   dotOp.replaceAllUsesWith(transposedResult);

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
@@ -1,5 +1,6 @@
 #include "triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h"
 
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Support/LogicalResult.h"
@@ -58,7 +59,7 @@ DecomposeScaledBlocked::getComputeType(ScaleDotElemType aType,
 TypedValue<RankedTensorType>
 DecomposeScaledBlocked::scaleTo16(PatternRewriter &rewriter,
                                   TypedValue<RankedTensorType> scale,
-                                  FloatType computeType) const {
+                                  FloatType computeType, bool handleNan) const {
   auto loc = scale.getLoc();
   auto scaleTy = scale.getType();
   assert(computeType == rewriter.getBF16Type() ||
@@ -86,9 +87,24 @@ DecomposeScaledBlocked::scaleTo16(PatternRewriter &rewriter,
       arith::ConstantIntOp::create(rewriter, loc, shiftValue, intWidth);
   auto shift =
       SplatOp::create(rewriter, loc, scaleTy.clone(intType), shiftConst);
-  auto shlRes = arith::ShLIOp::create(rewriter, loc, zexted, shift);
+  Value scaleBits = arith::ShLIOp::create(rewriter, loc, zexted, shift);
+  if (computeType.isBF16()) {
+    // E8M0 byte zero is 2^-127, which is subnormal in bf16 and rounds to
+    // zero in fp16.
+    auto minScaleBits = arith::ConstantIntOp::create(rewriter, loc, 0x0040, 16);
+    auto minScale =
+        SplatOp::create(rewriter, loc, scaleTy.clone(intType), minScaleBits);
+    scaleBits = arith::MaxUIOp::create(rewriter, loc, scaleBits, minScale);
+  }
   Value scaleFP =
-      BitcastOp::create(rewriter, loc, scaleTy.clone(largeFpType), shlRes);
+      BitcastOp::create(rewriter, loc, scaleTy.clone(largeFpType), scaleBits);
+  if (handleNan) {
+    // Preserve finite scales and turn byte 255's infinity encoding into NaN.
+    auto zero =
+        arith::ConstantOp::create(rewriter, loc, scaleFP.getType(),
+                                  rewriter.getZeroAttr(scaleFP.getType()));
+    scaleFP = math::FmaOp::create(rewriter, loc, scaleFP, zero, scaleFP);
+  }
   if (largeFpType != computeType) {
     scaleFP = arith::TruncFOp::create(rewriter, loc, scaleTy.clone(computeType),
                                       scaleFP);
@@ -155,7 +171,7 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::maskNan(
   TypedValue<RankedTensorType> scaleIsNan;
   if (isa<FloatType>(scaleTy.getElementType())) {
     auto computeType = cast<FloatType>(mxfp.getType().getElementType());
-    auto scaleFp = scaleTo16(rewriter, scale, computeType);
+    auto scaleFp = scaleTo16(rewriter, scale, computeType, /*handleNan=*/true);
     scaleIsNan = cast<TypedValue<RankedTensorType>>(
         arith::CmpFOp::create(rewriter, loc, arith::CmpFPredicate::UNO, scaleFp,
                               scaleFp)
@@ -215,22 +231,19 @@ DecomposeScaledBlocked::scaleArg(PatternRewriter &rewriter,
   if (!scale)
     return v;
 
-  // 1) Cast scale to fp16/bf16, broadcast it and convert its layout
-  auto reshapeScale = extendAndBroadcastScale(rewriter, scaledDotOp, scale,
-                                              computeType, v.getType(), opIdx);
+  // Cast scale to fp16/bf16, broadcast it and convert its layout.
+  auto reshapeScale = extendAndBroadcastScale(
+      rewriter, scaledDotOp, scale, computeType, v.getType(), opIdx,
+      /*handleNan=*/!scaledDotOp.getFastMath());
 
-  // 2) Multiply
-  auto mxfp = cast<TypedValue<RankedTensorType>>(
+  return cast<TypedValue<RankedTensorType>>(
       arith::MulFOp::create(rewriter, loc, v, reshapeScale).getResult());
-
-  // 3) If the scale is NaN, return NaN, else return the scaled value.
-  return maskNan(rewriter, scaledDotOp, mxfp, scale, kDim);
 }
 
 TypedValue<RankedTensorType> DecomposeScaledBlocked::extendAndBroadcastScale(
     PatternRewriter &rewriter, DotScaledOp scaledDotOp,
     TypedValue<RankedTensorType> &scale, FloatType computeType,
-    RankedTensorType dstType, int opIdx) const {
+    RankedTensorType dstType, int opIdx, bool handleNan) const {
   auto loc = scale.getLoc();
   auto mod = scaledDotOp->getParentOfType<ModuleOp>();
   auto v = opIdx == 0 ? scaledDotOp.getA() : scaledDotOp.getB();
@@ -248,7 +261,7 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::extendAndBroadcastScale(
   }
 
   // 1) Cast scale to compute type (fp16/bf16)
-  auto scale16 = scaleTo16(rewriter, scale, computeType);
+  auto scale16 = scaleTo16(rewriter, scale, computeType, handleNan);
 
   // 2) Broadcast scale to the same shape as v and convert the layout
   auto reshapeScale = broadcastScale(rewriter, scaledDotOp, mod, scale16, kDim);

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3905,7 +3905,7 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
         tl.static_assert(x.dtype == tl.uint8)
 
         if to_type == tl.bfloat16:
-            upcasted_scale = (scale.to(tl.uint16) << 7).to(tl.bfloat16, bitcast=True)
+            upcasted_scale = tl.maximum(scale.to(tl.uint16) << 7, 0x0040).to(tl.uint16).to(tl.bfloat16, bitcast=True)
         else:
             tl.static_assert(to_type == tl.float16)
             scale_fp32 = (scale.to(tl.uint32) << 23).to(tl.float32, bitcast=True)
@@ -4095,6 +4095,70 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
     if is_hip_cdna4() and normal_type in ["bf16", "fp16"]:
         amdgcn = pgm.asm['amdgcn']
         assert (re.search(r"v_cvt_scalef32_pk_.*?(fp4|fp8|bf8).*?op_sel", amdgcn))
+
+
+@triton.jit
+def _scaled_dot_scale_kernel(X, W, S, Y, RHS_SCALE: tl.constexpr, NORMAL_TYPE: tl.constexpr, SCALE_FACTOR: tl.constexpr,
+                             FAST_MATH: tl.constexpr):
+    indices = tl.arange(0, 128)
+    offsets = indices[:, None] * 128 + indices[None, :]
+    x = tl.load(X + offsets)
+    w = tl.load(W + offsets)
+    scales = tl.load(S + indices[:, None] * (128 // SCALE_FACTOR) + tl.arange(0, 128 // SCALE_FACTOR)[None, :])
+    if RHS_SCALE:
+        y = tl.dot_scaled(x, None, NORMAL_TYPE, w, scales, "e4m3", fast_math=FAST_MATH)
+    else:
+        y = tl.dot_scaled(w, scales, "e4m3", x, None, NORMAL_TYPE, fast_math=FAST_MATH)
+    tl.store(Y + offsets, y)
+
+
+@pytest.mark.parametrize("rhs_scale", [False, True])
+@pytest.mark.parametrize("normal_type", ["bf16", "fp16"])
+@pytest.mark.parametrize("fast_math", [False, True])
+@pytest.mark.enable_warmup(min_capability=9)
+def test_scaled_dot_minimum_scale(rhs_scale, normal_type, fast_math, device):
+    if not is_cuda() or torch.cuda.get_device_capability() < (8, 9):
+        pytest.skip("requires CUDA FP8 support")
+
+    dtype = torch.bfloat16 if normal_type == "bf16" else torch.float16
+    x = torch.full((128, 128), 2.0**112 if normal_type == "bf16" else 1.0, dtype=dtype, device=device)
+    w = torch.full((128, 128), 256.0, dtype=torch.float8_e4m3fn, device=device)
+    scales = torch.empty((128, 4), dtype=torch.uint8, device=device)
+    out = torch.empty((128, 128), dtype=torch.float32, device=device)
+    # The decoded BF16 weight is normal despite its subnormal scale. FP16
+    # legitimately underflows for this scale; unit scales cover its live path.
+    expected_values = ((1.0, 2.0, 2.0**127, float("inf"), float("nan")) if normal_type == "bf16" else
+                       (0.0, 0.0, 32768.0, float("inf"), float("nan")))
+    for scale, expected in zip((0, 1, 127, 254, 255), expected_values):
+        if fast_math and scale == 255:
+            continue
+        scales.fill_(scale)
+        _scaled_dot_scale_kernel[(1, )](x, w, scales, out, rhs_scale, normal_type, 32, fast_math, num_warps=4)
+        if is_compile_warmup():
+            return
+        torch.testing.assert_close(out, torch.full_like(out, expected), rtol=0, atol=0, equal_nan=True)
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("rhs_scale", [False, True])
+@pytest.mark.parametrize("normal_type", ["bf16", "fp16"])
+@pytest.mark.parametrize("scale_dtype, scale_factor", [(torch.uint8, 32), (torch.float8_e4m3fn, 16)])
+@pytest.mark.enable_warmup(min_capability=9)
+def test_scaled_dot_zero_scale(rhs_scale, normal_type, scale_dtype, scale_factor, device):
+    if not is_interpreter() and (not is_cuda() or torch.cuda.get_device_capability() < (8, 9)):
+        pytest.skip("requires CUDA FP8 support")
+
+    dtype = torch.bfloat16 if normal_type == "bf16" else torch.float16
+    x = torch.ones((128, 128), dtype=dtype, device=device)
+    w = torch.full((128, 128), 256.0, dtype=torch.float8_e4m3fn, device=device)
+    scales = torch.zeros((128, 128 // scale_factor), dtype=scale_dtype, device=device)
+    out = torch.empty((128, 128), dtype=torch.float32, device=device)
+    # Eight warps avoid a ptxas crash in the FP8-scale BF16 configuration.
+    _scaled_dot_scale_kernel[(1, )](x, w, scales, out, rhs_scale, normal_type, scale_factor, False, num_warps=8)
+    if is_compile_warmup():
+        return
+    expected = 2.0**-112 if normal_type == "bf16" and scale_dtype == torch.uint8 else 0.0
+    torch.testing.assert_close(out, torch.full_like(out, expected), rtol=0, atol=0)
 
 
 @pytest.mark.interpreter

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -1122,6 +1122,36 @@ def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, with_a_sc
 
 
 @triton.jit
+def rhs_scaled_n_packed_fp4_matmul(A, B, BS, C):
+    a = tl.load(A + tl.arange(0, 128)[:, None] * 32 + tl.arange(0, 32)[None, :])
+    b = tl.load(B + tl.arange(0, 32)[:, None] * 64 + tl.arange(0, 64)[None, :])
+    bs = tl.load(BS + tl.arange(0, 128)[:, None])
+    c = tl.dot_scaled(a, None, "bf16", b, bs, "e2m1", rhs_k_pack=False)
+    tl.store(C + tl.arange(0, 128)[:, None] * 128 + tl.arange(0, 128)[None, :], c)
+
+
+def test_dot_scaled_unscaled_lhs_fp4_rhs(device):
+    if not is_cuda() or torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip("Requires NVIDIA compute capability >= 8")
+
+    M, N, K = 128, 128, 32
+    torch.manual_seed(42)
+    a = torch.randn((M, K), dtype=torch.bfloat16, device=device)
+    b_mxfp4 = MXFP4Tensor(size=(K, N), device=device).random()
+    b = b_mxfp4.to_packed_tensor(dim=1)
+    b_scale = MXScaleTensor(size=(N, K // 32), device=device).random(low=0.5, high=2.0)
+    output = torch.empty((M, N), dtype=torch.float32, device=device)
+
+    rhs_scaled_n_packed_fp4_matmul[(1, )](a, b, b_scale.data, output)
+    if is_compile_warmup():
+        return
+
+    scale_ref = b_scale.to(torch.float32).T
+    ref_out = torch.matmul(a.float(), b_mxfp4.to(torch.float32) * scale_ref)
+    torch.testing.assert_close(output, ref_out, atol=1e-3, rtol=1e-3)
+
+
+@triton.jit
 def mxfp8_mxfp4_matmul(  #
         a_ptr, b_ptr, output_ptr,  #
         a_scale, b_scale,  #

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -249,12 +249,17 @@ def _umulhi_64(a, b):
     return (int(a) * int(b)) >> 64
 
 
-def _e8m0_to_f32(scale):
+def _dot_scaled_scale_to_f32(scale_handle, compute_type):
+    scale = scale_handle.data
     assert scale.dtype in (np.uint8, np.int8)
-    scale = scale.astype(np.uint8)
-    scale = scale.astype(np.int32)
-    scale = scale << 23
-    scale = scale.view(np.float32)
+    bits = scale.view(np.uint8).astype(np.int32) << 23
+    if compute_type == tl.bfloat16 and scale_handle.dtype.is_int():
+        # E8M0 byte zero is 2^-127, which rounds to zero in FP16.
+        bits = np.maximum(bits, 0x00400000)
+    scale = bits.view(np.float32)
+    if scale_handle.dtype.is_int():
+        # FMA turns byte 255's infinity into NaN while preserving finite scales.
+        scale = _interpreter.fma_fp32(scale, np.zeros_like(scale), scale)
     return scale
 
 
@@ -316,7 +321,7 @@ def _unpack_e2m1(data, axis):
     return np.moveaxis(unpacked, -1, axis)
 
 
-def _prepare_dot_scaled_operand(value_handle, scale_handle, format_enum, k_pack, is_rhs):
+def _prepare_dot_scaled_operand(value_handle, scale_handle, format_enum, k_pack, compute_type, is_rhs):
     if format_enum == _ir.ScaleDotElemTypeTY.E2M1:
         if is_rhs:
             unpack_axis = -2 if k_pack else -1
@@ -329,14 +334,13 @@ def _prepare_dot_scaled_operand(value_handle, scale_handle, format_enum, k_pack,
     if scale_handle is None:
         return value
 
-    scale = _e8m0_to_f32(scale_handle.data)
+    scale_factor = value.shape[-2 if is_rhs else -1] // scale_handle.data.shape[-1]
+    scale = _dot_scaled_scale_to_f32(scale_handle, compute_type)
+    scale = np.repeat(scale, scale_factor, axis=-1)
 
     if is_rhs:
         # rhs is in [K, N] layout, but rhs_scale is supplied as [N, K / group].
-        scale = np.repeat(scale, value.shape[-2] // scale.shape[-1], axis=-1)
         scale = np.swapaxes(scale, -1, -2)
-    else:
-        scale = np.repeat(scale, value.shape[-1] // scale.shape[-1], axis=-1)
 
     return value * scale
 
@@ -876,8 +880,11 @@ class InterpreterBuilder:
                           rhs_scale_handle: Optional[TensorHandle], rhs_format_enum: _ir.ScaleDotElemTypeTY,
                           fast_math: bool, lhs_k_pack: bool, rhs_k_pack: bool,
                           acc_handle: TensorHandle) -> TensorHandle:
-        lhs_data = _prepare_dot_scaled_operand(lhs, lhs_scale_handle, lhs_format_enum, lhs_k_pack, is_rhs=False)
-        rhs_data = _prepare_dot_scaled_operand(rhs, rhs_scale_handle, rhs_format_enum, rhs_k_pack, is_rhs=True)
+        compute_type = tl.float16 if _ir.ScaleDotElemTypeTY.FP16 in (lhs_format_enum, rhs_format_enum) else tl.bfloat16
+        lhs_data = _prepare_dot_scaled_operand(lhs, lhs_scale_handle, lhs_format_enum, lhs_k_pack, compute_type,
+                                               is_rhs=False)
+        rhs_data = _prepare_dot_scaled_operand(rhs, rhs_scale_handle, rhs_format_enum, rhs_k_pack, compute_type,
+                                               is_rhs=True)
 
         result = np.matmul(lhs_data, rhs_data) + acc_handle.data
         return TensorHandle(result, tl.float32)

--- a/python/triton/tools/mxfp.py
+++ b/python/triton/tools/mxfp.py
@@ -230,6 +230,13 @@ class MXFP4Tensor:
         return data.type(torch.uint8)
 
 
+def fp8e8m0_to_float32(scale):
+    """Decode raw E8M0 scale bytes as float32."""
+    scale = scale.view(torch.uint8)
+    bits = (scale.to(torch.int32) << 23).clamp_min(0x00400000)
+    return bits.masked_fill(scale == 255, 0x7FC00000).view(torch.float32)
+
+
 class MXScaleTensor:
 
     def __init__(self, data=None, size=None, device=None):
@@ -268,14 +275,7 @@ class MXScaleTensor:
 
     def to(self, dtype):
         assert dtype == torch.float32, "Currently only float32 is supported for f8e8m0 to float conversion"
-        data = self.data.type(dtype)
-        is_nan = (data == 255)
-        e_biased = data.clone()
-        e_biased[is_nan] = 0
-        e = e_biased - 127
-        value = torch.pow(2.0, e)
-        value[is_nan] = torch.nan
-        return value.type(dtype)
+        return fp8e8m0_to_float32(self.data)
 
     def _from_float(self, values):
         """

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -496,7 +496,14 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     %scale: tensor<128x2xi8, #blocked1>,
     %b_bf16: tensor<64x128xbf16, #blocked>
     ) -> tensor<128x128xf32, #blocked> {
+    // CHECK-DAG: %[[MIN_SCALE:.*]] = arith.constant dense<64>
+    // CHECK-DAG: %[[ZERO:.*]] = arith.constant dense<0.000000e+00> : tensor<{{.*}}xbf16,
     // CHECK: ttg.fp4_to_fp
+    // CHECK: %[[SHIFTED_SCALE:.*]] = arith.shli
+    // CHECK: %[[SCALE_BITS:.*]] = arith.maxui %[[SHIFTED_SCALE]], %[[MIN_SCALE]]
+    // CHECK: %[[SCALE:.*]] = tt.bitcast %[[SCALE_BITS]] : {{.*}} -> tensor<{{.*}}xbf16,
+    // CHECK: math.fma %[[SCALE]], %[[ZERO]], %[[SCALE]]
+    // CHECK-NOT: arith.select
     // CHECK: ttng.warp_group_dot
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %result = tt.dot_scaled %a scale %scale, %b_bf16, %cst lhs = e2m1 rhs = bf16 {fastMath = false} : tensor<128x32xi8, #blocked2>, tensor<128x2xi8, #blocked1> * tensor<64x128xbf16, #blocked> -> tensor<128x128xf32, #blocked>
@@ -869,6 +876,10 @@ module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num
 module attributes {"ttg.target" = "cuda:120", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @sm120_dot_scaled_fp16_fp8_fallback
   // CHECK-NOT: tt.dot_scaled
+  // CHECK: %[[SCALE_BITS:.*]] = arith.shli
+  // CHECK: %[[SCALE_F32:.*]] = tt.bitcast %[[SCALE_BITS]] : {{.*}} -> tensor<{{.*}}xf32,
+  // CHECK: %[[DECODED_SCALE:.*]] = math.fma %[[SCALE_F32]], %{{.*}}, %[[SCALE_F32]]
+  // CHECK: arith.truncf %[[DECODED_SCALE]] : {{.*}} to tensor<{{.*}}xf16,
   // CHECK: tt.dot
   // CHECK-NOT: tt.dot_scaled
   // CHECK: tt.return
@@ -919,8 +930,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttg.fp4_to_fp
   // CHECK: tt.fp_to_fp
   // CHECK: arith.mulf
-  // CHECK: arith.cmpf uno
-  // CHECK: arith.select
+  // CHECK-NOT: arith.cmpf uno
+  // CHECK-NOT: arith.select
   // CHECK-NOT: ttng.tc_gen5_mma_scaled
   // CHECK: ttng.tc_gen5_mma
   // CHECK-NOT: tt.dot_scaled

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -251,6 +251,25 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_k = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: unscaled_lhs_keeps_mn_packed_rhs
+  tt.func public @unscaled_lhs_keeps_mn_packed_rhs(
+      %a: tensor<128x64xbf16, #blocked_k>,
+      %b: tensor<64x64xi8, #blocked>,
+      %scale_b: tensor<128x2xi8, #blocked>) -> tensor<128x128xf32, #blocked> {
+    // CHECK-NOT: tt.dot_scaled
+    // CHECK: ttg.fp4_to_fp %{{.*}} {axis = 0 : i32} : tensor<64x64xi8, {{.*}}> -> tensor<128x64xbf16, {{.*}}>
+    // CHECK: ttng.tc_gen5_mma
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %d = tt.dot_scaled %a, %b scale %scale_b, %cst lhs = bf16 rhs = e2m1 {fastMath = false, rhs_k_pack = false} : tensor<128x64xbf16, #blocked_k> * tensor<64x64xi8, #blocked>, tensor<128x2xi8, #blocked> -> tensor<128x128xf32, #blocked>
+    tt.return %d : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -46,7 +46,8 @@ def TritonAMDGPUAccelerateMatmul : Pass<"tritonamdgpu-accelerate-matmul", "mlir:
     (e.g., AMD matrix cores)
   }];
 
-  let dependentDialects = ["mlir::triton::amdgpu::TritonAMDGPUDialect"];
+  let dependentDialects = ["mlir::triton::amdgpu::TritonAMDGPUDialect",
+                           "mlir::math::MathDialect"];
 
   let options = [
     Option<"gfxArch", "gfx-arch",

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -2,6 +2,7 @@
 #include "TritonAMDGPUTransforms/Passes.h"
 #include "TritonAMDGPUTransforms/WmmaGroup.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -884,10 +885,11 @@ public:
       reshapeScale = mlir::triton::gpu::ConvertLayoutOp::create(
           rewriter, loc, newScaleType, reshapeScale);
     } else {
-      // Cast scale to bf16, broadcast it and convert the layout
+      // This is an exponent carrier; restore NaNs after the native upcast.
       FloatType bf16Type = rewriter.getBF16Type();
       reshapeScale = extendAndBroadcastScale(rewriter, dotOp, scale, bf16Type,
-                                             resultType.clone(bf16Type), opIdx);
+                                             resultType.clone(bf16Type), opIdx,
+                                             /*handleNan=*/false);
     }
 
     // Upcast with scale


### PR DESCRIPTION
The core part of #11624 (66aa2f8a6) onto `release/3.8.x`, plus #11613 (20601f014), for #11735.

On 3.8.0 `tl.dot_scaled` decodes an E8M0 scale byte of 0 as zero instead of 2^-127, and a scale that is subnormal in bf16 rounds to zero: main's `test_scaled_dot_minimum_scale` and `test_scaled_dot_zero_scale` fail on the wheel with every element wrong. #11624 fixes the software decomposition, the interpreter and `tools/mxfp.py`; that is what this cherry-pick carries, with its tests and the `accelerate-matmul.mlir` update. The AMD lowering, the fp sanitizer, the gluon translator and the `triton_kernels` parts of the original commit are left out, so it is marked as a partial cherry-pick in the message. #11613 is the small follow-up in the same area: a scaled dot with an unscaled bf16 lhs and an MN-packed fp4 rhs failed in `AccelerateMatmul` (`PassManager::run failed`, `test_dot_scaled_unscaled_lhs_fp4_rhs`).

Built on `release/3.8.x` with the branch's LLVM on an RTX PRO 6000: `test_scaled_dot_minimum_scale` and `test_scaled_dot_zero_scale` 8/8 each, `test_dot_scaled_unscaled_lhs_fp4_rhs` passes, the whole `test_scaled_dot` family 1728 passed, `accelerate-matmul.mlir` passes.
