### PR TITLE
[AMD] Support configurable warp-pipeline phase gaps

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1389,7 +1389,8 @@ void init_gluon_ir(py::module_ &m) {
              self.create<ttag::ClusterBarrierWaitOp>();
            })
       .def("create_warp_pipeline_border",
-           [](GluonOpBuilder &self, const std::string &marker, int priority) {
+           [](GluonOpBuilder &self, const std::string &marker, int priority,
+              int phaseGap) {
              auto border =
                  self.create<ROCDL::SchedBarrier>(ROCDL::SchedGroupMask::none);
              auto ctx = self.getContext();
@@ -1399,6 +1400,11 @@ void init_gluon_ir(py::module_ &m) {
                auto i32Ty = IntegerType::get(ctx, 32);
                border->setAttr("triton.warp_pipeline.priority",
                                IntegerAttr::get(i32Ty, priority));
+             }
+             if (phaseGap > 0) {
+               auto i32Ty = IntegerType::get(ctx, 32);
+               border->setAttr("triton.warp_pipeline.phase_gap",
+                               IntegerAttr::get(i32Ty, phaseGap));
              }
            });
 

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -4798,7 +4798,7 @@ def test_amd_warp_pipeline(target):
 
         # Simple loop with an explicit split point
         for i in range(c0, 10, one):
-            with ttgl.amd.warp_pipeline_stage("stage0"):
+            with ttgl.amd.warp_pipeline_stage("stage0", phase_gap=2):
                 x = i + one
             with ttgl.amd.warp_pipeline_stage("stage1"):
                 y = x * one
@@ -4822,7 +4822,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
       %c1_i32_0 = arith.constant 1 : i32
       %c1_i32_1 = arith.constant 1 : i32
       %4 = arith.addi %arg0, %c1_i32_1 : i32
-      rocdl.sched.barrier none {triton.warp_pipeline.border = "stage0"}
+      rocdl.sched.barrier none {triton.warp_pipeline.border = "stage0", triton.warp_pipeline.phase_gap = 2 : i32}
       %c1_i32_2 = arith.constant 1 : i32
       %c1_i32_3 = arith.constant 1 : i32
       %5 = arith.muli %4, %c1_i32_3 : i32

--- a/python/triton/experimental/gluon/language/amd/warp_pipeline.py
+++ b/python/triton/experimental/gluon/language/amd/warp_pipeline.py
@@ -54,15 +54,24 @@ class warp_pipeline_stage:
                     acc += a_tile * b_tile
 
             gl.store(c_ptr, acc)
+
+    ``phase_gap`` optionally selects how many pipeline stages separate the two
+    warp groups. It only needs to be specified on one stage in a loop and
+    defaults to one. All explicit values in a loop must agree.
     """
 
-    __slots__ = ("label", "priority", "_semantic")
+    __slots__ = ("label", "priority", "phase_gap", "_semantic")
 
-    def __init__(self, label=None, *, priority: int | None = None, **_internal):
+    def __init__(
+            self, label=None, *, priority: int | None = None,
+            phase_gap: int | None = None, **_internal):
         self.label = getattr(label, "value", None)
         if priority is not None:
             assert priority > -1 and priority < 4, "priority should be 0 to 3."
+        if phase_gap is not None:
+            assert phase_gap > 0, "phase_gap must be positive."
         self.priority = priority
+        self.phase_gap = phase_gap
         self._semantic = _internal.get("_semantic", None)
 
     def __enter__(self):
@@ -75,5 +84,7 @@ class warp_pipeline_stage:
             return False
         marker = self.label if self.label is not None else "cluster"
         prio = self.priority if self.priority is not None else -1
-        self._semantic.builder.create_warp_pipeline_border(marker, prio)
+        phase_gap = self.phase_gap if self.phase_gap is not None else -1
+        self._semantic.builder.create_warp_pipeline_border(
+            marker, prio, phase_gap)
         return False

--- a/python/triton/experimental/gluon/language/amd/warp_pipeline.py
+++ b/python/triton/experimental/gluon/language/amd/warp_pipeline.py
@@ -40,7 +40,8 @@ class warp_pipeline_stage:
 
             for k in range(0, K):
                 # Stage 0: prefetch tiles.
-                with gl.amd.warp_pipeline_stage("load", priority=3):
+                with gl.amd.warp_pipeline_stage(
+                        "load", priority=3, phase_gap=2):
                     a = gl.load(a_ptr + k)
                     b = gl.load(b_ptr + k)
 
@@ -55,21 +56,20 @@ class warp_pipeline_stage:
 
             gl.store(c_ptr, acc)
 
-    ``phase_gap`` optionally selects how many pipeline stages separate the two
-    warp groups. It only needs to be specified on one stage in a loop and
-    defaults to one. All explicit values in a loop must agree.
+    ``phase_gap`` is a loop-wide setting for the number of stages separating
+    the two warp groups. Specify it only on the first stage; the default is
+    one. Values 1 and 2 are supported; wider gaps are not yet validated.
+    Flat pipelines produced by unrolling support only the default gap.
     """
 
     __slots__ = ("label", "priority", "phase_gap", "_semantic")
 
-    def __init__(
-            self, label=None, *, priority: int | None = None,
-            phase_gap: int | None = None, **_internal):
+    def __init__(self, label=None, *, priority: int | None = None, phase_gap: int | None = None, **_internal):
         self.label = getattr(label, "value", None)
         if priority is not None:
             assert priority > -1 and priority < 4, "priority should be 0 to 3."
         if phase_gap is not None:
-            assert phase_gap > 0, "phase_gap must be positive."
+            assert phase_gap in (1, 2), "phase_gap must be 1 or 2."
         self.priority = priority
         self.phase_gap = phase_gap
         self._semantic = _internal.get("_semantic", None)
@@ -85,6 +85,5 @@ class warp_pipeline_stage:
         marker = self.label if self.label is not None else "cluster"
         prio = self.priority if self.priority is not None else -1
         phase_gap = self.phase_gap if self.phase_gap is not None else -1
-        self._semantic.builder.create_warp_pipeline_border(
-            marker, prio, phase_gap)
+        self._semantic.builder.create_warp_pipeline_border(marker, prio, phase_gap)
         return False

--- a/test/TritonGPU/amd/amd-convert-warp-pipeline-invalid.mlir
+++ b/test/TritonGPU/amd/amd-convert-warp-pipeline-invalid.mlir
@@ -30,6 +30,61 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
+// -----
+
+// ==== Unsupported phase gap ====
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @bad_phase_gap(%n: index, %ptr: !tt.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %v0 = arith.constant 0.0 : f32
+
+    // expected-error @+1 {{warp-pipeline phase_gap must be 1 or 2}}
+    scf.for %i = %c0 to %n step %c1 {
+      scf.execute_region {
+        tt.store %ptr, %v0 : !tt.ptr<f32>
+        scf.yield
+      } {triton.warp_pipeline.stage = "stage0"}
+      scf.execute_region {
+        tt.store %ptr, %v0 : !tt.ptr<f32>
+        scf.yield
+      } {triton.warp_pipeline.stage = "stage1"}
+      scf.yield
+    } {triton.warp_pipeline.pipelined_for,
+       triton.warp_pipeline.phase_gap = 3 : i32}
+
+    tt.return
+  }
+}
+
+// -----
+
+// ==== phase_gap must be an i32 integer ====
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @bad_phase_gap_type(%n: index, %ptr: !tt.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %v0 = arith.constant 0.0 : f32
+
+    // expected-error @+1 {{warp-pipeline phase_gap must be an i32 integer}}
+    scf.for %i = %c0 to %n step %c1 {
+      scf.execute_region {
+        tt.store %ptr, %v0 : !tt.ptr<f32>
+        scf.yield
+      } {triton.warp_pipeline.stage = "stage0"}
+      scf.execute_region {
+        tt.store %ptr, %v0 : !tt.ptr<f32>
+        scf.yield
+      } {triton.warp_pipeline.stage = "stage1"}
+      scf.yield
+    } {triton.warp_pipeline.pipelined_for,
+       triton.warp_pipeline.phase_gap = 1 : i64}
+
+    tt.return
+  }
+}
 
 // -----
 
@@ -63,7 +118,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
-
 // -----
 
 // ==== Both top-of-loop and bottom-of-loop pre-existing barriers ====
@@ -126,6 +180,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         scf.yield
       } {triton.warp_pipeline.stage = "stage1"}
 
+      scf.yield
+    } {triton.warp_pipeline.pipelined_for}
+
+    tt.return
+  }
+}
+
+// -----
+
+// ==== One stage is not a pipeline ====
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @bad_single_stage(%n: index, %ptr: !tt.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %v0 = arith.constant 0.0 : f32
+
+    // expected-error @+1 {{pipelined_for body must contain at least two pipeline stages}}
+    scf.for %i = %c0 to %n step %c1 {
+      scf.execute_region {
+        tt.store %ptr, %v0 : !tt.ptr<f32>
+        scf.yield
+      } {triton.warp_pipeline.stage = "stage0"}
       scf.yield
     } {triton.warp_pipeline.pipelined_for}
 

--- a/test/TritonGPU/amd/amd-convert-warp-pipeline-invalid.mlir
+++ b/test/TritonGPU/amd/amd-convert-warp-pipeline-invalid.mlir
@@ -30,6 +30,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// ==== Subgroup barriers cannot synchronize a pipeline boundary ====
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @bad_subgroup_barrier(%n: index, %ptr: !tt.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %v0 = arith.constant 0.0 : f32
+
+    scf.for %i = %c0 to %n step %c1 {
+      scf.execute_region {
+        tt.store %ptr, %v0 : !tt.ptr<f32>
+        scf.yield
+      } {triton.warp_pipeline.stage = "stage0"}
+
+      // expected-error @+1 {{unexpected op inside pipelined_for body}}
+      gpu.barrier scope <subgroup>
+
+      scf.execute_region {
+        tt.store %ptr, %v0 : !tt.ptr<f32>
+        scf.yield
+      } {triton.warp_pipeline.stage = "stage1"}
+      scf.yield
+    } {triton.warp_pipeline.pipelined_for}
+
+    tt.return
+  }
+}
 // -----
 
 // ==== Unsupported phase gap ====

--- a/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
+++ b/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
@@ -1449,6 +1449,42 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // -----
 
+// ---- Explicit two-stage warp-group phase gap ----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+tt.func @two_stage_phase_gap(%n: index, %ptr: !tt.ptr<f32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %v0 = arith.constant 0.0 : f32
+  %v1 = arith.constant 1.0 : f32
+
+  scf.for %i = %c0 to %n step %c1 {
+    scf.execute_region {
+      tt.store %ptr, %v0 : !tt.ptr<f32>
+      scf.yield
+    } {triton.warp_pipeline.stage = "stage0"}
+    scf.execute_region {
+      tt.store %ptr, %v1 : !tt.ptr<f32>
+      scf.yield
+    } {triton.warp_pipeline.stage = "stage1"}
+    scf.yield
+  } {triton.warp_pipeline.pipelined_for,
+     triton.warp_pipeline.phase_gap = 2 : i32}
+
+  tt.return
+}
+}
+
+// CHECK-LABEL: tt.func @two_stage_phase_gap
+// CHECK: %[[WARPLOW:.+]] = arith.cmpi eq
+// CHECK: %[[WARPHIGH:.+]] = arith.cmpi ne
+// CHECK-COUNT-2: amdg.cond_barrier %[[WARPHIGH]]
+// CHECK: scf.for
+// CHECK-COUNT-2: amdg.cond_barrier %[[WARPLOW]]
+// CHECK: tt.return
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [8], order = [0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -1457,7 +1493,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 !group = !ttg.memdesc<4x64xi32, #shared, #smem, mutable, 8x64>
 !source = !ttg.memdesc<256xi32, #shared, #smem, mutable>
 !tile = !ttg.memdesc<128xi32, #shared, #smem, mutable, 256>
-
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
 // The halves of %source are disjoint within an iteration, but its origin
 // shifts by 64 elements between iterations. The high write [128, 256) then

--- a/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
+++ b/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
@@ -1485,6 +1485,59 @@ tt.func @two_stage_phase_gap(%n: index, %ptr: !tt.ptr<f32>) {
 
 // -----
 
+// ---- Back-to-back pipelines retain synchronization if either gap is 2 ----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+tt.func @back_to_back_mixed_phase_gaps(%n: index, %ptr: !tt.ptr<f32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %v0 = arith.constant 0.0 : f32
+  %v1 = arith.constant 1.0 : f32
+
+  scf.for %i = %c0 to %n step %c1 {
+    scf.execute_region {
+      tt.store %ptr, %v0 : !tt.ptr<f32>
+      scf.yield
+    } {triton.warp_pipeline.stage = "a0"}
+    scf.execute_region {
+      tt.store %ptr, %v1 : !tt.ptr<f32>
+      scf.yield
+    } {triton.warp_pipeline.stage = "a1"}
+    scf.yield
+  } {triton.warp_pipeline.pipelined_for,
+     triton.warp_pipeline.phase_gap = 2 : i32}
+
+  scf.for %j = %c0 to %n step %c1 {
+    scf.execute_region {
+      tt.store %ptr, %v0 : !tt.ptr<f32>
+      scf.yield
+    } {triton.warp_pipeline.stage = "b0"}
+    scf.execute_region {
+      tt.store %ptr, %v1 : !tt.ptr<f32>
+      scf.yield
+    } {triton.warp_pipeline.stage = "b1"}
+    scf.yield
+  } {triton.warp_pipeline.pipelined_for,
+     triton.warp_pipeline.phase_gap = 1 : i32}
+
+  tt.return
+}
+}
+
+// CHECK-LABEL: tt.func @back_to_back_mixed_phase_gaps
+// CHECK: ttg.barrier local
+// CHECK-COUNT-2: amdg.cond_barrier
+// CHECK: scf.for
+// CHECK-COUNT-2: amdg.cond_barrier
+// The second pipeline's prelude LOCAL barrier must not be eliminated.
+// CHECK: ttg.barrier local
+// CHECK: amdg.cond_barrier
+// CHECK: scf.for
+// CHECK: amdg.cond_barrier
+// CHECK: tt.return
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [8], order = [0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -1536,3 +1589,225 @@ tt.func @loop_varying_subslice_origin(%n: i32, %initial: tensor<512xi32, #blocke
   tt.return %result#1 : tensor<128xi32, #blocked>
 }
 }
+
+// -----
+
+// ---- Shared-memory hazards with phase_gap=1 ----
+//
+// Four stages and four distinct LDS buffers, so each barrier slot is forced
+// by a different dependence kind:
+//   RAW  : stage0 writes %raw,  stage1 reads it  -> bars[1] LOCAL
+//   WAR  : stage1 reads %war,   stage2 writes it -> bars[2] LOCAL
+//   WAW  : stage2 writes %waw,  stage3 writes it -> bars[3] LOCAL
+//   wrap : stage3 writes %wrap, next stage0 reads it -> bars[0] LOCAL
+//
+// With a one-stage gap these are all adjacent (distance-1) concurrent pairs.
+
+#hz1_blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#hz1_mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 4], instrShape = [16, 16, 16], isTransposed = true}>
+#hz1_dot = #ttg.dot_op<{opIdx = 0, parent = #hz1_mma, kWidth = 4}>
+#hz1_shared = #ttg.swizzled_shared<{vec = 4, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#hz1_smem = #ttg.shared_memory
+!hz1_buf = !ttg.memdesc<256x64xf16, #hz1_shared, #hz1_smem, mutable>
+!hz1_tile = !ttg.memdesc<256x16xf16, #hz1_shared, #hz1_smem, mutable, 256x64>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @shared_hazards_phase_gap1(
+      %lb: i32, %ub: i32, %step: i32,
+      %init: tensor<256x16xf16, #hz1_dot>,
+      %ptr: tensor<256x64x!tt.ptr<f16>, #hz1_blocked>) {
+    %raw = ttg.local_alloc : () -> !hz1_buf
+    %war = ttg.local_alloc : () -> !hz1_buf
+    %waw = ttg.local_alloc : () -> !hz1_buf
+    %wrap = ttg.local_alloc : () -> !hz1_buf
+
+    %r:3 = scf.for %i = %lb to %ub step %step
+        iter_args(%rv = %init, %wv = %init, %xp = %init)
+        -> (tensor<256x16xf16, #hz1_dot>, tensor<256x16xf16, #hz1_dot>, tensor<256x16xf16, #hz1_dot>) : i32 {
+      %s0 = scf.execute_region -> tensor<256x16xf16, #hz1_dot> no_inline {
+        %data = tt.load %ptr : tensor<256x64x!tt.ptr<f16>, #hz1_blocked>
+        ttg.local_store %data, %raw : tensor<256x64xf16, #hz1_blocked> -> !hz1_buf
+        %sub = ttg.memdesc_subslice %wrap[0, 0] : !hz1_buf -> !hz1_tile
+        %ld = ttg.local_load %sub : !hz1_tile -> tensor<256x16xf16, #hz1_dot>
+        scf.yield %ld : tensor<256x16xf16, #hz1_dot>
+      } {triton.warp_pipeline.stage = "raw_write_wrap_read"}
+
+      %s1:2 = scf.execute_region -> (tensor<256x16xf16, #hz1_dot>, tensor<256x16xf16, #hz1_dot>) no_inline {
+        %suba = ttg.memdesc_subslice %raw[0, 0] : !hz1_buf -> !hz1_tile
+        %lda = ttg.local_load %suba : !hz1_tile -> tensor<256x16xf16, #hz1_dot>
+        %subb = ttg.memdesc_subslice %war[0, 0] : !hz1_buf -> !hz1_tile
+        %ldb = ttg.local_load %subb : !hz1_tile -> tensor<256x16xf16, #hz1_dot>
+        scf.yield %lda, %ldb : tensor<256x16xf16, #hz1_dot>, tensor<256x16xf16, #hz1_dot>
+      } {triton.warp_pipeline.stage = "raw_read_war_read"}
+
+      scf.execute_region no_inline {
+        %data = tt.load %ptr : tensor<256x64x!tt.ptr<f16>, #hz1_blocked>
+        ttg.local_store %data, %war : tensor<256x64xf16, #hz1_blocked> -> !hz1_buf
+        ttg.local_store %data, %waw : tensor<256x64xf16, #hz1_blocked> -> !hz1_buf
+        scf.yield
+      } {triton.warp_pipeline.stage = "war_write_waw_write"}
+
+      scf.execute_region no_inline {
+        %data = tt.load %ptr : tensor<256x64x!tt.ptr<f16>, #hz1_blocked>
+        ttg.local_store %data, %waw : tensor<256x64xf16, #hz1_blocked> -> !hz1_buf
+        ttg.local_store %data, %wrap : tensor<256x64xf16, #hz1_blocked> -> !hz1_buf
+        scf.yield
+      } {triton.warp_pipeline.stage = "waw_write_wrap_write"}
+
+      scf.yield %s1#0, %s1#1, %s0 : tensor<256x16xf16, #hz1_dot>, tensor<256x16xf16, #hz1_dot>, tensor<256x16xf16, #hz1_dot>
+    } {triton.warp_pipeline.pipelined_for}
+
+    ttg.local_dealloc %wrap : !hz1_buf
+    ttg.local_dealloc %waw : !hz1_buf
+    ttg.local_dealloc %war : !hz1_buf
+    ttg.local_dealloc %raw : !hz1_buf
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func @shared_hazards_phase_gap1
+// CHECK: ttg.barrier local
+// CHECK: amdg.cond_barrier
+// CHECK: scf.for
+// Stage 0: write RAW buffer, read wrap buffer from the previous iteration.
+// CHECK: ttg.local_store
+// CHECK: ttg.local_load
+// bars[1] LOCAL (RAW stage0 write -> stage1 read).
+// CHECK: rocdl.sched.barrier none
+// CHECK-NEXT: ttg.barrier local
+// CHECK-NEXT: rocdl.sched.barrier none
+// Stage 1: read RAW buffer, read WAR buffer.
+// CHECK: ttg.local_load
+// CHECK: ttg.local_load
+// bars[2] LOCAL (WAR stage1 read -> stage2 write).
+// CHECK: rocdl.sched.barrier none
+// CHECK-NEXT: ttg.barrier local
+// CHECK-NEXT: rocdl.sched.barrier none
+// Stage 2: write WAR buffer, write WAW buffer.
+// CHECK: ttg.local_store
+// CHECK: ttg.local_store
+// bars[3] LOCAL (WAW stage2 write -> stage3 write).
+// CHECK: rocdl.sched.barrier none
+// CHECK-NEXT: ttg.barrier local
+// CHECK-NEXT: rocdl.sched.barrier none
+// Stage 3: write WAW buffer, write wrap buffer.
+// CHECK: ttg.local_store
+// CHECK: ttg.local_store
+// bars[0] LOCAL (next-iteration RAW: stage3 write -> stage0 read).
+// CHECK: rocdl.sched.barrier none
+// CHECK-NEXT: ttg.barrier local
+// CHECK-NEXT: rocdl.sched.barrier none
+// CHECK: scf.yield
+// CHECK: amdg.cond_barrier
+
+// -----
+
+// ---- Shared-memory hazards with phase_gap=2 ----
+//
+// Four stages. Distance-2 pairs run concurrently across warp groups, so
+// those LOCAL barriers must sit immediately before the destination:
+//   WAW  : stage0 writes %waw,  stage1 writes it -> bars[1] LOCAL (adjacent)
+//   RAW  : stage0 writes %raw,  stage2 reads it  -> bars[2] LOCAL (concurrent)
+//   WAR  : stage1 reads %war,   stage3 writes it -> bars[3] LOCAL (concurrent)
+//   wrap : stage3 writes %wrap, next stage0 reads it -> bars[0] LOCAL
+
+#hz2_blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#hz2_mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 4], instrShape = [16, 16, 16], isTransposed = true}>
+#hz2_dot = #ttg.dot_op<{opIdx = 0, parent = #hz2_mma, kWidth = 4}>
+#hz2_shared = #ttg.swizzled_shared<{vec = 4, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#hz2_smem = #ttg.shared_memory
+!hz2_buf = !ttg.memdesc<256x64xf16, #hz2_shared, #hz2_smem, mutable>
+!hz2_tile = !ttg.memdesc<256x16xf16, #hz2_shared, #hz2_smem, mutable, 256x64>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @shared_hazards_phase_gap2(
+      %lb: i32, %ub: i32, %step: i32,
+      %init: tensor<256x16xf16, #hz2_dot>,
+      %ptr: tensor<256x64x!tt.ptr<f16>, #hz2_blocked>) {
+    %raw = ttg.local_alloc : () -> !hz2_buf
+    %war = ttg.local_alloc : () -> !hz2_buf
+    %waw = ttg.local_alloc : () -> !hz2_buf
+    %wrap = ttg.local_alloc : () -> !hz2_buf
+
+    %r:3 = scf.for %i = %lb to %ub step %step
+        iter_args(%rv = %init, %wv = %init, %xp = %init)
+        -> (tensor<256x16xf16, #hz2_dot>, tensor<256x16xf16, #hz2_dot>, tensor<256x16xf16, #hz2_dot>) : i32 {
+      %s0 = scf.execute_region -> tensor<256x16xf16, #hz2_dot> no_inline {
+        %data = tt.load %ptr : tensor<256x64x!tt.ptr<f16>, #hz2_blocked>
+        ttg.local_store %data, %raw : tensor<256x64xf16, #hz2_blocked> -> !hz2_buf
+        ttg.local_store %data, %waw : tensor<256x64xf16, #hz2_blocked> -> !hz2_buf
+        %sub = ttg.memdesc_subslice %wrap[0, 0] : !hz2_buf -> !hz2_tile
+        %ld = ttg.local_load %sub : !hz2_tile -> tensor<256x16xf16, #hz2_dot>
+        scf.yield %ld : tensor<256x16xf16, #hz2_dot>
+      } {triton.warp_pipeline.stage = "raw_waw_write_wrap_read"}
+
+      %s1 = scf.execute_region -> tensor<256x16xf16, #hz2_dot> no_inline {
+        %data = tt.load %ptr : tensor<256x64x!tt.ptr<f16>, #hz2_blocked>
+        ttg.local_store %data, %waw : tensor<256x64xf16, #hz2_blocked> -> !hz2_buf
+        %sub = ttg.memdesc_subslice %war[0, 0] : !hz2_buf -> !hz2_tile
+        %ld = ttg.local_load %sub : !hz2_tile -> tensor<256x16xf16, #hz2_dot>
+        scf.yield %ld : tensor<256x16xf16, #hz2_dot>
+      } {triton.warp_pipeline.stage = "waw_write_war_read"}
+
+      amdg.async_wait {num_inst = 0 : i32}
+
+      %s2 = scf.execute_region -> tensor<256x16xf16, #hz2_dot> no_inline {
+        %sub = ttg.memdesc_subslice %raw[0, 0] : !hz2_buf -> !hz2_tile
+        %ld = ttg.local_load %sub : !hz2_tile -> tensor<256x16xf16, #hz2_dot>
+        scf.yield %ld : tensor<256x16xf16, #hz2_dot>
+      } {triton.warp_pipeline.stage = "raw_read"}
+
+      scf.execute_region no_inline {
+        %data = tt.load %ptr : tensor<256x64x!tt.ptr<f16>, #hz2_blocked>
+        ttg.local_store %data, %war : tensor<256x64xf16, #hz2_blocked> -> !hz2_buf
+        ttg.local_store %data, %wrap : tensor<256x64xf16, #hz2_blocked> -> !hz2_buf
+        scf.yield
+      } {triton.warp_pipeline.stage = "war_write_wrap_write"}
+
+      scf.yield %s2, %s1, %s0 : tensor<256x16xf16, #hz2_dot>, tensor<256x16xf16, #hz2_dot>, tensor<256x16xf16, #hz2_dot>
+    } {triton.warp_pipeline.pipelined_for,
+       triton.warp_pipeline.phase_gap = 2 : i32}
+
+    ttg.local_dealloc %wrap : !hz2_buf
+    ttg.local_dealloc %waw : !hz2_buf
+    ttg.local_dealloc %war : !hz2_buf
+    ttg.local_dealloc %raw : !hz2_buf
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func @shared_hazards_phase_gap2
+// CHECK: %[[HZ2_LOW:.+]] = arith.cmpi eq
+// CHECK: %[[HZ2_HIGH:.+]] = arith.cmpi ne
+// CHECK-COUNT-2: amdg.cond_barrier %[[HZ2_HIGH]]
+// CHECK: scf.for
+// Stage 0: write RAW and WAW buffers, read wrap buffer.
+// CHECK: ttg.local_store
+// CHECK: ttg.local_store
+// CHECK: ttg.local_load
+// bars[1] LOCAL (WAW stage0 write -> stage1 write).
+// CHECK: rocdl.sched.barrier none
+// CHECK-NEXT: ttg.barrier local
+// CHECK-NEXT: rocdl.sched.barrier none
+// Stage 1: write WAW buffer, read WAR buffer.
+// CHECK: ttg.local_store
+// CHECK: ttg.local_load
+// The existing async wait does not provide an LDS fence. bars[2] therefore
+// adds a LOCAL barrier after it for the concurrent stage0 -> stage2 RAW.
+// CHECK: rocdl.sched.barrier none
+// CHECK-NEXT: amdg.async_wait
+// CHECK-NEXT: ttg.barrier local
+// CHECK-NEXT: rocdl.sched.barrier none
+// Stage 2: read RAW buffer.
+// CHECK: ttg.local_load
+// bars[3] LOCAL (concurrent WAR stage1 read -> stage3 write).
+// CHECK: rocdl.sched.barrier none
+// CHECK-NEXT: ttg.barrier local
+// CHECK-NEXT: rocdl.sched.barrier none
+// Stage 3: write WAR and wrap buffers.
+// CHECK: ttg.local_store
+// CHECK: ttg.local_store
+// bars[0] LOCAL (next-iteration RAW: stage3 write -> stage0 read).
+// CHECK: rocdl.sched.barrier none
+// CHECK-NEXT: ttg.barrier local
+// CHECK-NEXT: rocdl.sched.barrier none
+// CHECK: scf.yield
+// CHECK-COUNT-2: amdg.cond_barrier %[[HZ2_LOW]]

--- a/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
+++ b/test/TritonGPU/amd/amd-convert-warp-pipeline.mlir
@@ -775,16 +775,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // ---- Flat pipeline with pre-existing barrier between stages ----
 //
-// When an async_wait (or similar barrier op) already exists between
-// flat pipeline stages, the pass should wrap it with sched_barriers
-// instead of inserting a redundant s_barrier.
+// An async_wait between flat pipeline stages is preserved before the
+// boundary's single synchronization barrier.
 //
 // Stage layout: stage0 -- async_wait -- stage1 -- (nothing) -- stage2
 //
 // Expected between stage0 and stage1:
-//   sched_barrier + async_wait + sched_barrier   (wrapped, no s_barrier)
+//   sched_barrier + async_wait + s_barrier + sched_barrier
 // Expected between stage1 and stage2:
-//   sched_barrier + s_barrier + sched_barrier     (inserted, no async_wait)
+//   sched_barrier + s_barrier + sched_barrier
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func @flat_pipeline_existing_barrier(%ptr: !tt.ptr<f32>) {
@@ -823,14 +822,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // Stage 0 ops.
 // CHECK: tt.store
 //
-// Between stage 0 and 1: existing async_wait wrapped, no s_barrier.
+// Between stage 0 and 1: existing async_wait followed by one s_barrier.
 // The per-mem-op barrier (non_mem_non_sideeffect) follows stage 0's store; the
 // cluster barrier (none) is next.
 // CHECK: rocdl.sched.barrier non_mem_non_sideeffect
 // CHECK-NEXT: rocdl.sched.barrier none
 // CHECK-NEXT: amdg.async_wait
+// CHECK-NEXT: rocdl.s.barrier
 // CHECK-NEXT: rocdl.sched.barrier none
-// CHECK-NOT: rocdl.s.barrier
 // Stage 1 ops.
 // CHECK: tt.store
 //
@@ -1646,6 +1645,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         scf.yield
       } {triton.warp_pipeline.stage = "war_write_waw_write"}
 
+      ttg.barrier none
+
       scf.execute_region no_inline {
         %data = tt.load %ptr : tensor<256x64x!tt.ptr<f16>, #hz1_blocked>
         ttg.local_store %data, %waw : tensor<256x64xf16, #hz1_blocked> -> !hz1_buf
@@ -1685,7 +1686,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // Stage 2: write WAR buffer, write WAW buffer.
 // CHECK: ttg.local_store
 // CHECK: ttg.local_store
-// bars[3] LOCAL (WAW stage2 write -> stage3 write).
+// The existing control barrier is upgraded in place for the stage2 -> stage3
+// WAW. The CHECK-NEXT chain ensures no second barrier is inserted.
 // CHECK: rocdl.sched.barrier none
 // CHECK-NEXT: ttg.barrier local
 // CHECK-NEXT: rocdl.sched.barrier none

--- a/test/TritonGPU/amd/amd-warp-pipeline-invalid.mlir
+++ b/test/TritonGPU/amd/amd-warp-pipeline-invalid.mlir
@@ -115,3 +115,105 @@ tt.func @flat_form_for_in_cluster(%n: index, %ptr: !tt.ptr<f32>) {
 
   tt.return
 }
+
+// -----
+
+// ---- Loop-form: phase_gap on a later stage is rejected ----
+
+tt.func @phase_gap_on_second_stage(%n: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  scf.for %i = %c0 to %n step %c1 {
+    %a = arith.addi %i, %c1 : index
+    rocdl.sched.barrier none {triton.warp_pipeline.border = "stage0"}
+
+    %b = arith.addi %a, %i : index
+    // expected-error @+1 {{warp-pipeline phase_gap may only be specified on the first stage}}
+    rocdl.sched.barrier none {triton.warp_pipeline.border = "stage1", triton.warp_pipeline.phase_gap = 2 : i32}
+
+    scf.yield
+  }
+
+  tt.return
+}
+
+// -----
+
+// ---- Loop-form: phase_gap is currently limited to two stages ----
+
+tt.func @phase_gap_too_wide(%n: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  scf.for %i = %c0 to %n step %c1 {
+    %a = arith.addi %i, %c1 : index
+    // expected-error @+1 {{warp-pipeline phase_gap must be 1 or 2}}
+    rocdl.sched.barrier none {triton.warp_pipeline.border = "stage0", triton.warp_pipeline.phase_gap = 3 : i32}
+
+    %b = arith.addi %a, %i : index
+    rocdl.sched.barrier none {triton.warp_pipeline.border = "stage1"}
+
+    scf.yield
+  }
+
+  tt.return
+}
+
+// -----
+
+// ---- Loop-form: phase_gap must be an i32 integer ----
+
+tt.func @phase_gap_wrong_type(%n: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  scf.for %i = %c0 to %n step %c1 {
+    %a = arith.addi %i, %c1 : index
+    // expected-error @+1 {{warp-pipeline phase_gap must be an i32 integer}}
+    rocdl.sched.barrier none {triton.warp_pipeline.border = "stage0", triton.warp_pipeline.phase_gap = "2"}
+
+    %b = arith.addi %a, %i : index
+    rocdl.sched.barrier none {triton.warp_pipeline.border = "stage1"}
+
+    scf.yield
+  }
+
+  tt.return
+}
+
+// -----
+
+// ---- Flat-form: phase_gap is not silently ignored ----
+
+tt.func @flat_phase_gap(%n: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  %a = arith.addi %c0, %c1 : index
+  // expected-error @+1 {{flat warp pipelines only support phase_gap=1}}
+  rocdl.sched.barrier none {triton.warp_pipeline.border = "stage0", triton.warp_pipeline.phase_gap = 2 : i32}
+  %b = arith.addi %a, %n : index
+  rocdl.sched.barrier none {triton.warp_pipeline.border = "stage1"}
+
+  tt.return
+}
+
+// -----
+
+// ---- Loop-form: one stage is not a pipeline ----
+
+tt.func @single_stage_pipeline(%n: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // expected-error @+1 {{warp_pipeline_stage borders did not produce at least two stages}}
+  scf.for %i = %c0 to %n step %c1 {
+    %a = arith.addi %i, %c1 : index
+    rocdl.sched.barrier none {triton.warp_pipeline.border = "stage0"}
+
+    scf.yield
+  }
+
+  tt.return
+}

--- a/test/TritonGPU/amd/amd-warp-pipeline.mlir
+++ b/test/TritonGPU/amd/amd-warp-pipeline.mlir
@@ -93,6 +93,31 @@ tt.func @two_stage_example(%n: index) {
 // CHECK-NOT: rocdl.sched.barrier
 // CHECK: tt.return
 
+// -- phase_gap on the first stage is copied onto the loop ----
+
+tt.func @first_stage_phase_gap(%n: index) {
+  %c0  = arith.constant 0 : index
+  %c1  = arith.constant 1 : index
+
+  scf.for %i = %c0 to %n step %c1 {
+    %x = arith.addi %i, %c1 : index
+    rocdl.sched.barrier none {triton.warp_pipeline.border = "stage0", triton.warp_pipeline.phase_gap = 2 : i32}
+    %y = arith.muli %x, %c1 : index
+    rocdl.sched.barrier none {triton.warp_pipeline.border = "stage1"}
+    scf.yield
+  }
+
+  tt.return
+}
+
+// CHECK-LABEL: tt.func @first_stage_phase_gap(
+// CHECK: scf.for
+// CHECK-COUNT-2: scf.execute_region
+// CHECK: triton.warp_pipeline.phase_gap = 2
+// CHECK-SAME: triton.warp_pipeline.pipelined_for
+// CHECK-NOT: rocdl.sched.barrier
+// CHECK: tt.return
+
 // -- pipelining with pre-existing barrier (ignorable ops) ----
 
 // CHECK-LABEL: tt.func public @triple_buf_two_stages
@@ -167,7 +192,7 @@ tt.func @flat_pipeline_example(%n: index) {
   %a  = arith.addi %c0, %c1 : index
   %a2 = arith.muli %a, %c1 : index
 
-  rocdl.sched.barrier none {triton.warp_pipeline.border = "stage0_epi", triton.warp_pipeline.priority = 1 : i32}
+  rocdl.sched.barrier none {triton.warp_pipeline.border = "stage0_epi", triton.warp_pipeline.phase_gap = 1 : i32, triton.warp_pipeline.priority = 1 : i32}
 
   // Stage 1
   %b  = arith.addi %a2, %c0 : index

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -53,6 +53,29 @@ namespace mlir::triton {
 
 namespace {
 
+constexpr StringLiteral kPhaseGapAttr = "triton.warp_pipeline.phase_gap";
+constexpr int kDefaultPhaseGap = 1;
+constexpr int kMaxSupportedPhaseGap = 2;
+
+static int getPhaseGap(Operation *op) {
+  if (auto attr = op->getAttrOfType<IntegerAttr>(kPhaseGapAttr))
+    return attr.getInt();
+  return kDefaultPhaseGap;
+}
+
+static LogicalResult validatePhaseGap(Operation *op) {
+  Attribute attr = op->getAttr(kPhaseGapAttr);
+  if (!attr)
+    return success();
+  auto intAttr = dyn_cast<IntegerAttr>(attr);
+  if (!intAttr || !intAttr.getType().isInteger(32))
+    return op->emitError("warp-pipeline phase_gap must be an i32 integer");
+  int64_t value = intAttr.getInt();
+  if (value < kDefaultPhaseGap || value > kMaxSupportedPhaseGap)
+    return op->emitError("warp-pipeline phase_gap must be 1 or 2");
+  return success();
+}
+
 // Construct a virtual block describing a pipeline cluster's buffer R/W set.
 // Walks recursively so that LDS effects inside nested non-loop regions
 // (scf.if / tt.reduce / tt.scan / etc.) are accounted for.  Loops (scf.for /
@@ -120,6 +143,11 @@ static scf::ExecuteRegionOp getPipelineStage(Operation *op) {
 // failure on any deviation.  Side-effect free: leaves the IR untouched so
 // callers can fail fast before mutating anything.
 static LogicalResult validatePipelinedForBody(scf::ForOp forOp) {
+  // Wider gaps are technically possible, but have not yet been validated by
+  // the dependency analysis or the cross-pipeline barrier optimization.
+  if (failed(validatePhaseGap(forOp.getOperation())))
+    return failure();
+
   std::map<int, Operation *> existingBarrierMap;
   int numClusters = 0;
   for (auto &op : *forOp.getBody()) {
@@ -150,63 +178,21 @@ static LogicalResult validatePipelinedForBody(scf::ForOp forOp) {
   return success();
 }
 
-// Pairwise LDS-dependency analysis between pipeline clusters.
+// Mark cluster boundaries that need an LDS fence. bars[i] is immediately
+// before cluster i; for a loop, bars[0] is the wrap-around boundary.
 //
-// `circular` selects the index topology used by the analysis:
-//   * true  — the schedule wraps modulo N.  Used by loop pipelines (scf.for)
-//             where the wrap-around represents iter-i feeding iter-(i+1).
-//   * false — the schedule is straight-line, indices stay in [0, N).  Used
-//             by flat (unrolled) pipelines.
-// The rest of this comment uses "circular" / "linear" exclusively, since
-// the analysis only cares about topology and not about the source IR kind.
+// Sequential pairs may use any LOCAL barrier on their path. For non-adjacent
+// pairs we preserve the existing placement at dst - 1. Loop stages separated
+// by phaseGap execute concurrently across warp groups, so their fence must be
+// immediately before dst; an earlier barrier does not cover that pair.
 //
-// LAYOUT
-// ------
-//   cluster:   c0    c1    c2    ...    c_{N-1}
-//   bars:    b0    b1    b2    b3   ...        b_{N-1}        (b_i sits
-//                                                              before c_i)
-//
-//   * circular: b0 is the wrap-around barrier inside the loop body —
-//     sitting between c_{N-1} of one iteration and c0 of the next.
-//   * linear:   b0 has no physical slot (no barrier exists before the first
-//     cluster), and the schedule never wraps around.
-//
-// GOAL
-// ----
-//   For every ordered pair (src, dst) whose LDS effects intersect, guarantee
-//   that the schedule has at least one LOCAL (ds_wait + s_barrier) barrier
-//   somewhere on the path src → dst.  If no existing slot on the path is
-//   LOCAL, mark one as LOCAL.
-//
-// PLACEMENT CHOICE
-// ----------------
-//   When forced to place a LOCAL barrier we pick:
-//     dist == 1 → bars[dst]      (the only slot between src and dst)
-//     dist >  1 → bars[dst - 1]  (the second-rightmost slot on the path)
-//   The `dst - 1` choice is somewhat arbitrary — any slot in (src, dst] is
-//   correct for memory ordering — and is preserved here to match upstream
-//   behavior and existing tests.
-//
-// COVERAGE CHECK
-// --------------
-//   A pair is "covered" if any slot in (src, barrierLoc] is already LOCAL.
-//   Note that bars[dst] is intentionally NOT consulted when dist > 1; this
-//   mirrors the placement choice (we never look at, nor place into, the
-//   slot owned by the adjacent (dst-1, dst) pair).
-//
-// ITERATION ORDER
-// ---------------
-//   We sweep `dist` from 1 up to `maxDist`:
-//     * circular: maxDist = N.  dist == N is the self-loop (src == dst),
-//       which captures iter-i write vs iter-(i+1) read across the
-//       wrap-around when only one cluster touches the buffer.
-//     * linear:   maxDist = N - 1.  No wrap.
-//   Walking by increasing distance ensures the shorter-range LOCAL
-//   barriers we just placed are visible when checking longer-range pairs,
-//   skipping many redundant placements.
+// Circular analysis includes distance N to model dependencies across the next
+// loop iteration. Iteration-varying descriptor origins are invalidated only
+// for pairs that cross that boundary.
 static void analyzePipelineDependencies(ArrayRef<BlockInfo> clusterInfo,
                                         SmallVectorImpl<bool> &bars,
-                                        Allocation *allocation, bool circular) {
+                                        Allocation *allocation, bool circular,
+                                        int phaseGap) {
   const int N = clusterInfo.size();
   const int maxDist = circular ? N : N - 1;
 
@@ -242,8 +228,12 @@ static void analyzePipelineDependencies(ArrayRef<BlockInfo> clusterInfo,
     const int srcEnd = circular ? N : N - dist;
     for (int src = 0; src < srcEnd; src++) {
       const int dst = wrap(src + dist);
-      const int barrierLoc = (dist == 1) ? dst : wrap(dst - 1);
-      if (isCovered(src, barrierLoc))
+      const bool isConcurrentPair = circular && dist == phaseGap;
+      const int barrierLoc =
+          (dist == 1 || isConcurrentPair) ? dst : wrap(dst - 1);
+      const bool covered =
+          isConcurrentPair ? bars[barrierLoc] : isCovered(src, barrierLoc);
+      if (covered)
         continue;
       const BlockInfo &sourceInfo =
           src + dist >= N ? previousIterationInfo[src] : clusterInfo[src];
@@ -280,16 +270,20 @@ static void emitClusterPriority(OpBuilder &r, Location loc,
 // Wrap a pre-existing barrier op (e.g. async_wait) with sched_barriers so the
 // backend scheduler cannot move ops across it, and emit the cluster's
 // priority just before the barrier.  Used in place of inserting a fresh
-// cluster barrier when one already exists at the cluster boundary.
+// cluster barrier when one already exists at the cluster boundary. If the
+// dependency analysis requires an LDS fence, add one after a non-LOCAL wait.
 static void wrapExistingBarrier(OpBuilder &b, Location loc,
                                 Operation *clusterOp,
                                 Operation *existingBarrier, bool anyHasPriority,
-                                bool emitPriority = true) {
+                                bool needLocal, bool emitPriority = true) {
   b.setInsertionPoint(existingBarrier);
   if (emitPriority)
     emitClusterPriority(b, loc, clusterOp, anyHasPriority);
   ROCDL::SchedBarrier::create(b, loc, ROCDL::SchedGroupMask::none);
   b.setInsertionPointAfter(existingBarrier);
+  auto localBarrier = dyn_cast<triton::gpu::BarrierOp>(existingBarrier);
+  if (needLocal && (!localBarrier || !localBarrier.hasLocal()))
+    triton::gpu::BarrierOp::create(b, loc, triton::gpu::AddrSpace::Local);
   ROCDL::SchedBarrier::create(b, loc, ROCDL::SchedGroupMask::none);
 }
 
@@ -330,7 +324,7 @@ static bool shouldPlaceBackedgeBarrierAtHead(
 // Returns warpLow (for reconverge) and warpHigh (consumed by phase shift).
 static std::pair<Value, Value>
 emitPipelinePrelude(OpBuilder &b, Location loc, int threadsPerPipelineGroup,
-                    int phaseGap = 1) {
+                    int phaseGap = kDefaultPhaseGap) {
   // Flush any pending shared-memory (LDS) dependencies before entering the
   // warp-pipelined region.  Without this barrier ModuleMembarAnalysis may
   // later insert a barrier inside the first pipeline stage, which would
@@ -357,7 +351,8 @@ emitPipelinePrelude(OpBuilder &b, Location loc, int threadsPerPipelineGroup,
 static void emitPipelinePostlude(OpBuilder &b, Location loc,
                                  bool anyHasPriority, Value warpLow,
                                  bool emitPostludeBarrier = false,
-                                 bool needLocal = false, int phaseGap = 1) {
+                                 bool needLocal = false,
+                                 int phaseGap = kDefaultPhaseGap) {
   if (emitPostludeBarrier)
     emitClusterBarrier(b, loc, needLocal);
   if (anyHasPriority)
@@ -390,12 +385,8 @@ public:
     if (!allocation)
       return rewriter.notifyMatchFailure(forOp, "no Allocation for function");
 
-    int phaseGap = 1;
-    if (auto attr =
-            forOp->getAttrOfType<IntegerAttr>("triton.warp_pipeline.phase_gap"))
-      phaseGap = attr.getInt();
+    int phaseGap = getPhaseGap(forOp.getOperation());
     forOp->removeAttr("triton.warp_pipeline.pipelined_for");
-    forOp->removeAttr("triton.warp_pipeline.phase_gap");
     emitPipelinedFor(rewriter, forOp.getLoc(), forOp, allocation,
                      threadsPerPipelineGroup, phaseGap);
     return success();
@@ -459,15 +450,18 @@ private:
 
     // 3. Circular dependency analysis (wrap-around for loop pipelines).
     analyzePipelineDependencies(clusterInfo, bars, allocation,
-                                /*circular=*/true);
-    if (shouldPlaceBackedgeBarrierAtHead(isaFamily, clusterOps, clusterBlocks,
+                                /*circular=*/true, phaseGap);
+    // This placement heuristic is tuned for the original one-stage phase
+    // offset. Keep the analyzed backedge placement for wider gaps.
+    if (phaseGap == kDefaultPhaseGap &&
+        shouldPlaceBackedgeBarrierAtHead(isaFamily, clusterOps, clusterBlocks,
                                          bars, hasTopBarrier, hasBottomBarrier))
       hasTopBarrier = true;
 
     // 4. Materializing final cluster-scope barriers.  For each cluster index:
     //  • If there is a pre-existing barrier at that location, we wrap it with
-    //    sched_barriers so that backend scheduling cannot move operations
-    //    across it.
+    //    sched_barriers and add a LOCAL fence if the dependency analysis
+    //    requires one.
     //  • If no barrier exists but `bars[i]` is true, we insert a new cluster
     //    barrier (SchedBarrier + Local/SBarrier + SchedBarrier).
     //    The “local” variant is chosen when cluster-to-cluster memory
@@ -502,12 +496,9 @@ private:
 
       if (auto exBar = existingBarrierMap.find(i);
           exBar != existingBarrierMap.end()) {
-        // FIXME: If bars[i] is true, wrapping a non-LOCAL pre-existing
-        // barrier is not enough to satisfy LDS ordering.  For now we rely on
-        // the producer to place such barriers only where no local fence is
-        // needed.
         wrapExistingBarrier(b, loc, clusterOps[i], exBar->second,
-                            anyHasPriority, emitPriorityAtBoundary);
+                            anyHasPriority, /*needLocal=*/bars[i],
+                            emitPriorityAtBoundary);
       } else {
         if (emitPriorityAtBoundary)
           emitClusterPriority(b, loc, clusterOps[i], anyHasPriority);
@@ -602,7 +593,7 @@ static void emitPipelinedFlat(SmallVector<scf::ExecuteRegionOp> &clusterOps,
   // 1. Pre-barrier and phase shift before the first execute_region.
   b.setInsertionPoint(clusterOps.front());
   auto [warpLow, warpHigh] =
-      emitPipelinePrelude(b, loc, threadsPerPipelineGroup);
+      emitPipelinePrelude(b, loc, threadsPerPipelineGroup, kDefaultPhaseGap);
 
   // 2. Collect cluster info.
   SmallVector<Block *> clusterBlocks;
@@ -623,13 +614,13 @@ static void emitPipelinedFlat(SmallVector<scf::ExecuteRegionOp> &clusterOps,
 
   // 3. Linear dependency analysis (no wrap-around for flat pipelines).
   analyzePipelineDependencies(clusterInfo, bars, allocation,
-                              /*circular=*/false);
+                              /*circular=*/false, kDefaultPhaseGap);
 
   // 4. Materialize cluster barriers.
   //    Cluster 0 gets only its priority (inserted after cond_barrier above).
   //    Clusters 1..N get priority + cluster barrier, unless a pre-existing
   //    barrier op (e.g., async_wait) already exists between the clusters —
-  //    in that case, wrap it with sched_barriers instead of adding a new one.
+  //    in that case, wrap it and add a LOCAL fence only when required.
   emitClusterPriority(b, loc, clusterOps[0], anyHasPriority);
 
   for (int i = 1; i < numClusters; i++) {
@@ -643,11 +634,8 @@ static void emitPipelinedFlat(SmallVector<scf::ExecuteRegionOp> &clusterOps,
     }
 
     if (existingBarrier) {
-      // FIXME: If bars[i] is true, wrapping a non-LOCAL pre-existing barrier
-      // is not enough to satisfy LDS ordering.  For now we rely on the
-      // producer to place such barriers only where no local fence is needed.
       wrapExistingBarrier(b, loc, clusterOps[i], existingBarrier,
-                          anyHasPriority);
+                          anyHasPriority, /*needLocal=*/bars[i]);
     } else {
       b.setInsertionPoint(clusterOps[i]);
       emitClusterPriority(b, loc, clusterOps[i], anyHasPriority);
@@ -657,7 +645,9 @@ static void emitPipelinedFlat(SmallVector<scf::ExecuteRegionOp> &clusterOps,
 
   // 5. Post-sequence reconverge.
   b.setInsertionPointAfter(clusterOps.back());
-  emitPipelinePostlude(b, loc, anyHasPriority, warpLow);
+  emitPipelinePostlude(b, loc, anyHasPriority, warpLow,
+                       /*emitPostludeBarrier=*/false,
+                       /*needLocal=*/false, kDefaultPhaseGap);
 }
 
 // Walk the module for flat warp-pipeline execute_region sequences
@@ -981,6 +971,16 @@ static void eliminateRedundantCondBarriers(ModuleOp m,
           continue;
         }
 
+        // The carry-over analysis below models a one-stage offset. For wider
+        // offsets, retain the next pipeline's LOCAL prelude barrier and both
+        // reconvergence/phase-shift sequences. This is also conservative when
+        // adjacent pipelines request different gaps.
+        if (getPhaseGap(prevFor.getOperation()) != kDefaultPhaseGap ||
+            getPhaseGap(next) != kDefaultPhaseGap) {
+          LDBG("phase gap is not 1 on both pipelines; keeping barriers");
+          continue;
+        }
+
         // The post-loop cond_barrier must be immediately followed by the
         // prelude's ttg.barrier local — this proves no operations were
         // inserted between the two pipelines.
@@ -1060,9 +1060,11 @@ public:
     // offending op; we bail out hard rather than producing half-converted
     // IR.
     bool malformed = false;
+    SmallVector<scf::ForOp> pipelinedLoops;
     m.walk([&](scf::ForOp forOp) {
       if (!forOp->getAttr("triton.warp_pipeline.pipelined_for"))
         return;
+      pipelinedLoops.push_back(forOp);
       if (failed(validatePipelinedForBody(forOp)))
         malformed = true;
     });
@@ -1087,6 +1089,13 @@ public:
     // barriers inserted) but before patternInline (inlining execute_regions
     // would flatten the IR and obscure the cond_barrier adjacency we rely on).
     eliminateRedundantCondBarriers(m, moduleAllocation);
+
+    // phase_gap is retained through conversion so the adjacent-pipeline
+    // optimization can make a conservative decision. It is no longer needed
+    // after that optimization.
+    for (scf::ForOp forOp : pipelinedLoops)
+      if (!forOp->hasAttr("triton.warp_pipeline.pipelined_for"))
+        forOp->removeAttr(kPhaseGapAttr);
 
     if (failed(applyPatternsGreedily(m, std::move(patternInline))))
       return signalPassFailure();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -329,7 +329,8 @@ static bool shouldPlaceBackedgeBarrierAtHead(
 // Emit pre-barrier, thread-ID partitioning, and phase-shift cond_barrier.
 // Returns warpLow (for reconverge) and warpHigh (consumed by phase shift).
 static std::pair<Value, Value>
-emitPipelinePrelude(OpBuilder &b, Location loc, int threadsPerPipelineGroup) {
+emitPipelinePrelude(OpBuilder &b, Location loc, int threadsPerPipelineGroup,
+                    int phaseGap = 1) {
   // Flush any pending shared-memory (LDS) dependencies before entering the
   // warp-pipelined region.  Without this barrier ModuleMembarAnalysis may
   // later insert a barrier inside the first pipeline stage, which would
@@ -346,7 +347,8 @@ emitPipelinePrelude(OpBuilder &b, Location loc, int threadsPerPipelineGroup) {
                                        warpIDX, constZero);
   auto warpHigh = arith::CmpIOp::create(b, loc, arith::CmpIPredicate::ne,
                                         warpIDX, constZero);
-  mlir::triton::amdgpu::CondBarrierOp::create(b, loc, warpHigh);
+  for (int i = 0; i < phaseGap; ++i)
+    mlir::triton::amdgpu::CondBarrierOp::create(b, loc, warpHigh);
 
   return {warpLow, warpHigh};
 }
@@ -355,12 +357,13 @@ emitPipelinePrelude(OpBuilder &b, Location loc, int threadsPerPipelineGroup) {
 static void emitPipelinePostlude(OpBuilder &b, Location loc,
                                  bool anyHasPriority, Value warpLow,
                                  bool emitPostludeBarrier = false,
-                                 bool needLocal = false) {
+                                 bool needLocal = false, int phaseGap = 1) {
   if (emitPostludeBarrier)
     emitClusterBarrier(b, loc, needLocal);
   if (anyHasPriority)
     ROCDL::SetPrioOp::create(b, loc, 0);
-  mlir::triton::amdgpu::CondBarrierOp::create(b, loc, warpLow);
+  for (int i = 0; i < phaseGap; ++i)
+    mlir::triton::amdgpu::CondBarrierOp::create(b, loc, warpLow);
 }
 
 class ConvertPipelinedForPattern : public OpRewritePattern<scf::ForOp> {
@@ -387,20 +390,25 @@ public:
     if (!allocation)
       return rewriter.notifyMatchFailure(forOp, "no Allocation for function");
 
+    int phaseGap = 1;
+    if (auto attr =
+            forOp->getAttrOfType<IntegerAttr>("triton.warp_pipeline.phase_gap"))
+      phaseGap = attr.getInt();
     forOp->removeAttr("triton.warp_pipeline.pipelined_for");
+    forOp->removeAttr("triton.warp_pipeline.phase_gap");
     emitPipelinedFor(rewriter, forOp.getLoc(), forOp, allocation,
-                     threadsPerPipelineGroup);
+                     threadsPerPipelineGroup, phaseGap);
     return success();
   }
 
 private:
   void emitPipelinedFor(PatternRewriter &b, Location loc, scf::ForOp forOp,
-                        Allocation *allocation,
-                        int threadsPerPipelineGroup) const {
+                        Allocation *allocation, int threadsPerPipelineGroup,
+                        int phaseGap) const {
     // 1. Pre-barrier, thread partitioning, and phase shift.
     b.setInsertionPoint(forOp);
     auto [warpLow, warpHigh] =
-        emitPipelinePrelude(b, loc, threadsPerPipelineGroup);
+        emitPipelinePrelude(b, loc, threadsPerPipelineGroup, phaseGap);
 
     // 2. Walk the (already-validated) body once to collect clusters and any
     // pre-existing inter-cluster barriers (e.g. from prefetch patterns).
@@ -511,7 +519,7 @@ private:
     b.setInsertionPointAfter(forOp);
     bool emitPostludeBarrier = hasTopBarrier;
     emitPipelinePostlude(b, loc, anyHasPriority, warpLow, emitPostludeBarrier,
-                         /*needLocal=*/bars[0]);
+                         /*needLocal=*/bars[0], phaseGap);
   }
 
   ModuleAllocation &moduleAllocation;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -111,9 +111,11 @@ static BlockInfo buildBlockInfoFromBlock(Block *block, Allocation *allocation) {
 // isPipelineIgnorable in WarpPipeliner.cpp plus the ROCDL-lowered forms that
 // can appear after intermediate passes.
 static bool isWarpPipelineIgnorableBarrier(Operation *op) {
-  return isa<ROCDL::BarrierOp, gpu::BarrierOp, triton::gpu::BarrierOp,
-             triton::gpu::AsyncWaitOp, triton::amdgpu::AsyncWaitOp,
-             triton::amdgpu::AsyncTDMWait,
+  if (auto barrier = dyn_cast<gpu::BarrierOp>(op))
+    return barrier.getScope() == gpu::BarrierScope::Workgroup &&
+           !barrier.getNamedBarrier();
+  return isa<ROCDL::BarrierOp, triton::gpu::BarrierOp, triton::gpu::AsyncWaitOp,
+             triton::amdgpu::AsyncWaitOp, triton::amdgpu::AsyncTDMWait,
              triton::amdgpu::AsyncTDMIntrinsicWait>(op);
 }
 
@@ -267,23 +269,40 @@ static void emitClusterPriority(OpBuilder &r, Location loc,
   }
 }
 
-// Wrap a pre-existing barrier op (e.g. async_wait) with sched_barriers so the
-// backend scheduler cannot move ops across it, and emit the cluster's
-// priority just before the barrier.  Used in place of inserting a fresh
-// cluster barrier when one already exists at the cluster boundary. If the
-// dependency analysis requires an LDS fence, add one after a non-LOCAL wait.
-static void wrapExistingBarrier(OpBuilder &b, Location loc,
-                                Operation *clusterOp,
-                                Operation *existingBarrier, bool anyHasPriority,
-                                bool needLocal, bool emitPriority = true) {
-  b.setInsertionPoint(existingBarrier);
+// Materialize a boundary containing a pre-existing wait or barrier. Every
+// boundary has exactly one synchronization barrier; waits precede it, while an
+// existing barrier is reused or upgraded with the required LDS fence.
+static void materializeExistingBoundary(OpBuilder &b, Location loc,
+                                        Operation *clusterOp,
+                                        Operation *existingOp,
+                                        bool anyHasPriority, bool needLocal,
+                                        bool emitPriority = true) {
+  if (needLocal) {
+    if (auto barrier = dyn_cast<triton::gpu::BarrierOp>(existingOp)) {
+      if (!barrier.hasLocal()) {
+        b.setInsertionPoint(barrier);
+        auto addrSpace = barrier.getAddrSpace() | triton::gpu::AddrSpace::Local;
+        auto replacement =
+            triton::gpu::BarrierOp::create(b, barrier.getLoc(), addrSpace);
+        barrier.erase();
+        existingOp = replacement;
+      }
+    }
+    // gpu.barrier and rocdl.barrier already provide workgroup memory ordering.
+  }
+
+  b.setInsertionPoint(existingOp);
   if (emitPriority)
     emitClusterPriority(b, loc, clusterOp, anyHasPriority);
   ROCDL::SchedBarrier::create(b, loc, ROCDL::SchedGroupMask::none);
-  b.setInsertionPointAfter(existingBarrier);
-  auto localBarrier = dyn_cast<triton::gpu::BarrierOp>(existingBarrier);
-  if (needLocal && (!localBarrier || !localBarrier.hasLocal()))
-    triton::gpu::BarrierOp::create(b, loc, triton::gpu::AddrSpace::Local);
+  b.setInsertionPointAfter(existingOp);
+  if (!isa<ROCDL::BarrierOp, gpu::BarrierOp, triton::gpu::BarrierOp>(
+          existingOp)) {
+    if (needLocal)
+      triton::gpu::BarrierOp::create(b, loc, triton::gpu::AddrSpace::Local);
+    else
+      ROCDL::SBarrierOp::create(b, loc);
+  }
   ROCDL::SchedBarrier::create(b, loc, ROCDL::SchedGroupMask::none);
 }
 
@@ -459,9 +478,9 @@ private:
       hasTopBarrier = true;
 
     // 4. Materializing final cluster-scope barriers.  For each cluster index:
-    //  • If there is a pre-existing barrier at that location, we wrap it with
-    //    sched_barriers and add a LOCAL fence if the dependency analysis
-    //    requires one.
+    //  • A pre-existing wait or barrier is preserved inside the boundary,
+    //    which contains exactly one synchronization barrier with the required
+    //    memory scope.
     //  • If no barrier exists but `bars[i]` is true, we insert a new cluster
     //    barrier (SchedBarrier + Local/SBarrier + SchedBarrier).
     //    The “local” variant is chosen when cluster-to-cluster memory
@@ -496,9 +515,9 @@ private:
 
       if (auto exBar = existingBarrierMap.find(i);
           exBar != existingBarrierMap.end()) {
-        wrapExistingBarrier(b, loc, clusterOps[i], exBar->second,
-                            anyHasPriority, /*needLocal=*/bars[i],
-                            emitPriorityAtBoundary);
+        materializeExistingBoundary(
+            b, loc, clusterOps[i], exBar->second, anyHasPriority,
+            /*needLocal=*/bars[i], emitPriorityAtBoundary);
       } else {
         if (emitPriorityAtBoundary)
           emitClusterPriority(b, loc, clusterOps[i], anyHasPriority);
@@ -619,8 +638,8 @@ static void emitPipelinedFlat(SmallVector<scf::ExecuteRegionOp> &clusterOps,
   // 4. Materialize cluster barriers.
   //    Cluster 0 gets only its priority (inserted after cond_barrier above).
   //    Clusters 1..N get priority + cluster barrier, unless a pre-existing
-  //    barrier op (e.g., async_wait) already exists between the clusters —
-  //    in that case, wrap it and add a LOCAL fence only when required.
+  //    wait or barrier already exists between the clusters. Such an op is
+  //    preserved in a boundary containing exactly one synchronization barrier.
   emitClusterPriority(b, loc, clusterOps[0], anyHasPriority);
 
   for (int i = 1; i < numClusters; i++) {
@@ -634,8 +653,8 @@ static void emitPipelinedFlat(SmallVector<scf::ExecuteRegionOp> &clusterOps,
     }
 
     if (existingBarrier) {
-      wrapExistingBarrier(b, loc, clusterOps[i], existingBarrier,
-                          anyHasPriority, /*needLocal=*/bars[i]);
+      materializeExistingBoundary(b, loc, clusterOps[i], existingBarrier,
+                                  anyHasPriority, /*needLocal=*/bars[i]);
     } else {
       b.setInsertionPoint(clusterOps[i]);
       emitClusterPriority(b, loc, clusterOps[i], anyHasPriority);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/WarpPipeliner.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/WarpPipeliner.cpp
@@ -225,6 +225,29 @@ static PipelineResult createPipeline(OpBuilder &b, Location loc,
 
   sinkPureScalarsIntoNextStage(blk);
 
+  int phaseGap = 1;
+  bool hasExplicitPhaseGap = false;
+  for (Operation &op : blk) {
+    if (!isPipelineBorder(&op))
+      continue;
+    auto attr =
+        op.getAttrOfType<IntegerAttr>("triton.warp_pipeline.phase_gap");
+    if (!attr)
+      continue;
+    int requestedGap = attr.getInt();
+    if (requestedGap < 1) {
+      op.emitError("warp-pipeline phase gap must be positive");
+      return PipelineResult::Malformed;
+    }
+    if (hasExplicitPhaseGap && requestedGap != phaseGap) {
+      op.emitError("all explicit warp-pipeline phase gaps in a loop must "
+                   "agree");
+      return PipelineResult::Malformed;
+    }
+    phaseGap = requestedGap;
+    hasExplicitPhaseGap = true;
+  }
+
   // One pass over the body; collect clusters split by explicit borders.
   for (Operation &opRef : llvm::make_early_inc_range(blk)) {
     Operation *op = &opRef;
@@ -286,6 +309,8 @@ static PipelineResult createPipeline(OpBuilder &b, Location loc,
   // Annotate the loop for the backend.
   b.setInsertionPoint(forOp);
   forOp->setAttr("triton.warp_pipeline.pipelined_for", b.getUnitAttr());
+  forOp->setAttr("triton.warp_pipeline.phase_gap",
+                 b.getI32IntegerAttr(phaseGap));
 
   LDBG("[warp-pipeline] total_stages=" << totalStages << "\n");
   return PipelineResult::Created;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/WarpPipeliner.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/WarpPipeliner.cpp
@@ -23,6 +23,10 @@ namespace tt = mlir::triton;
 
 namespace mlir {
 
+constexpr StringLiteral kPhaseGapAttr = "triton.warp_pipeline.phase_gap";
+constexpr int kDefaultPhaseGap = 1;
+constexpr int kMaxSupportedPhaseGap = 2;
+
 #define GEN_PASS_DEF_TRITONAMDGPUWARPPIPELINE
 #include "TritonAMDGPUTransforms/Passes.h.inc"
 
@@ -225,27 +229,38 @@ static PipelineResult createPipeline(OpBuilder &b, Location loc,
 
   sinkPureScalarsIntoNextStage(blk);
 
-  int phaseGap = 1;
-  bool hasExplicitPhaseGap = false;
+  // phase_gap is a loop-level stagger, so only the first stage may set it.
+  int phaseGap = kDefaultPhaseGap;
+  bool seenFirstBorder = false;
   for (Operation &op : blk) {
     if (!isPipelineBorder(&op))
       continue;
-    auto attr =
-        op.getAttrOfType<IntegerAttr>("triton.warp_pipeline.phase_gap");
-    if (!attr)
+    Attribute attr = op.getAttr(kPhaseGapAttr);
+    if (!seenFirstBorder) {
+      seenFirstBorder = true;
+      if (!attr)
+        continue;
+      auto intAttr = dyn_cast<IntegerAttr>(attr);
+      if (!intAttr || !intAttr.getType().isInteger(32)) {
+        op.emitError("warp-pipeline phase_gap must be an i32 integer");
+        return PipelineResult::Malformed;
+      }
+      int64_t requestedGap = intAttr.getInt();
+      // Wider phase gaps are technically possible, but the dependency and
+      // cross-pipeline analyses have only been validated for gaps of 1 and 2.
+      if (requestedGap < kDefaultPhaseGap ||
+          requestedGap > kMaxSupportedPhaseGap) {
+        op.emitError("warp-pipeline phase_gap must be 1 or 2");
+        return PipelineResult::Malformed;
+      }
+      phaseGap = requestedGap;
       continue;
-    int requestedGap = attr.getInt();
-    if (requestedGap < 1) {
-      op.emitError("warp-pipeline phase gap must be positive");
+    }
+    if (attr) {
+      op.emitError(
+          "warp-pipeline phase_gap may only be specified on the first stage");
       return PipelineResult::Malformed;
     }
-    if (hasExplicitPhaseGap && requestedGap != phaseGap) {
-      op.emitError("all explicit warp-pipeline phase gaps in a loop must "
-                   "agree");
-      return PipelineResult::Malformed;
-    }
-    phaseGap = requestedGap;
-    hasExplicitPhaseGap = true;
   }
 
   // One pass over the body; collect clusters split by explicit borders.
@@ -309,10 +324,9 @@ static PipelineResult createPipeline(OpBuilder &b, Location loc,
   // Annotate the loop for the backend.
   b.setInsertionPoint(forOp);
   forOp->setAttr("triton.warp_pipeline.pipelined_for", b.getUnitAttr());
-  forOp->setAttr("triton.warp_pipeline.phase_gap",
-                 b.getI32IntegerAttr(phaseGap));
+  forOp->setAttr(kPhaseGapAttr, b.getI32IntegerAttr(phaseGap));
 
-  LDBG("[warp-pipeline] total_stages=" << totalStages << "\n");
+  LDBG("total_stages=" << totalStages << " phase_gap=" << phaseGap);
   return PipelineResult::Created;
 }
 
@@ -335,6 +349,23 @@ static PipelineResult createFlatPipeline(OpBuilder &b, Block &block) {
   // No borders at all means the block did not opt into flat pipelining.
   if (allBorders.empty())
     return PipelineResult::NotApplicable;
+
+  // Flat pipelines use the original one-stage offset. Accept an explicit
+  // default, but do not silently ignore a wider requested gap.
+  for (Operation *border : allBorders) {
+    Attribute attr = border->getAttr(kPhaseGapAttr);
+    if (!attr)
+      continue;
+    auto intAttr = dyn_cast<IntegerAttr>(attr);
+    if (!intAttr || !intAttr.getType().isInteger(32)) {
+      border->emitError("warp-pipeline phase_gap must be an i32 integer");
+      return PipelineResult::Malformed;
+    }
+    if (intAttr.getInt() != kDefaultPhaseGap) {
+      border->emitError("flat warp pipelines only support phase_gap=1");
+      return PipelineResult::Malformed;
+    }
+  }
 
   // A single border cannot form a 2-stage pipeline; treat as malformed input
   // since the user did opt in (the lone border would otherwise leak through


### PR DESCRIPTION
## Summary

Add configurable phase gaps to AMD Gluon warp pipelines. This allows the two warp groups to be offset by one or two pipeline stages.

## Details

- Add `phase_gap` to `warp_pipeline_stage`.
  - Supported values: `1` and `2` (larger numbers can be supported in theory but no known use case yet).
  - Defaults to `1`.
  - Must be specified on the first stage only.
- Propagate the setting from the stage marker to the pipelined loop.
- Emit matching phase-shift and reconvergence barriers.
- Make LDS dependency analysis aware of the phase offset, including cross-iteration RAW, WAR, and WAW dependencies.
- Preserve boundaries between adjacent pipelines unless both use `phase_gap=1`.
- Avoid duplicate barriers after AMD async waits.
- Avoid redundant LOCAL barriers for async global-to-local producers whose dependencies are covered by explicit waits.