### PR TITLE
[TEST] Give test_int_annotation a buffer its store fits in

### DIFF
--- a/python/test/unit/language/test_annotations.py
+++ b/python/test/unit/language/test_annotations.py
@@ -29,7 +29,7 @@ def test_int_annotation(signed, width, device):
     def _kernel(X, v):
         tl.store(X + v, v)
 
-    h = _kernel[(1, )](torch.empty(1, device=device), 3)
+    h = _kernel[(1, )](torch.empty(4, device=device), 3)
     pfx = 'si' if signed else 'ui'
     if not signed and width < 64:
         assert "arith.extui %v" in h.asm["ttir"]


### PR DESCRIPTION
`test_int_annotation` launches `tl.store(X + v, v)` with `v = 3` on a `torch.empty(1)` buffer, so the kernel's only store lands three elements past the end of the allocation. The test just inspects the TTIR for the `extsi`/`extui` and the device lets the write through, so nothing fails today; it showed up when I ran the suite under a bounds-checked interpreter of the TTIR, where this is the one out-of-bounds write in `test_annotations.py`. Four elements cover the fixed `v = 3` for every `width`.
