### PR TITLE
[BC-Breaking][Frontend] Promote mixed BF16 and FP8 to BF16

### DIFF
--- a/docs/python-api/triton-semantics.rst
+++ b/docs/python-api/triton-semantics.rst
@@ -10,15 +10,17 @@ Type Promotion
 
 The algorithm is as follows:
 
-1. **Kind** If one tensor is of a dtype of a higher kind, the other tensor is promoted to this dtype: ``(int32, bfloat16) -> bfloat16``
+1. **Kind** If one tensor is of a dtype of a higher kind, the other tensor is promoted to this dtype: ``(int32, float16) -> float16``. Mixed ``bfloat16`` and integer tensors use ``float32``.
 
-2. **Width** If both tensors are of dtypes of the same kind, and one of them is of a higher width, the other one is promoted to this dtype: ``(float32, float16) -> float32``
+2. **Width** If both tensors are of dtypes of the same kind, and one of them is of a higher width, the other one is promoted to this dtype: ``(float32, float16) -> float32``, ``(bfloat16, float8e4nv) -> bfloat16``
 
 3. **Prefer float16** If both tensors are of the same width and signedness but different dtypes (``float16`` and ``bfloat16`` or different ``fp8`` types), they are both promoted to ``float16``. ``(float16, bfloat16) -> float16``
 
 4. **Prefer unsigned** Otherwise (same width, different signedness), they are promoted to the unsigned dtype: ``(int32, uint32) -> uint32``
 
 Division and modulo are an exception to the rules above: they do not exist natively for floating point dtypes narrower than ``float32``, so if either operand is a float (of any width), both operands are promoted to ``float32`` for these two operations. Integer division and modulo keep integer promotion.
+
+The width rule makes ``bfloat16`` the common dtype for ``bfloat16`` and FP8 tensors. Finite FP8 values are exactly representable in ``bfloat16``, but arithmetic results can round: adding FP8 ``1`` and ``bfloat16`` ``1/256`` produces ``bfloat16`` ``1``, rather than the ``float32`` result ``1.00390625``. Cast an operand to ``float32`` before the operation when that precision is required.
 
 The rules are a bit different when they involve a scalar. By scalar here we mean a numeric literal, a variable marked with `tl.constexpr` or a combination of these. These are represented by NumPy scalars and have types ``bool``, ``int`` and ``float``.
 

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -31,6 +31,7 @@ def type_convert_triton(src, dst, rounding : tl.constexpr, BLOCK_SIZE : tl.const
 
     x = tl.load(src + idxs)
     y = x.to(dst.dtype.element_ty, fp_downcast_rounding=rounding)
+    tl.static_assert(y.dtype == dst.dtype.element_ty)
     tl.store(dst + idxs, y)
 
 
@@ -259,7 +260,7 @@ def upcast_test(src_dtype, dst_dtype, exponent_bits, mantissa_bits, exponent_bia
     ('float8e5', 'float32'),
 
     ('float8e4b15', 'float16'),
-    # ('float8e4b15', 'bfloat16'), # Unsupported conversion from f8E4M3B11FNUZ to bf16
+    ('float8e4b15', 'bfloat16'),
     ('float8e4b15', 'float32'),
 
     ('float8e4nv', 'float16'),

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -441,6 +441,32 @@ def test_bin_op(dtype_x, dtype_y, op, num_ctas, device):
             test_broadcast=(op != "%"), x_low=x_low, x_high=x_high, filter_y=filter_y, test_scalar=not skip_scalar_test)
 
 
+@pytest.mark.parametrize("op, reference", [(tl.add, torch.add), (tl.sub, torch.sub), (tl.mul, torch.mul)])
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_bfloat16_fp8_promotion(op, reference, dtype, reverse, device):
+    check_type_supported("bfloat16", device)
+    check_type_supported(torch_dtype_name(dtype), device)
+
+    @triton.jit
+    def kernel(X, Y, Z, op: tl.constexpr, SIZE: tl.constexpr):
+        offsets = tl.arange(0, SIZE)
+        result = op(tl.load(X + offsets), tl.load(Y + offsets))
+        tl.static_assert(result.dtype == tl.bfloat16)
+        tl.store(Z + offsets, result)
+
+    x = torch.tensor([0, 1, -1, 1.25, -1.5, 2**-9, 128, 256], dtype=torch.float32, device=device).to(dtype)
+    y = torch.tensor([0, 2**-8, 2**-9, -2**-8, 1.0078125, -1.0078125, 1, 3], dtype=torch.bfloat16, device=device)
+    x, y = x.repeat_interleave(8), y.repeat(8)
+    if reverse:
+        x, y = y, x
+    # A float32 output exposes rounding in the operation, including 1 + 2**-8.
+    result = torch.empty(x.shape, dtype=torch.float32, device=device)
+    kernel[(1, )](x, y, result, op, x.numel())
+    expected = reference(x.float(), y.float()).bfloat16().float()
+    torch.testing.assert_close(result, expected, rtol=0, atol=0)
+
+
 def test_bfloat16_mul_rounds_to_nearest_even(device):
     # A bf16 multiply has to round to nearest even. Hardware multiply-accumulate
     # instructions that write a bf16 result may truncate instead, which is off by

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -110,6 +110,52 @@ def test_minimum_maximum_tensor_promotion(op, other_dtype, expected_dtype):
     run_parser(kernel, args=(op, other_dtype, expected_dtype))
 
 
+@pytest.mark.parametrize(
+    "dtype, expected_dtype",
+    [(dtype, tl.bfloat16)
+     for dtype in [tl.float8e4nv, tl.float8e5, tl.float8e4b15, tl.float8e4b8, tl.float8e5b16, tl.bfloat16]] +
+    [(tl.float16, tl.float16), (tl.float32, tl.float32), (tl.float64, tl.float64), (tl.int1, tl.float32),
+     (tl.int32, tl.float32)])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_bfloat16_mixed_promotion(dtype, expected_dtype, reverse):
+
+    @triton.jit
+    def kernel(dtype: tl.constexpr, expected_dtype: tl.constexpr, reverse: tl.constexpr):
+        x = tl.full((8, ), 1, tl.bfloat16)
+        y = tl.full((8, ), 2, tl.float32).to(dtype)
+        if reverse:
+            x, y = y, x
+        tl.static_assert((x + y).dtype == expected_dtype)
+        tl.static_assert((x - y).dtype == expected_dtype)
+        tl.static_assert((x * y).dtype == expected_dtype)
+        tl.static_assert(tl.minimum(x, y).dtype == expected_dtype)
+        tl.static_assert(tl.maximum(x, y).dtype == expected_dtype)
+        tl.static_assert(tl.where(tl.arange(0, 8) % 2 == 0, x, y).dtype == expected_dtype)
+        division_dtype: tl.constexpr = tl.float64 if dtype == tl.float64 else tl.float32
+        tl.static_assert((x / y).dtype == division_dtype)
+        tl.static_assert((x % y).dtype == division_dtype)
+
+    run_parser(kernel, args=(dtype, expected_dtype, reverse),
+               kwargs=dict(supported_fp8_dtypes=("fp8e4nv", "fp8e5", "fp8e4b15", "fp8e4b8", "fp8e5b16")))
+
+
+@pytest.mark.parametrize("op", [tl.fma, tl.clamp])
+@pytest.mark.parametrize("dtype", [tl.float8e4nv, tl.float8e5])
+@pytest.mark.parametrize("third_dtype", [tl.bfloat16, tl.float16, tl.float32])
+def test_bfloat16_fp8_ternary_promotion(op, dtype, third_dtype):
+
+    @triton.jit
+    def kernel(op: tl.constexpr, dtype: tl.constexpr, third_dtype: tl.constexpr):
+        x = tl.full((8, ), 1, tl.bfloat16)
+        y = tl.full((8, ), 1, tl.float32).to(dtype)
+        z = tl.full((8, ), 1, third_dtype)
+        tl.static_assert(op(x, y, z).dtype == third_dtype)
+        tl.static_assert(op(y, z, x).dtype == third_dtype)
+        tl.static_assert(op(z, x, y).dtype == third_dtype)
+
+    run_parser(kernel, args=(op, dtype, third_dtype))
+
+
 @pytest.mark.parametrize("op", ["minimum", "maximum", "clamp", "cumsum", "cumprod"])
 @pytest.mark.parametrize("dtype", [tl.bfloat16, tl.float16, tl.float32], ids=str)
 def test_bfloat16_promotion_elementwise_and_scan(op, dtype):

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -95,11 +95,9 @@ class TritonSemantic(Generic[TensorTy]):
         #     Supported PTX op: add, sub, mul, fma, neg, abs, min, max, tanh, ex2, setp
         if a_ty.is_fp16() or b_ty.is_fp16():
             return tl.float16
-        # 5) return bf16 only if both operands are of bf16
-        if a_ty.is_bf16() and b_ty.is_bf16():
-            return tl.bfloat16
+        # 5) preserve bf16 with bf16 or fp8; use fp32 with integers
         if a_ty.is_bf16() or b_ty.is_bf16():
-            return tl.float32
+            return tl.bfloat16 if a_ty.is_floating() and b_ty.is_floating() else tl.float32
         # 6) return fp16 if operands are different fp8
         if a_ty.is_fp8() and b_ty.is_fp8():
             return a_ty if a_ty == b_ty else tl.float16

--- a/third_party/nvidia/language/cuda/utils.py
+++ b/third_party/nvidia/language/cuda/utils.py
@@ -87,9 +87,7 @@ def convert_float16_to_fp8e4b15(arg, has_minx2, _semantic=None):
 def convert_custom_float8(arg, dst_ty, fp_downcast_rounding, has_minx2, _semantic=None):
     if arg.type.scalar.is_fp8e4b15():
         upcast_val = convert_fp8e4b15_to_float16(arg, _semantic=_semantic)
-        if dst_ty.scalar.is_fp32():
-            upcast_val = upcast_val.to(core.float32, _semantic=_semantic)
-        return upcast_val
+        return upcast_val.to(dst_ty.scalar, _semantic=_semantic)
 
     assert arg.type.scalar.is_fp16() or arg.type.scalar.is_fp32()
     downcast_val = arg


### PR DESCRIPTION
Mixed BF16/FP8 tensors currently promote to FP32. Use BF16 as their common dtype, following the documented width rule and existing FP16/FP8 behavior. All finite FP8 inputs fit exactly in BF16, so the [original concern about lossy input conversion](https://github.com/triton-lang/triton/pull/588#discussion_r924874380) does not apply.

**Compatibility:** arithmetic results can round earlier. `FP8(1) + BF16(1/256)` now yields BF16 `1.0`, previously FP32 `1.00390625`. Cast an operand to `tl.float32` before the operation to retain FP32 precision. The shared rule also affects selection, min/max, fma/clamp and Gluon. BF16/integer mixing, division/modulo and FP16/FP32/FP64 precedence are preserved.

Honor the destination dtype in the legacy `float8e4b15` decoder so it also supports this promotion.

Related: [Triton type promotion semantics for floating dtypes are very non-intuitive](https://github.com/triton-lang/triton/issues/4697), [Remove outdated bfloat16 promotion rules](https://github.com/triton-lang/triton/pull/11473).

## Validation

- H100 (SM90) and GB300 (SM103): 145 targeted tests pass on each, covering mixed-FP8 arithmetic, existing BF16 binary operations, multiply rounding and FP8 upcasts. Both new dtype regressions fail on the base.
- Frontend: all 205 tests in `test_frontend.py` pass, including all five FP8 formats and ternary operand ordering.
- Offline compilation: 48 cases across gfx942/gfx950 and all four supported FP8 formats; 18 legacy-FP8 cases across SM80/SM90/SM100. All pass. AMD hardware execution was not run.

GPU runs use this PR's Python sources and existing compiler builds with NVIDIA/shared sources identical to the base.

## Diff size

| Files | Added | Removed | Net |
|---|---:|---:|---:|
| Tests | +74 | -1 | +73 |
| Non-tests | +7 | -9 | -2 |
| All | +81 | -10 | +71 |

## Reviewer's guide

- `python/triton/language`: narrow the shared BF16 promotion rule to preserve BF16 with FP8.
- `third_party/nvidia/language`: honor the requested output type after decoding legacy FP8.
- `python/test/unit/language`: test result dtypes, arithmetic rounding, ternary operand ordering and legacy conversion.
- `docs/python-api`: document mixed-width promotion, the precision tradeoff and the retained integer exception.

<!-- codex-thread: 01a09750-9996-7da3-8f05-6ea4a0f10fcf -->
