### PR TITLE
[release/3.8] [TRITONGPU] FuseNestedLoops: preserve empty inner loops when flattening (#11607, #11688)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -1154,12 +1154,11 @@ static LogicalResult speculateInnerLoopLength(scf::ForOp outerLoop,
   // Mark the inner loop.
   innerLoop->setAttr(kMustExecuteAttrName, b.getUnitAttr());
 
-  // Speculate on whether the length of the inner loop is zero.
-  Value lenInner = computeNumIters(b, innerLoop);
-  auto zeroAttr = IntegerAttr::get(lenInner.getType(), 0);
-  Value innerLoopEmpty =
-      arith::CmpIOp::create(b, arith::CmpIPredicate::eq, lenInner,
-                            arith::ConstantOp::create(b, zeroAttr));
+  // SCF for loops have positive steps, so inverted bounds are empty too.
+  auto predicate = innerLoop.getUnsignedCmp() ? arith::CmpIPredicate::uge
+                                              : arith::CmpIPredicate::sge;
+  Value innerLoopEmpty = arith::CmpIOp::create(
+      b, predicate, innerLoop.getLowerBound(), innerLoop.getUpperBound());
   auto ifOp = scf::IfOp::create(b, outerLoop.getResultTypes(), innerLoopEmpty);
 
   // In the `then` branch, the inner loop does not execute. Clone the loop nest

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6449,6 +6449,29 @@ def test_tl_range_fuse(device):
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
 
 
+@pytest.mark.parametrize("bounds", [(2, 5, 1), (5, 5, 1), (5, 2, 1), (5, 2, 2), (5, 4, 2), (2, 5, 2)])
+@pytest.mark.parametrize("flatten", [False, True])
+def test_tl_range_fuse_empty_inner_bounds(bounds, flatten, device):
+
+    @triton.jit
+    def kernel(x_ptr, out_ptr, lower, upper, step, FLATTEN: tl.constexpr):
+        acc = 7
+        for i in tl.range(3, flatten=FLATTEN):
+            acc += 10
+            for j in range(lower, upper, step):
+                acc += tl.load(x_ptr + j)
+            acc += 100
+        tl.store(out_ptr, acc)
+
+    lower, upper, step = bounds
+    x = torch.arange(32, dtype=torch.int32, device=device)
+    out = torch.empty((), dtype=torch.int32, device=device)
+    kernel[(1, )](x, out, lower, upper, step, flatten)
+    # Empty inner loops must still preserve the outer prologue and epilogue.
+    expected = 7 + 3 * (110 + sum(range(lower, upper, step)))
+    assert out.item() == expected
+
+
 def test_tl_range_fuse_dependent(device):
 
     @triton.jit

--- a/test/TritonGPU/fuse-nested-loops.mlir
+++ b/test/TritonGPU/fuse-nested-loops.mlir
@@ -476,10 +476,9 @@ tt.func @preserve_stage_count(%lb: i32, %ub: i32) {
 tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
   %c1_i32 = arith.constant 1 : i32
 
-  // CHECK: [[LEN:%.*]] = arith.subi [[UB]], [[LB]]
-  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[LEN]], %c0_i32
+  // CHECK: [[IS_EMPTY:%.*]] = arith.cmpi sge, [[LB]], [[UB]]
 
-  // CHECK: scf.if [[IS_ZERO]]
+  // CHECK: scf.if [[IS_EMPTY]]
   // CHECK-NEXT: scf.for %{{.*}} = [[LB]] to [[UB]] step %c1_i32
   // CHECK-NEXT:   "prologue"
   // CHECK-NXET: } {tt.flatten}
@@ -509,9 +508,10 @@ tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
 tt.func @speculate_hoist(%lb: i32, %ub: i32) {
   %c1_i32 = arith.constant 1 : i32
 
-  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[UB]], %c0_i32
+  // CHECK: [[INNER_UB:%.*]] = arith.addi [[LB]], [[UB]]
+  // CHECK: [[IS_EMPTY:%.*]] = arith.cmpi sge, [[LB]], [[INNER_UB]]
 
-  // CHECK: scf.if [[IS_ZERO]]
+  // CHECK: scf.if [[IS_EMPTY]]
   scf.for %i = %lb to %ub step %c1_i32 : i32 {
     "prologue"(%i) : (i32) -> ()
     %ubj = arith.addi %lb, %ub : i32
@@ -519,6 +519,31 @@ tt.func @speculate_hoist(%lb: i32, %ub: i32) {
       "body"(%i, %j) : (i32, i32) -> ()
       scf.yield
     }
+  } {tt.flatten}
+  tt.return
+}
+
+// The empty-loop check must use the inner loop's comparison signedness.
+// CHECK-LABEL: @speculate_unsigned_inner_bounds
+// CHECK-SAME: [[M:%.*]]: i32, [[LB:%.*]]: i32, [[UB:%.*]]: i32
+tt.func @speculate_unsigned_inner_bounds(%m: i32, %lb: i32, %ub: i32) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  // CHECK: [[EMPTY:%.*]] = arith.cmpi uge, [[LB]], [[UB]]
+  // CHECK-NEXT: scf.if [[EMPTY]] {
+  // CHECK-NEXT: scf.for
+  // CHECK-NEXT: "prologue"
+  // CHECK-NEXT: "epilogue"
+  // CHECK-NEXT: }
+  // CHECK-NEXT: } else {
+  // CHECK: scf.for
+  // CHECK: "body"
+  scf.for %i = %c0 to %m step %c1 : i32 {
+    "prologue"(%i) : (i32) -> ()
+    scf.for unsigned %j = %lb to %ub step %c1 : i32 {
+      "body"(%j) : (i32) -> ()
+    }
+    "epilogue"(%i) : (i32) -> ()
   } {tt.flatten}
   tt.return
 }

--- a/test/TritonGPU/fuse-nested-loops.mlir
+++ b/test/TritonGPU/fuse-nested-loops.mlir
@@ -481,7 +481,7 @@ tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
   // CHECK: scf.if [[IS_EMPTY]]
   // CHECK-NEXT: scf.for %{{.*}} = [[LB]] to [[UB]] step %c1_i32
   // CHECK-NEXT:   "prologue"
-  // CHECK-NXET: } {tt.flatten}
+  // CHECK-NEXT: } {tt.flatten}
 
   // CHECK: else
   // CHECK-COUNT-1: scf.for
@@ -603,5 +603,43 @@ tt.func @prologue_output(%ub: i32) {
     scf.yield %next : i32
   } {"ttg.always-fuse"}
 
+  tt.return
+}
+
+// -----
+
+// CHECK-LABEL: @assume_not_dominating_loop
+// An llvm.assume(ub > lb) that does not dominate the inner loop (it sits on
+// another branch of an scf.if) must not license dropping the zero-trip version
+// split of the fused loop: the nest is not reachable from the assume, so the
+// fast path must be declined and the runtime zero-trip guard kept.
+// CHECK-SAME: [[LB:%.*]]: i32, [[UB:%.*]]: i32, [[FLAG:%.*]]: i1
+tt.func @assume_not_dominating_loop(%lb: i32, %ub: i32, %flag: i1) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+
+  // The inner loop is empty when %ub <= 0. Keep its runtime guard because
+  // the assume on the other branch does not dominate the loop.
+  // CHECK: [[IS_EMPTY:%.*]] = arith.cmpi sle, [[UB]], %c0_i32
+  // CHECK-NEXT: scf.if [[IS_EMPTY]]
+  // CHECK-NEXT: scf.for %{{.*}} = %c0_i32 to [[UB]] step %c1_i32
+  // CHECK-NEXT:   "prologue"
+  // CHECK-NOT: arith.constant true
+  scf.if %flag {
+    // The assume is in force only where %flag holds; the loop nest below is
+    // only reachable where %flag does not hold.
+    %cmp = arith.cmpi sgt, %ub, %lb : i32
+    llvm.intr.assume %cmp : i1
+    scf.yield
+  } else {
+    scf.for %i = %c0_i32 to %ub step %c1_i32 : i32 {
+      "prologue"(%i) : (i32) -> ()
+      scf.for %j = %c0_i32 to %ub step %c1_i32 : i32 {
+        "body"(%i, %j) : (i32, i32) -> ()
+        scf.yield
+      }
+    } {tt.flatten}
+    scf.yield
+  }
   tt.return
 }


### PR DESCRIPTION
Cherry-picks of #11607 (4a57ffb21) and its reland #11688 (59c11c8d8) onto `release/3.8.x`, for #11735.

On 3.8.0 a `tl.range(..., flatten=True)` loop whose inner loop has inverted runtime bounds (lower > upper) runs the inner body once per outer iteration instead of never: main's `test_tl_range_fuse_empty_inner_bounds` gives 352 where 337 is expected on the wheel. #11607 keeps the empty inner loop's guard when flattening and #11688 corrects the emptiness test's signedness.

#11607 applies cleanly; #11688 conflicts only in `fuse-nested-loops.mlir`, where the release file lacks other main-only cases, so its lit hunks were merged onto the release file by hand (the new `@speculate_unsigned_inner_bounds` case is included). Built on `release/3.8.x` with the branch's LLVM on an RTX PRO 6000: the 12 cases of the test pass and the lit file passes.

The same test also fails on the 3.7.1 wheel (sm_89, the same 352), so this is long-standing rather than a regression shipped in 3.8.0. An earlier version of this description said the opposite, which was my misreading of my own results table.

