### PR TITLE
[release/3.8] [FRONTEND] Five frontend fixes from main (#10888, #11426, #11234, #11409, #10891)

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3389,7 +3389,7 @@ def test_amd_scaled_upcast_fp8_cdna(target):
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @kernel() attributes {noinline = false} {
     %cst = arith.constant 1.000000e+00 : f32
-    %0 = arith.truncf %cst : f32 to f8E4M3FN
+    %0 = tt.fp_to_fp %cst, rounding = rtne : f32 -> f8E4M3FN
     %1 = tt.splat %0 : f8E4M3FN -> tensor<16x64xf8E4M3FN, #blocked>
     %c2_i8 = arith.constant 2 : i8
     %cst_0 = arith.constant dense<2> : tensor<16x64xi8, #blocked>

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -582,3 +582,18 @@ def test_err_nested_function_def():
     err_msg = format_exception(e.type, value=e.value, tb=e.tb)
     assert "StopIteration" not in err_msg, "nested def should not leak StopIteration"
     assert "nested function" in err_msg, "error should mention nested function"
+
+
+@pytest.mark.parametrize("ptr_ty", ["*i8", "*i16", "*i64"])
+def test_err_histogram_non_32bit_int(ptr_ty):
+
+    @triton.jit
+    def kernel(x_ptr, z_ptr, N: tl.constexpr):
+        x = tl.load(x_ptr + tl.arange(0, 8))
+        tl.store(z_ptr + tl.arange(0, N), tl.histogram(x, N))
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(
+            triton.compiler.ASTSource(fn=kernel, signature={"x_ptr": ptr_ty, "z_ptr": "*i32", "N": "constexpr"},
+                                      constexprs={"N": 4}))
+    assert "histogram only supports 32-bit integer input" in str(e.value.__cause__)

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -421,6 +421,29 @@ def test_tuple_assignment_constexpr_tuple_normalizes_recursively():
     run_parser(kernel)
 
 
+def test_list_comprehension_if_filter():
+
+    @triton.jit
+    def kernel():
+        # an `if` filter drops the elements whose condition is false
+        vals: tl.constexpr = [x for x in (10, 20, 30, 40) if x >= 30]
+        tl.static_assert(len(vals) == 2)
+        tl.static_assert(vals[0] == 30)
+        tl.static_assert(vals[1] == 40)
+
+        # multiple `if` clauses compose as "and"
+        multi: tl.constexpr = [x for x in (0, 1, 2, 3, 4, 5) if x > 1 if x % 2 == 0]
+        tl.static_assert(len(multi) == 2)
+        tl.static_assert(multi[0] == 2)
+        tl.static_assert(multi[1] == 4)
+
+        # an unfiltered comprehension is unchanged
+        allv: tl.constexpr = [x for x in (10, 20, 30, 40)]
+        tl.static_assert(len(allv) == 4)
+
+    run_parser(kernel)
+
+
 def test_named_expr_respects_prior_constexpr_annotation():
 
     @triton.jit

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -26,6 +26,35 @@ def anchor(v):
     pass
 
 
+@pytest.mark.parametrize("dtype",
+                         [tl.float16, tl.bfloat16, tl.float32, tl.float64, tl.float8e4nv, tl.float8e5, tl.float8e4b15],
+                         ids=str)
+def test_scalar_constant_preserves_signed_zero(dtype):
+
+    @triton.jit
+    def kernel(dtype: tl.constexpr):
+        # CHECK: arith.constant -0.000000e+00
+        anchor(tl.full((), -0.0, dtype))
+        # CHECK: arith.constant 0.000000e+00
+        anchor(tl.full((), 0.0, dtype))
+
+    run_filecheck_test(kernel, args=(dtype, ))
+
+
+@pytest.mark.parametrize("dtype",
+                         [tl.int1, tl.int8, tl.int16, tl.int32, tl.int64, tl.uint8, tl.uint16, tl.uint32, tl.uint64],
+                         ids=str)
+@pytest.mark.parametrize("value", [0.0, -0.0])
+def test_scalar_constant_float_zero_to_integer(dtype, value):
+
+    @triton.jit
+    def kernel(dtype: tl.constexpr, value: tl.constexpr):
+        # CHECK: arith.constant {{0|false}}
+        anchor(tl.full((), value, dtype))
+
+    run_filecheck_test(kernel, args=(dtype, value))
+
+
 @triton.aggregate
 class Pair:
     first: tl.tensor

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -613,6 +613,19 @@ def test_call_in_while():
             trivial_return()
 
 
+@filecheck_test
+@triton.jit
+def test_while_integer_condition():
+    # CHECK-LABEL: test_while_integer_condition
+    i = tl.program_id(0)
+    # CHECK: scf.while
+    # CHECK: [[COND:%.*]] = arith.cmpi ne, %{{.*}}, %{{.*}} : i32
+    # CHECK: scf.condition([[COND]])
+    while i:
+        i -= 1
+    anchor(i)
+
+
 def test_return_in_while():
 
     @triton.jit

--- a/python/test/unit/language/test_standard.py
+++ b/python/test/unit/language/test_standard.py
@@ -145,6 +145,33 @@ def test_swizzle2d(size_i, size_j, size_g, device):
     assert (output == expected_order).all(), (output, expected_order)
 
 
+# ---------------
+# test softmax
+# ---------------
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("shape, dim", [((2, 2), 1), ((8, 64), -1), ((128, ), 0)])
+def test_softmax(shape, dim, device):
+    # Reproducer for https://github.com/triton-lang/triton/issues/11406, where
+    # softmax normalized along the wrong axis for every dim but the default.
+
+    @triton.jit
+    def softmax_kernel(X, Z, numel: tl.constexpr, shape: tl.constexpr, dim: tl.constexpr):
+        # X is contiguous, so its row-major flat offsets are just an arange.
+        offs = tl.arange(0, numel).reshape(shape)
+        x = tl.load(X + offs)
+        z = tl.softmax(x, dim=dim)
+        tl.static_assert(z.shape == x.shape, "softmax must preserve the input shape")
+        tl.store(Z + offs, z)
+
+    x = numpy_random(shape, dtype_str='float32')
+    x = torch.from_numpy(x).to(device)
+    z = torch.empty_like(x)
+    softmax_kernel[(1, )](x, z, x.numel(), shape, dim)
+    torch.testing.assert_close(z, torch.softmax(x, dim=dim), rtol=1e-5, atol=1e-6)
+
+
 @pytest.mark.interpreter
 @pytest.mark.parametrize("shape, dim", [((1, 2, 4), 0), ((2, 1, 4), 1), ((2, 4, 1), 2)])
 def test_squeeze(shape, dim, device):

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -537,7 +537,9 @@ class CodeGenerator(ast.NodeVisitor):
         results = []
         for item in iter:
             self.set_value(comp.target.id, item)
-            results.append(self.visit(node.elt))
+            # Apply the comprehension's `if` filters (the conditions are constexpr).
+            if all(self.visit(cond) for cond in comp.ifs):
+                results.append(self.visit(node.elt))
         return tl_tuple(results)
 
     # By design, only non-kernel functions can return

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1151,6 +1151,8 @@ class CodeGenerator(ast.NodeVisitor):
                 if cond.disable_licm:
                     while_op.set_attr("llvm.loop_annotation", self.builder.get_disable_loop_licm_attr())
                 cond = cond.condition
+            if _is_triton_tensor(cond):
+                cond = cond.to(language.int1, _semantic=self.semantic)
             self.builder.set_insertion_point_to_end(before_block)
             # create ConditionOp: e.g., scf.condition(%cond) %arg0, %arg1, ...
             self.builder.create_condition_op(cond.handle, block_args)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1231,7 +1231,7 @@ class tensor(base_value):
     def sigmoid(self) -> tensor:
         ...
 
-    def softmax(self, dim=None, keep_dims=False, ieee_rounding=False) -> tensor:
+    def softmax(self, dim=None, ieee_rounding=False) -> tensor:
         ...
 
     def ravel(self) -> tensor:

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -602,11 +602,15 @@ class TritonSemantic(Generic[TensorTy]):
         # scalar
         if dtype is None:
             raise ValueError("dtype must be specified when value is not a tensor")
-        if value == 0:
-            value = self.builder.get_null_value(dtype.to_ir(self.builder))
-        elif dtype.is_fp8():
-            value = self.builder.get_fp32(value)
-            value = self.builder.create_fp_trunc(value, dtype.to_ir(self.builder))
+        if dtype.is_int() and value == 0:
+            # For BC, we explicitly allow e.g. tl.full((), 0.0, tl.int32)
+            # which raises a type error for non-zero values.
+            value = 0
+        if dtype.is_fp8():
+            # Validate target support
+            dtype.to_ir(self.builder)
+            value = self.tensor(self.builder.get_fp32(value), tl.float32)
+            return self.cast(value, dtype)
         else:
             get_value_fn = getattr(self.builder, f"get_{dtype.name}")
             value = get_value_fn(value)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1767,7 +1767,8 @@ class TritonSemantic(Generic[TensorTy]):
 
     def histogram(self, input: TensorTy, num_bins: int, mask: Optional[TensorTy]) -> TensorTy:
         assert len(input.shape) == 1, "histogram only supports 1D input"
-        assert input.dtype.is_int(), "histogram only supports integer input"
+        if not (input.dtype.is_int() and input.dtype.int_bitwidth == 32):
+            raise ValueError(f"histogram only supports 32-bit integer input, but got {input.dtype}")
         if mask is not None:
             mask = self.broadcast_impl_shape(mask, input.shape)
             if not mask.type.scalar.is_bool():

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -52,15 +52,25 @@ def sigmoid(x):
 
 @core._tensor_member_fn
 @jit
-@math._add_math_1arg_docstr("softmax")
-def softmax(x, dim=None, keep_dims=False, ieee_rounding=False):
+def softmax(x, dim=None, ieee_rounding=False):
+    """
+    Computes the softmax of :code:`x` along the given axis.
+
+    :param x: the input values
+    :type x: Block
+    :param dim: the axis along which to normalize. Defaults to 0 -- note that
+        this is *not* the last axis, unlike :code:`torch.softmax`.
+    :type dim: int | None
+    :param ieee_rounding: whether the final division uses IEEE-compliant rounding
+    :type ieee_rounding: bool
+    """
     if dim is None:
         _dim: core.constexpr = 0
     else:
         _dim: core.constexpr = dim
-    z = x - max(x, _dim, keep_dims=keep_dims)
+    z = x - max(x, _dim, keep_dims=True)
     num = math.exp(z)
-    den = sum(num, _dim, keep_dims=keep_dims)
+    den = sum(num, _dim, keep_dims=True)
     return math.fdiv(num, den, ieee_rounding)
 
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -233,6 +233,12 @@ def _convert_float(input, input_dtype, output_dtype, rounding_mode):
         shift[subnormal_index] = (1 - bias_output) - (exponent[subnormal_index] - bias_input)
         significand_output[subnormal_index] = (significand_output[subnormal_index] >> shift[subnormal_index]) | (
             1 << (output_dtype.fp_mantissa_width - shift[subnormal_index]))
+    if output_dtype in (tl.float8e4b8, tl.float8e5b16):
+        # FNUZ formats have only unsigned zero; the sign bit alone encodes NaN.
+        zero_output = (exponent_output == 0) & (significand_output == 0)
+        if input_dtype in (tl.float8e4b8, tl.float8e5b16):
+            zero_output &= input_bin != 0x80
+        sign_output[zero_output] = 0
     output = (sign_output << (output_dtype.primitive_bitwidth - 1)) | (
         exponent_output << output_dtype.fp_mantissa_width) | significand_output
     return output.reshape(input.shape)
@@ -484,6 +490,9 @@ class InterpreterBuilder:
 
     def get_fp16(self, value):
         return TensorHandle(np.array([value], dtype=np.float16), tl.float16)
+
+    def get_bf16(self, value):
+        return self.create_fp_trunc(self.get_fp32(value), tl.bfloat16)
 
     def get_fp32(self, value):
         return TensorHandle(np.array([value], dtype=np.float32), tl.float32)

--- a/python/triton_kernels/triton_kernels/topk_details/_topk_forward.py
+++ b/python/triton_kernels/triton_kernels/topk_details/_topk_forward.py
@@ -123,7 +123,7 @@ def _topk_forward(X, stride_xm,  # inputs
 
     # normalize selected values
     if APPLY_SOFTMAX:
-        y_values = tl.softmax(y_values.to(tl.float32), dim=1, keep_dims=True).to(x_dtype)
+        y_values = tl.softmax(y_values.to(tl.float32), dim=1).to(x_dtype)
 
     # write back
     for rank in tl.static_range(N_PEERS):


### PR DESCRIPTION
Five frontend fixes cherry-picked onto `release/3.8.x`, for #11735: #10888 (14abad9a7), #11426 (9151221f5), #11234 (d8b932cc5), #11409 (31b1bf9ae), #10891 (d59ee53cf).

What each one changes for a user of the 3.8.0 wheel: a list comprehension with an `if` filter in a `constexpr` context ignored the filter (`[x for x in (10, 20, 30, 40) if x >= 30]` had four elements); `tl.full(shape, -0.0, dtype)` produced +0.0; a `while` loop with an integer condition failed with `error encountered during parsing`; `tl.softmax` normalized along the wrong axis for `dim != -1`; `tl.histogram` on a non-32-bit input failed inside the pass manager instead of with a frontend error.

All five apply cleanly. Built on `release/3.8.x` with the branch's LLVM on an RTX PRO 6000: main's tests for them pass (`test_list_comprehension_if_filter`, `test_while_integer_condition`, `test_softmax`, `test_err_histogram_non_32bit_int`), and `tl.full([4], -0.0, tl.float32)` now has the sign bit set.
