### PR TITLE
[AMD] [gfx1250] Bump pinned AMD LLVM to pick up the entry-sequence fix

### DIFF
--- a/cmake/amd-llvm-info.json
+++ b/cmake/amd-llvm-info.json
@@ -1,17 +1,18 @@
 {
-  "llvm_hash": "941a04e69ee8fe4c7a162b2f1e215aa8df867534",
+  "llvm_hash": "ce3529423abda3fc4ad0b542daa50af21e539a29",
   "build_number": 1,
   "sha256sum": {},
   "bootstrap_llvm": {
     "build_number": 1,
     "sha256sum": {
-      "almalinux-arm64": "9dc8c436259c595683af88ce522593d1d8fdd2580458a405c1a0b01540c304ae",
-      "almalinux-x64": "a01e6c491a807af198959300f1020d18f27a56d40961b9d90e0785cd8ad28143",
-      "macos-arm64": "055906a91eca4565b8d0b04a0c97bf122faded02daa9a4f1edb6d2f43c2ad996",
-      "macos-x64": "35162b654e2780dd99f31eb7dc9ce6fe2833407b1a40a7afa021e4cf5fe3f767",
-      "ubuntu-arm64": "ee561d72b97474c7a78909dce74853d972c1fd0b561bd4b0943af6e87e77ac9d",
-      "ubuntu-x64": "6da421dd5fe5eda50bb4abf679a86ed8cf7543fd0dbace7398a10828dc7ae2aa",
-      "windows-x64": "983d1453841523e889a5caa3921fa5f002ed3144ee7ce98c6bcca28d111f4d2f"
+      "almalinux-arm64": "b66134e232015cbdf443d5a2520714bc07c1546f30aa1a1f05b5571706debfc1",
+      "almalinux-x64": "8d2502f7647e393b580a10cbc3650467f84993d8be53db750706a437c349477e",
+      "macos-arm64": "4aaca94f931a4300c0041884a26149ef4bd9b5728b5d970d22f3440e75f8b034",
+      "macos-x64": "35a798de4116833ae7ecadf1fa6617e4546517d728ef69fc72603c76b2d70c70",
+      "ubuntu-arm64": "c0036e8bd18be160029dd9c24d2c87166fdd182ba6af8bf7ca4476cda4dbaa16",
+      "ubuntu-x64": "f20d30fdb2ea3c14ef032245214663ddb99c0ed0a9fdb46e1ebd47d3513d4ada",
+      "windows-arm64": "7260cc3e10bdddf690104d4e1ce14d6d7f942d4715e62471b3e0f9b1d8d9ca9f",
+      "windows-x64": "ac84a8d0e63db6b6d155c2ae9714d29aa3d9458d674a840f4684c5c02ce6401a"
     }
   }
 }


### PR DESCRIPTION
The separately pinned AMD codegen LLVM (941a04e6) contains llvm/llvm-project@ae98c7d9d386 ("[AMDGPU][GFX1250] Use null register for global_prefetch_b8 instead of s[0:1]", llvm#214127), which makes gfx1250 kernels fault at runtime:

  HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION

Upstream LLVM fixed this in llvm/llvm-project@1109d68feb1b (llvm#215450), which restores a real zeroed address, and refined it in llvm/llvm-project@739eaa08d45e (llvm#216897).

Bump the AMD pin from 941a04e6 to ce3529423abd, which contains both.  That revision is already published as a Triton core LLVM build (cmake/llvm-info.json at b5505fe8e3), so the artifact and checksums are ones CI already consumes; the core and AMD pins download from the same llvm-builds path.